### PR TITLE
docs: use brand mono for the TORX wordmark

### DIFF
--- a/docs_site/scripts/site_assets/index.css
+++ b/docs_site/scripts/site_assets/index.css
@@ -18,7 +18,7 @@
   .tx-brand .tx-logo { width: auto; height: 25px; flex-shrink: 0; color: var(--tx-solar);
     transition: color .2s ease, filter .2s ease; }
   .tx-brand:hover .tx-logo { animation: tx-shimmer 1.2s ease-in-out infinite; }
-  .tx-brand-name { font-family: var(--tx-wordmark); font-size: 17px; letter-spacing: 0.12em; color: var(--tx-solar); }
+  .tx-brand-name { font-family: var(--tx-wordmark); font-weight: 700; font-size: 17px; letter-spacing: 0.12em; color: var(--tx-solar); }
   .tx-pills { display: flex; gap: 8px; }
   .tx-pill { display: inline-flex; align-items: center; gap: .45em; background: transparent; border: 1px solid var(--tx-landing-rule);
     color: var(--tx-solar); font-family: var(--tx-mono); font-size: 11px; letter-spacing: .01em; padding: 8px 16px;

--- a/docs_site/scripts/site_assets/prelude.css
+++ b/docs_site/scripts/site_assets/prelude.css
@@ -26,7 +26,7 @@
     --tx-display: "Kessler Display W", Georgia, "Times New Roman", serif;
     --tx-subhead: "Suisse BP Int'l", -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
     --tx-mono: "Suisse Int'l Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-    --tx-wordmark: "Rephlex Trial", "Suisse BP Int'l", Arial, sans-serif;
+    --tx-wordmark: var(--tx-mono);
   }
   /* Logo shimmer on hover, shared by the top-bar brand and the landing brand. */
   @keyframes tx-shimmer {

--- a/docs_site/scripts/site_assets/theme.css
+++ b/docs_site/scripts/site_assets/theme.css
@@ -221,7 +221,7 @@
   .tx-topbar .tx-logo { width: auto; height: 22px; flex-shrink: 0; color: var(--tx-cream);
     transition: color .2s ease, filter .2s ease; }
   .tx-topbar .tx-brand:hover .tx-logo { animation: tx-shimmer 1.2s ease-in-out infinite; }
-  .tx-topbar .tx-title { font-family: "Rephlex Trial", "Suisse BP Int'l", sans-serif; font-size: 17px;
+  .tx-topbar .tx-title { font-family: var(--tx-wordmark); font-weight: 700; font-size: 17px;
     letter-spacing: 0.12em; color: var(--tx-cream); }
   .tx-topbar .tx-pills { display: flex; gap: 8px; }
   .tx-topbar .tx-pill { display: inline-flex; align-items: center; font-size: 10.5px; letter-spacing: -0.01em;


### PR DESCRIPTION
## What
Point the site wordmark (`--tx-wordmark`) at the existing brand mono (`--tx-mono` / Suisse Int'l Mono) instead of the private `Rephlex Trial` font, and give it bold weight.

## Why
`--tx-wordmark` referenced `Rephlex Trial`, which lives only in the private `docs-assets` build. Anywhere those licensed fonts are absent (local builds), the "TORX" wordmark fell back to plain Arial. Reusing the mono that the nav and body already use keeps the wordmark on-brand, renders correctly with no private assets, and reads as one family with the mono chrome. The dotted-triangle mark carries the distinctiveness. Bold weight gives the wordmark logotype presence.

## Diff
3 lines, 3 files:
- `prelude.css`: `--tx-wordmark: var(--tx-mono)`
- `index.css`: `.tx-brand-name` -> `font-weight: 700` (landing top bar)
- `theme.css`: `.tx-topbar .tx-title` -> shared `--tx-wordmark` token + `font-weight: 700` (doc-page top bar)

No new font assets, no license files, no build changes. Renders as system mono locally, real Suisse Int'l Mono on the deployed build.

## Note
`Rephlex` remains the intended wordmark if/when it can be self-hosted from `docs-assets` (pending a licensing check on the "Trial" version). This change is the dependency-free, on-brand default until then.
