### PR TITLE
docs: mobile polish (hide RTD flyout, responsive images, phone topbar)

### DIFF
--- a/docs_site/scripts/site_assets/index.css
+++ b/docs_site/scripts/site_assets/index.css
@@ -126,3 +126,6 @@
     letter-spacing: .01em; text-transform: uppercase; }
   .tx-foot-inner a { color: var(--tx-accent); }
   .tx-foot-inner a:hover { color: var(--tx-solar); }
+
+  /* Read the Docs injects a version flyout; the site is single-version, so hide it. */
+  readthedocs-flyout { display: none; }

--- a/docs_site/scripts/site_assets/theme.css
+++ b/docs_site/scripts/site_assets/theme.css
@@ -147,6 +147,8 @@
     display: block; margin: 1.4rem auto 1.8rem; max-width: 100%; height: auto;
     background: #E9E5DA; border-radius: 10px; padding: 10px;
     box-shadow: 0 0 0 1px rgba(243,236,224,.10); }
+  /* Any other content image (markdown cells, doc pages) fits the column on phones. */
+  .jp-RenderedHTMLCommon img, .tx-doc img { max-width: 100%; height: auto; }
   .jp-RenderedText pre, .jp-OutputArea-output pre { color: var(--tx-ink); background: transparent; }
   /* A text-final output ends a cell flush with the pre's last line; give the wrapper the
      card's 1.5rem bottom rhythm so following prose doesn't cram. Image-final outputs are
@@ -220,6 +222,16 @@
     border-radius: 2px; padding: 6px 13px; text-decoration: none !important;
     transition: background .16s ease, border-color .16s ease; }
   .tx-topbar .tx-pill:hover { background: rgba(255,132,0,.16); border-color: var(--tx-accent); }
+  /* Shrink the top bar's wordmark + pills on phones so they never overflow / clip. */
+  @media (max-width: 560px) {
+    .tx-topbar { padding: 0 12px; }
+    .tx-topbar .tx-title { font-size: 14px; letter-spacing: .08em; }
+    .tx-topbar .tx-pills { gap: 5px; }
+    .tx-topbar .tx-pill { font-size: 9px; padding: 5px 8px; letter-spacing: 0; }
+  }
+  @media (max-width: 380px) { .tx-topbar .tx-title { display: none; } }
+  /* Read the Docs injects a version flyout; the site is single-version, so hide it. */
+  readthedocs-flyout { display: none; }
 
   /* ---- Left sidebar (docs + notebooks) ---- */
   .tx-sidebar { position: fixed; top: 46px; left: 0; bottom: 0; width: 16.5rem; z-index: 997;


### PR DESCRIPTION
CSS-only, +15 LOC. Three small mobile fixes for the docs site:

- **Hide the Read the Docs version flyout.** RTD addons inject a floating `latest` version widget that overlaps the prev/next notebook nav (and the site is single-version, so it carries no information). Hidden via `readthedocs-flyout { display: none; }` in both the docs theme and the landing page CSS.
- **Images always fit the column.** Notebook *output* figures already had `max-width: 100%`, but markdown-cell and doc-page images didn't; added a generic `.jp-RenderedHTMLCommon img, .tx-doc img { max-width: 100%; height: auto; }`.
- **Topbar fits on phones.** Ported THRML's `560px`/`380px` topbar shrink rules (tighter padding, smaller wordmark + pills, wordmark dropped on the narrowest screens).

Verified locally: rebuilt the site and swept all 16 notebooks + getting-started + index at 390px — zero horizontal overflow, no image wider than the viewport, and a stubbed `<readthedocs-flyout>` element computes `display: none`. Pills/wordmark unchanged at desktop widths.