### PR TITLE
docs: rewrite notebook prose for a readable tutorial voice

### DIFF
--- a/docs_site/scripts/site_assets/theme.css
+++ b/docs_site/scripts/site_assets/theme.css
@@ -40,7 +40,7 @@
   .jp-RenderedHTMLCommon li { margin: .35rem 0; }
   /* Opening paragraph reads as a lede, like the docs pages. Some notebooks
      keep it in the title cell; others put it in the first prose cell after the
-     TL;DR note (or after a second stacked note), so cover all three layouts. */
+     summary note (or after a second stacked note), so cover all three layouts. */
   body.jp-Notebook > main > .jp-MarkdownCell:first-of-type .jp-RenderedHTMLCommon > p:first-of-type,
   body.jp-Notebook > main > .jp-MarkdownCell:first-of-type:not(:has(.jp-RenderedHTMLCommon > p)) + .jp-MarkdownCell:has(.note) + .jp-MarkdownCell .jp-RenderedHTMLCommon > p:first-child,
   body.jp-Notebook > main > .jp-MarkdownCell:first-of-type:not(:has(.jp-RenderedHTMLCommon > p)) + .jp-MarkdownCell:has(.note) + .jp-MarkdownCell:has(.note) + .jp-MarkdownCell .jp-RenderedHTMLCommon > p:first-child {

--- a/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
+++ b/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
@@ -128,7 +128,7 @@
     "\n",
     "We start with pbits because their gates are small enough to write out in full as a matrix, which means we can check every sampled result against something we derived by hand.\n",
     "\n",
-    "A **pbit** (probabilistic bit) is a binary stochastic site: at any instant it is 0 or 1 with some probability. A joint configuration is written as a ket, $|ab)$ with $a,b\\in\\{0,1\\}$, a label for one of the $2^2=4$ basis configurations of two pbits ($n$ pbits have $2^n$).\n",
+    "A **pbit** (probabilistic bit) is a binary stochastic site: at any instant it's 0 or 1 with some probability. A joint configuration is written as a ket, $|ab)$ with $a,b\\in\\{0,1\\}$, a label for one of the $2^2=4$ basis configurations of two pbits ($n$ pbits have $2^n$).\n",
     "\n",
     "A gate over pbits is a column-stochastic kernel $K(y\\mid x)$ on these configurations, with $\\sum_y K(y\\mid x)=1$. Read it by column: column $x$ holds the distribution over outputs $y$ given the input $|x)$.\n",
     "\n",
@@ -136,7 +136,7 @@
     "\n",
     "$$G(\\theta)=\\underbrace{(1-\\sigma(\\theta))\\,I}_{\\vphantom{\\big|}\\text{stay branch}}+\\underbrace{\\sigma(\\theta)\\,B}_{\\vphantom{\\big|}\\text{op branch}},\\qquad p=\\sigma(\\theta)=\\frac{1}{1+e^{-\\theta}}.$$\n",
     "\n",
-    "Torx does not store $p$ itself. It parametrises these branch gates by the logit $\\theta=\\log\\frac{p}{1-p}$, which ranges over all of $\\mathbb{R}$ and therefore works cleanly with gradients, and applying the sigmoid recovers the physical switching probability $p$.\n",
+    "What Torx actually stores is the logit $\\theta=\\log\\frac{p}{1-p}$ rather than $p$ itself, because $\\theta$ ranges over all of $\\mathbb{R}$ and therefore works cleanly with gradients, and applying the sigmoid recovers the physical switching probability whenever we need it.\n",
     "\n",
     "`PISING`, introduced below, is the energy-based exception: its parameter vector defines an Ising bond update rather than a single switching logit.\n",
     "\n",
@@ -480,7 +480,7 @@
     "\n",
     "so only single-spin-flip neighbors get off-diagonal rates and each column sums to zero. Here $J$ is the bond coupling and $h_1, h_2$ are the local fields. The inverse temperature $\\beta$ scales the energy change of the proposed flip, so larger $\\beta$ means a colder, more selective update.\n",
     "\n",
-    "The gate itself is the matrix exponential $\\mathsf{PISING}(\\theta)=\\exp(\\Delta t\\,Q)$. Unlike the branch-table gates above, it is a $4\\times 4$ column-stochastic kernel. Its parameter vector $\\theta=[J,h_1,h_2,\\beta,\\Delta t]$ holds the physical bond parameters.\n",
+    "The gate itself is the matrix exponential $\\mathsf{PISING}(\\theta)=\\exp(\\Delta t\\,Q)$. Unlike the branch-table gates above, it's a $4\\times 4$ column-stochastic kernel. Its parameter vector $\\theta=[J,h_1,h_2,\\beta,\\Delta t]$ holds the physical bond parameters.\n",
     "\n",
     "Rather than sample this gate, we build it and evaluate its transition matrix directly with `get_matrix`, then plot that matrix as a heatmap for the bond parameters chosen below. This is the first place in the notebook where we read a kernel instead of sampling one, and the multi-flip entries are what to watch: they are positive, but at $\\Delta t=0.35$ they are small enough to round to 0.00 in the heatmap."
    ]

--- a/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
+++ b/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
@@ -13,8 +13,8 @@
    "id": "ad6dd7ec",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We tour Torx's gates over <a href=\"#Pbit-gates\">pbits</a>, <a href=\"#Pdit-gates\">pdits</a>, and <a href=\"#Pmode-gates\">pmodes</a>, composing the PSWAP, PNOT, and Gaussian examples into circuits while evaluating PISING and PditCycle directly from their transition matrices. We connect each constructor to its transition kernel or Gaussian map and sample the circuit examples.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We build parametrised stochastic circuits over the three Torx data primitives, <a href=\"#Pbit-gates\">pbits</a>, <a href=\"#Pdit-gates\">pdits</a>, and <a href=\"#Pmode-gates\">pmodes</a>, so that every gate constructor becomes readable as a transition kernel or a Gaussian map. We inspect those gates two ways, because the two answer different questions: we compose some into circuits and sample them to see the distribution that comes out, and we evaluate others directly from their transition matrices to see the kernel itself.</p>\n",
     "</div>"
    ]
   },
@@ -23,7 +23,7 @@
    "id": "a404784d",
    "metadata": {},
    "source": [
-    "In this tutorial, we build parametrised stochastic circuits (PSCs) and run them on the three Torx data primitives. Torx is a JAX framework for programs that transform probability distributions, so a circuit here is a recipe for reshaping a distribution. This notebook is the entry point to the example gallery; the gates and sampling workflow here reappear throughout the later notebooks. The examples assume basic familiarity with probability distributions and JAX, and use Torx, JAX, NumPy, and Matplotlib.\n",
+    "In this tutorial, we build parametrised stochastic circuits (PSCs) and run them on the three Torx data primitives. Torx is a JAX framework for programs that transform probability distributions, so a circuit here is a recipe for reshaping a distribution. This notebook is the entry point to the example gallery, because the gates and the sampling workflow we set up here reappear throughout the later notebooks. The examples assume basic familiarity with probability distributions and JAX, and use Torx, JAX, NumPy, and Matplotlib.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -52,7 +52,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "We first configure the helper path, the shared plotting style, and the `savefig` utility used throughout.\n",
+    "Nothing in this section is specific to stochastic circuits. We point Python at the shared helper modules, apply the plotting style the whole gallery uses, and create the `savefig` utility so every figure below is written to the same output directory.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx gates and simulators produce transition matrices and samples.</li><li>Notebook code assembles circuits and computes the NumPy analytic mixture contour and checks.</li><li><code>examples/helpers/_plots_fields.py</code> and <code>examples/helpers/_plots_schematics.py</code> render figures.</li><li><code>examples/helpers/_notebook_style.py</code> and <code>examples/helpers/_notebook_paths.py</code> apply styling and choose output paths.</li></ul></details>"
    ]
@@ -126,6 +126,8 @@
    "source": [
     "## Pbit gates\n",
     "\n",
+    "We start with pbits because their gates are small enough to write out in full as a matrix, which means we can check every sampled result against something we derived by hand.\n",
+    "\n",
     "A **pbit** (probabilistic bit) is a binary stochastic site: at any instant it is 0 or 1 with some probability. A joint configuration is written as a ket, $|ab)$ with $a,b\\in\\{0,1\\}$, a label for one of the $2^2=4$ basis configurations of two pbits ($n$ pbits have $2^n$).\n",
     "\n",
     "A gate over pbits is a column-stochastic kernel $K(y\\mid x)$ on these configurations, with $\\sum_y K(y\\mid x)=1$. Read it by column: column $x$ holds the distribution over outputs $y$ given the input $|x)$.\n",
@@ -134,11 +136,11 @@
     "\n",
     "$$G(\\theta)=\\underbrace{(1-\\sigma(\\theta))\\,I}_{\\vphantom{\\big|}\\text{stay branch}}+\\underbrace{\\sigma(\\theta)\\,B}_{\\vphantom{\\big|}\\text{op branch}},\\qquad p=\\sigma(\\theta)=\\frac{1}{1+e^{-\\theta}}.$$\n",
     "\n",
-    "Torx parametrises these branch gates by the logit $\\theta=\\log\\frac{p}{1-p}$, which ranges over all of $\\mathbb{R}$ and works cleanly with gradients; applying the sigmoid recovers the physical switching probability $p$.\n",
+    "Torx does not store $p$ itself. It parametrises these branch gates by the logit $\\theta=\\log\\frac{p}{1-p}$, which ranges over all of $\\mathbb{R}$ and therefore works cleanly with gradients, and applying the sigmoid recovers the physical switching probability $p$.\n",
     "\n",
     "`PISING`, introduced below, is the energy-based exception: its parameter vector defines an Ising bond update rather than a single switching logit.\n",
     "\n",
-    "Throughout this section we fix the switching probability at $p=0.30$."
+    "Throughout this section we fix the switching probability at $p=0.30$, so the sampled bars from different gates are directly comparable."
    ]
   },
   {
@@ -146,7 +148,7 @@
    "id": "4f4239cd",
    "metadata": {},
    "source": [
-    "Next, we import the circuit and simulator classes along with the binary gates, and define the shared demo logit, sample count, and random number generator keys."
+    "We import the circuit and simulator classes together with the two binary gates, then fix the values every pbit demo shares: the switching logit, the sample count, and one random number generator key per sampled figure, so re-running a single cell reproduces its own plot rather than shifting the ones after it."
    ]
   },
   {
@@ -182,7 +184,7 @@
    "id": "72636243",
    "metadata": {},
    "source": [
-    "We create the shared `BranchingSimulator` and define `sample_distribution`: given a compiled circuit (each gate demo compiles its circuit once), it calls `sample` and returns empirical probabilities for each output state."
+    "Sampling looks the same for every gate below, so we set it up once. We create the shared `BranchingSimulator` and define `sample_distribution`, which takes a compiled circuit, calls `sample`, and returns the empirical probability of each output state. Each gate demo compiles its circuit once and reuses that compiled object across the inputs it feeds in."
    ]
   },
   {
@@ -218,6 +220,8 @@
    "source": [
     "### PSWAP\n",
     "\n",
+    "`PSWAP` is the smallest gate that couples two pbits, which makes it a good place to establish the pattern the rest of the gallery follows: write the kernel down, build a one-gate circuit, then sample it.\n",
+    "\n",
     "With probability $p$, `PSWAP` swaps two pbits, and otherwise it leaves them alone. Only $|01)$ and $|10)$ change, and $|00)$ and $|11)$ are fixed points:\n",
     "\n",
     "$$\\mathsf{PSWAP}(p)\\,|ab)=(1-p)\\,|ab)+p\\,|ba).$$\n",
@@ -226,7 +230,7 @@
     "\n",
     "$$\\mathsf{PSWAP}(p)=\\begin{pmatrix}1 & 0 & 0 & 0\\\\ 0 & 1-p & p & 0\\\\ 0 & p & 1-p & 0\\\\ 0 & 0 & 0 & 1\\end{pmatrix}.$$\n",
     "\n",
-    "Below we build the one-gate circuit, compile it once for both inputs, and draw the diagram: a single `PSWAP` gate acting on two pbits."
+    "Below we build the one-gate circuit and compile it once for both inputs, then draw it so the wiring is explicit: a single `PSWAP` gate acting on two pbits."
    ]
   },
   {
@@ -296,7 +300,7 @@
    "id": "15cb2074",
    "metadata": {},
    "source": [
-    "We sample the two changeable inputs to make the stay and swap branches visible."
+    "The matrix says that only $|01)$ and $|10)$ can move, so those are the two inputs worth sampling. We draw 20,000 samples from each of them and plot the empirical distribution, where the stay and swap branches should appear as bars at $1-p$ and $p$."
    ]
   },
   {
@@ -375,11 +379,13 @@
    "source": [
     "### PNOT\n",
     "\n",
+    "`PNOT` is the single-site version of the same branch construction, so its kernel is the smallest one in the notebook and takes only two columns to read.\n",
+    "\n",
     "With probability $p$, `PNOT` flips one pbit, and otherwise the bit is unchanged. Its kernel is the convex combination (a probability-weighted blend) of $I$ and the NOT operation:\n",
     "\n",
     "$$\\mathsf{PNOT}(p)=\\begin{pmatrix}1-p & p\\\\ p & 1-p\\end{pmatrix}.$$\n",
     "\n",
-    "The sampled distributions below show both possible inputs and their flipped and unchanged outcomes."
+    "A single pbit has only two possible inputs, so we sample both below and compare the flipped and unchanged outcomes against the two columns above."
    ]
   },
   {
@@ -460,6 +466,8 @@
    "source": [
     "### PISING\n",
     "\n",
+    "The two gates so far choose between staying put and applying one fixed operation. `PISING` is built differently, because its kernel comes out of an energy model rather than a single switching probability, and that changes what shows up in the matrix.\n",
+    "\n",
     "The [`PISING`](https://docs.torx.ai/en/latest/api-gates.html#PISING) gate is a finite-time kernel for [Glauber dynamics](https://doi.org/10.1063/1.1703954) on an Ising bond. It integrates a single-spin-flip generator for a time $\\Delta t$, so the resulting kernel includes multi-flip paths.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Glauber dynamics</summary><p>The generator $Q$ gives instantaneous rates for one-spin jumps. Its matrix exponential sums every allowed jump sequence over $\\Delta t$, so a finite-time transition can contain more than one flip.</p></details>\n",
@@ -474,7 +482,7 @@
     "\n",
     "The gate itself is the matrix exponential $\\mathsf{PISING}(\\theta)=\\exp(\\Delta t\\,Q)$. Unlike the branch-table gates above, it is a $4\\times 4$ column-stochastic kernel. Its parameter vector $\\theta=[J,h_1,h_2,\\beta,\\Delta t]$ holds the physical bond parameters.\n",
     "\n",
-    "We build the gate, evaluate its transition matrix with `get_matrix`, and plot it as a heatmap for the chosen bond parameters. The multi-flip entries are positive but small, and at $\\Delta t=0.35$ they round to 0.00 in the heatmap."
+    "Rather than sample this gate, we build it and evaluate its transition matrix directly with `get_matrix`, then plot that matrix as a heatmap for the bond parameters chosen below. This is the first place in the notebook where we read a kernel instead of sampling one, and the multi-flip entries are what to watch: they are positive, but at $\\Delta t=0.35$ they are small enough to round to 0.00 in the heatmap."
    ]
   },
   {
@@ -561,7 +569,9 @@
    "source": [
     "## Pdit gates\n",
     "\n",
-    "A **pdit** is a discrete stochastic site with $d$ states, the generalization of a pbit to more than two states. We use [`PditCycle`](https://docs.torx.ai/en/latest/api-gates.html#PditCycle), a random walk on a cyclic $d$-state pdit with stay, forward, and backward branches. The heatmap below is its column-stochastic transition matrix at $d=3$.\n",
+    "Going from two states to $d$ states changes nothing structural about a gate, and this section is the shortest way to show that.\n",
+    "\n",
+    "A **pdit** is a discrete stochastic site with $d$ states, the generalization of a pbit to more than two states. We use [`PditCycle`](https://docs.torx.ai/en/latest/api-gates.html#PditCycle), a random walk on a cyclic $d$-state pdit with stay, forward, and backward branches. Three branches are easier to check against a matrix than against sampled bars, so we take the same route as `PISING` here and read the column-stochastic transition matrix at $d=3$ directly, plotted below as a heatmap.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: three-way Pdit softmax</summary><p><code>PditCycle</code> applies softmax to $[0,\\theta_0,\\theta_1]$ for the stay, forward, and backward probabilities. Thus $\\theta=\\log([0.30,0.20]/0.50)$ reproduces $[0.50,0.30,0.20]$.</p></details>\n",
     "\n",
@@ -655,6 +665,8 @@
    "source": [
     "## Pmode gates\n",
     "\n",
+    "Continuous sites are the last primitive, and they need a different kind of gate, because a site valued in $\\mathbb{R}^N$ has no finite transition matrix to write down.\n",
+    "\n",
     "A **pmode** is a continuous stochastic site valued in $\\mathbb{R}^N$. [`AffineGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#AffineGaussianGate) is the general pmode gate we use here: it applies a linear map, adds a bias, and adds diagonal Gaussian noise. This form maps Gaussian inputs to Gaussian outputs:\n",
     "\n",
     "$$X \\mapsto \\underbrace{A X}_{\\vphantom{\\big|}\\text{linear map}} + \\mathbf{b} + \\varepsilon,\\qquad \\varepsilon \\sim \\mathcal{N}(0, \\Delta),$$\n",
@@ -663,7 +675,7 @@
     "\n",
     "The examples below use `AffineGaussianGate` directly, then [`MixtureGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#MixtureGaussianGate), which selects one of several diagonal Gaussian components (a mean shift plus diagonal noise) under a discrete control.\n",
     "\n",
-    "`AffineGaussianGate` already covers the common special cases: shift, scale, rotation, and diffusion."
+    "Those two gates cover more ground than they appear to, since `AffineGaussianGate` already contains the common special cases: shift, scale, rotation, and diffusion."
    ]
   },
   {
@@ -673,7 +685,7 @@
    "source": [
     "### AffineGaussianGate\n",
     "\n",
-    "We apply one `AffineGaussianGate` to an $\\mathcal{N}(0, I)$ input cloud and watch the distribution move: the linear map stretches and tilts it, the bias shifts it, and the diagonal noise sets the spread. The scatter plot compares the input cloud with the transformed one. The next cell defines `sample_continuous`, which compiles a circuit and samples its cloud from the origin.\n",
+    "One gate is enough to see what a pmode gate does to a distribution, because each of its three parts moves a cloud of points in a visibly different way. We apply a single `AffineGaussianGate` to an $\\mathcal{N}(0, I)$ input cloud and plot the input and the output on the same axes, where the linear map stretches and tilts, the bias shifts, and the diagonal noise sets the spread. The next cell defines `sample_continuous`, which compiles a circuit and samples its cloud starting from the origin.\n",
     "\n",
     "See [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb) for the full pmode-gate tour: the specialized `Displace`, `Scale`, `Mix`, and `Diffuse` gates, the exact moment and composition laws, closed-form conditioning, and the analytic-versus-sampled checks."
    ]
@@ -834,7 +846,7 @@
    "id": "6581d872",
    "metadata": {},
    "source": [
-    "The output cloud shows the affine map and diagonal noise applied to an $\\mathcal{N}(0, I)$ input drawn from a separate source circuit with its own key, so its points have no one-to-one correspondence with the plotted input points."
+    "The output cloud is stretched, tilted, and shifted relative to the input, which is the entire content of the affine map plus its diagonal noise. One caveat about reading the picture: the input cloud is drawn from a separate $\\mathcal{N}(0, I)$ source circuit with its own key, so its points have no one-to-one correspondence with the plotted output points."
    ]
   },
   {
@@ -844,13 +856,17 @@
    "source": [
     "### MixtureGaussianGate\n",
     "\n",
+    "This last gate is the first hybrid one, because it lets a discrete site steer a continuous one.\n",
+    "\n",
     "`MixtureGaussianGate` uses the control pdit value to choose which diagonal Gaussian component fires. The gate adds the selected component mean (plus diagonal Gaussian noise) to the input continuous state. We start the pmode at the origin and sample the control from known weights $\\pi$, so the marginal cloud follows the mixture density:\n",
     "\n",
     "$$p_{X'}(x)=\\sum_{k=0}^{K-1}\\pi_k\\,\\mathcal{N}(x;\\,\\mu_k,\\,\\Sigma_k),$$\n",
     "\n",
-    "where $\\pi_k$ is the control distribution (how often branch $k$ fires), $\\mu_k$ is branch $k$'s mean, and $\\Sigma_k=\\mathrm{diag}(\\sigma_k^2)$ is its diagonal covariance. Before plotting, we check the per-branch sample means and empirical branch weights against the parameters.\n",
+    "where $\\pi_k$ is the control distribution (how often branch $k$ fires), $\\mu_k$ is branch $k$'s mean, and $\\Sigma_k=\\mathrm{diag}(\\sigma_k^2)$ is its diagonal covariance.\n",
     "\n",
-    "In `sites=(0, 0)`, the first `0` addresses discrete control site 0 and the second addresses continuous site 0 in a separate namespace. Torx generates the samples and control labels. The notebook's NumPy code computes the analytic mixture density and assertions."
+    "Because we chose $\\pi_k$, $\\mu_k$, and $\\Sigma_k$ ourselves, we can check the samples against them before plotting anything. We compare each branch's sample mean against its parameter $\\mu_k$ within a tolerance that shrinks as $1/\\sqrt{n_k}$ in the number of samples that branch received, which tests the component means. We then compare the empirical branch frequencies against $\\pi$ within $3/\\sqrt{N}$, which tests that the control fires at the stated weights.\n",
+    "\n",
+    "In `sites=(0, 0)`, the first `0` addresses discrete control site 0 and the second addresses continuous site 0 in a separate namespace. Torx generates the samples and the control labels, and the notebook's own NumPy code both computes the analytic mixture density and runs the assertions that compare those samples against it."
    ]
   },
   {
@@ -1029,7 +1045,7 @@
    "id": "11caddbe",
    "metadata": {},
    "source": [
-    "The colored cloud is one marginal mixture sample: the control distribution chooses branch labels, and the contours show the analytic density from the same $\\pi_k$, $\\mu_k$, and $\\Sigma_k$."
+    "The cloud is a single draw from the marginal mixture, colored by the branch label the control gate itself produced rather than by any grouping we imposed afterward. Each colored lobe sits under a peak of the contours, which are the analytic density evaluated from the same $\\pi_k$, $\\mu_k$, and $\\Sigma_k$, so the picture shows visually what the branch-mean and branch-weight checks above already established numerically."
    ]
   },
   {
@@ -1039,9 +1055,9 @@
    "source": [
     "## Gate inventory\n",
     "\n",
-    "The table summarizes the gates we build in this tutorial, grouped by primitive.\n",
+    "This table is the part of the notebook worth coming back to, because it collects every gate we built in this tutorial, grouped by primitive, together with the later notebooks that put each one to work.\n",
     "\n",
-    "Each gate is parametrised by a logit or a small parameter set, then composed through `DiscretePCircuit` or `HybridPCircuit`. The Used in column points to the notebooks that build each one.\n",
+    "Each gate is parametrised by a logit or a small parameter set, then composed through `DiscretePCircuit` or `HybridPCircuit`, so a gate carries structure and its parameters always travel beside it in a separate list. The Used in column points to the notebooks that build each one.\n",
     "\n",
     "The Torx gate library extends beyond this introductory set. For example, `PJUMP` is a two-pbit branch gate that moves probability from $|10)$ to $|01)$.\n",
     "\n",
@@ -1062,10 +1078,10 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "In this tutorial, we built the basic parametrised stochastic circuits used by Torx.\n",
+    "In this tutorial, we built the basic parametrised stochastic circuits used by Torx, and the four points below are what carries forward into the rest of the gallery.\n",
     "\n",
     "- Torx programs act on three data primitives: pbits (binary), pdits ($d$-state), and pmodes (continuous, valued in $\\mathbb{R}^N$).\n",
-    "- Discrete gates are column-stochastic kernels; pmode gates are continuous Markov kernels (Gaussian maps). Many discrete branch-table gates combine the identity with a deterministic operation selected with probability $p$, parametrised by the logit $\\theta$ so they train with ordinary gradients. `PISING` uses a physical parameter vector instead.\n",
+    "- Discrete gates are column-stochastic kernels, while pmode gates are continuous Markov kernels (Gaussian maps). Many discrete branch-table gates combine the identity with a deterministic operation selected with probability $p$, parametrised by the logit $\\theta$ so they train with ordinary gradients. `PISING` uses a physical parameter vector instead.\n",
     "- `PSWAP`, `PNOT`, and `PISING` are the core pbit gates, and `PditCycle` walks a cyclic $d$-state pdit (stay/forward/backward).\n",
     "- `AffineGaussianGate` is an affine-Gaussian map, and `MixtureGaussianGate` selects one of several diagonal Gaussian components under a discrete control.\n",
     "\n",

--- a/examples/02_random_walks_on_graphs.ipynb
+++ b/examples/02_random_walks_on_graphs.ipynb
@@ -13,8 +13,8 @@
    "id": "2897853c",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We turn an eight-node random walk into one <code>PSWAP</code> layer per graph sweep and extend the construction to oriented edges with a directed <code>PJUMP</code> cycle. We then separate deterministic <a href=\"#ref-trotter-1959\">Trotter</a> bias, Monte Carlo noise, and the second-order gain from a <a href=\"#ref-strang-1968\">Strang</a> sweep.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We turn an eight-node random walk into one <code>PSWAP</code> layer per graph sweep, then carry the same construction over to oriented edges with a directed <code>PJUMP</code> cycle. Refining the layer count separates two errors with different causes: the deterministic bias that comes from chopping simultaneous edge updates into an ordered sequence (<a href=\"#ref-trotter-1959\">Trotter</a> splitting), and the random scatter left over from estimating occupancies out of a finite number of sampled walks (Monte Carlo noise). Running the edge order forward and then in reverse, a symmetric <a href=\"#ref-strang-1968\">Strang</a> sweep, squares the rate at which that bias falls.</p>\n",
     "</div>"
    ]
   },
@@ -29,9 +29,9 @@
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Trotter and Strang splitting</summary><p>[Trotter splitting](#ref-trotter-1959) replaces simultaneous evolution by many small ordered edge updates. [Strang splitting](#ref-strang-1968) uses a forward-and-back symmetric edge order to cancel the leading splitting error.</p></details>\n",
     "\n",
-    "The graph Laplacian is a sum of edge terms, so the continuous-time walk splits into small two-node updates. A single `PSWAP` is the exact update for one edge, and repeating a layer of `PSWAP` gates approximates the full walk.\n",
+    "The graph Laplacian is a sum of edge terms, so the continuous-time walk splits into small two-node updates. A single `PSWAP` is the exact update for one edge, which means a layer holding one `PSWAP` per edge, repeated in time, approximates the full walk.\n",
     "\n",
-    "We first map one edge to one `PSWAP` gate, which implements the exact two-node Markov kernel (the transition rule for one step of the walk). Then we compose an eight-node graph as one Trotter layer of `PSWAP` gates and watch the distribution diffuse. Finally, we sweep the Trotter resolution to separate Trotter bias from Monte Carlo noise, square the convergence rate with a symmetric Strang sweep, and extend the construction to directed edges with the `PJUMP` gate.\n",
+    "We build that up in stages. First we map one edge to one `PSWAP` gate, which implements the exact two-node Markov kernel (the transition rule for one step of the walk). Then we compose an eight-node graph as one Trotter layer of `PSWAP` gates and watch the distribution diffuse. Finally we sweep the Trotter resolution, because that sweep is what pulls Trotter bias apart from Monte Carlo noise, square the convergence rate with a symmetric Strang sweep, and carry the construction over to directed edges with the `PJUMP` gate.\n",
     "\n",
     "We assume familiarity with the gate set from [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb), and the code uses Torx, JAX, NumPy, and NetworkX.\n"
    ]
@@ -166,6 +166,8 @@
    "source": [
     "## What the circuit computes\n",
     "\n",
+    "Before writing any gates, we establish why a graph walk becomes a circuit at all. The whole construction rests on one structural fact: the generator of the walk is a sum of one term per edge, and each of those terms has an exact gate.\n",
+    "\n",
     "The walk spreads an occupancy distribution $p(t)$ over time, and it obeys the master equation (the rule for how the distribution changes over time) $\\dot p = Qp$.\n",
     "\n",
     "The exact answer is the matrix exponential $p(t) = e^{tQ}p_0$. For a symmetric graph walk the generator (the matrix that drives the time evolution) is minus the graph Laplacian, $Q = -L$, where\n",
@@ -185,13 +187,13 @@
     "\n",
     "The product runs one `PSWAP` per edge, each a two-node walk on edge $\\{i,j\\}$. Its rank-one term $(e_i - e_j)(e_i - e_j)^\\top$ is the same edge-local operator that appears in $L$.\n",
     "\n",
-    "Each `PSWAP` is the *exact* edge propagator $e^{\\Delta t\\,Q_{ij}}$ on its edge; the occupancy form $\\mathbb I - p_{ij}(e_i-e_j)(e_i-e_j)^\\top$ above is the single-walker map it induces. The circuit is the *ordered* product of these edge propagators, repeated $N$ times:\n",
+    "Each `PSWAP` is the *exact* edge propagator $e^{\\Delta t\\,Q_{ij}}$ on its edge, and the occupancy form $\\mathbb I - p_{ij}(e_i-e_j)(e_i-e_j)^\\top$ above is the single-walker map it induces. The circuit is the *ordered* product of these edge propagators, repeated $N$ times:\n",
     "\n",
     "$$\n",
     "p(t) \\;\\approx\\; \\underbrace{\\Big(\\textstyle\\prod_{\\{i,j\\}\\in E} e^{\\Delta t\\,Q_{ij}}\\Big)^{N}}_{\\vphantom{\\big|}\\text{the circuit}} p_0 \\;\\xrightarrow[N\\to\\infty]{}\\; \\underbrace{e^{-Lt}\\,p_0}_{\\vphantom{\\big|}\\text{exact heat flow}}, \\qquad \\Delta t = t/N\n",
     "$$\n",
     "\n",
-    "The edge generators do not commute, so the ordered product equals $e^{-Lt}$ only in the limit; this is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). The first-order expansion of one layer is $\\mathbb I - \\Delta t\\,L$ (one Euler step), which is where the $1/N$ Trotter bias studied below comes from."
+    "The edge generators do not commute, so the ordered product equals $e^{-Lt}$ only in the limit. This is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). The first-order expansion of one layer is $\\mathbb I - \\Delta t\\,L$ (one Euler step), which is where the $1/N$ Trotter bias studied below comes from."
    ]
   },
   {
@@ -199,7 +201,7 @@
    "id": "b88eb6d8",
    "metadata": {},
    "source": [
-    "The schematic follows one highlighted edge from the graph to its `PSWAP` factor, then tiles the per-edge gates into one Trotter layer $T$; the stacking of layers in time appears later, in the four-node ring circuit figure."
+    "The schematic below gives that algebra a picture: it follows one highlighted edge from the graph to its `PSWAP` factor, then tiles the per-edge gates into one Trotter layer $T$. How those layers stack in time comes later, in the four-node ring circuit figure."
    ]
   },
   {
@@ -257,7 +259,7 @@
    "source": [
     "## One edge, one PSWAP gate\n",
     "\n",
-    "The smallest graph has two nodes joined by one edge.\n",
+    "We start with the smallest graph there is, two nodes joined by one edge, because the exact answer is available in closed form and the gate has nowhere to hide.\n",
     "\n",
     "A walker at node 0 stays with probability $1-p$ and moves to node 1 with probability $p$. For a symmetric two-node walk at rate $r$ over a time $\\Delta t$:\n",
     "\n",
@@ -267,7 +269,7 @@
     "\n",
     "For the graph examples below, $r$ is the code constant `RATE`, so the first-order term $r\\,\\Delta t$ is the same $w_{ij}\\,\\Delta t$ from the Laplacian description.\n",
     "\n",
-    "This is the swap probability fed to `PSWAP`, which is parametrised by a logit (the log-odds of the probability). The wrapper below evaluates it via the shared helper in `examples/helpers/_graph_diffusion.py`. For gate-set details, see [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb)."
+    "That $p$ is the swap probability we feed to `PSWAP`, which is parametrised by a logit (the log-odds of the probability) rather than by the probability itself. The wrapper below evaluates it via the shared helper in `examples/helpers/_graph_diffusion.py`, so the sampled circuits and the deterministic baselines later in the notebook all read the same slice probability. For gate-set details, see [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb)."
    ]
   },
   {
@@ -294,7 +296,7 @@
    "id": "b98a6966",
    "metadata": {},
    "source": [
-    "These values define the one-edge transition."
+    "Turning that formula into a circuit takes three short steps. First we fix a walk rate and an elapsed time, which together define the one-edge transition. Then we wrap a single `PSWAP` gate on two pbits into a circuit, since one edge needs exactly one gate. Finally we draw the circuit, which makes the two-pbit gate explicit on the wires instead of leaving it implied by the code."
    ]
   },
   {
@@ -317,14 +319,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "dcd7622d",
-   "metadata": {},
-   "source": [
-    "The one-edge circuit uses a single `PSWAP` gate on two pbits."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 8,
    "id": "d6a7d916",
@@ -342,14 +336,6 @@
     "# `thetas`, one entry per gate aligned with `circuit.gates`.\n",
     "edge_circuit = DiscretePCircuit([PSWAP([0, 1])])\n",
     "edge_thetas = [jnp.array([logit(p_swap)])]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "03021081",
-   "metadata": {},
-   "source": [
-    "We draw the circuit to make the two-pbit gate explicit."
    ]
   },
   {
@@ -400,7 +386,7 @@
    "id": "ec2c950e",
    "metadata": {},
    "source": [
-    "The simulator estimates the endpoint occupancies, which we compare with the analytic two-node flow."
+    "With the circuit in place, we check the gate against the formula. We draw 20,000 samples, start the walker on node 0, and read out both endpoint occupancies, because the analytic two-node flow predicts those two numbers exactly."
    ]
   },
   {
@@ -446,7 +432,7 @@
    "id": "832842b3",
    "metadata": {},
    "source": [
-    "The sampled occupancies match the analytic two-node flow, which the next cell asserts within Monte Carlo tolerance."
+    "The sampled occupancies reproduce the analytic two-node flow, and the next cell states how close counts as agreement: within six times the binomial standard error $0.5/\\sqrt{N}$ at $N = 20{,}000$ samples. That tolerance is the scale of the sampling scatter itself, so passing it means the remaining gap is noise from finite sampling rather than a wrong gate."
    ]
   },
   {
@@ -505,7 +491,7 @@
    "id": "98e2669c",
    "metadata": {},
    "source": [
-    "We put most of the initial probability mass near node 0."
+    "We load most of the initial probability mass onto node 0 and its two ring neighbours, so the walk starts far from equilibrium and the spreading front has somewhere to spread from."
    ]
   },
   {
@@ -561,11 +547,9 @@
    "source": [
     "## Watching the walk diffuse\n",
     "\n",
-    "The target is the exact heat flow $p(t) = e^{tQ}p_0$ with $Q = -L$. The helpers `build_graph_generator` and `reference_heat_flow` assemble $Q$ and evaluate this matrix exponential.\n",
+    "Before sampling anything, we look at what the circuit will have to reproduce: the exact heat flow $p(t) = e^{tQ}p_0$ with $Q = -L$. The helpers `build_graph_generator` and `reference_heat_flow` assemble $Q$ and evaluate this matrix exponential, so the panels below are ground truth rather than an estimate.\n",
     "\n",
-    "The first snapshot is the initial state. Later snapshots show mass leaving the hot nodes 0, 1, and 7 along the cycle edges and chord shortcuts, spreading into the rest of the graph as the distribution approaches equilibrium.\n",
-    "\n",
-    "We clip the shared color scale to roughly the 98th percentile of the post-initial snapshots, so the later spread stays readable while the $t=0$ peak saturates the warm end."
+    "The first snapshot is the initial state, and its peak is far taller than anything that follows. We therefore clip the shared color scale to roughly the 98th percentile of the post-initial snapshots, which keeps the later spread readable while the $t=0$ peak saturates the warm end."
    ]
   },
   {
@@ -642,7 +626,7 @@
    "id": "5d6d0fc2",
    "metadata": {},
    "source": [
-    "The snapshots show probability mass spreading through both the cycle edges and the chord shortcuts."
+    "Mass leaves the hot nodes 0, 1, and 7 along both the cycle edges and the chord shortcuts, and by the last snapshot it has spread into the rest of the graph as the distribution approaches equilibrium."
    ]
   },
   {
@@ -652,9 +636,9 @@
    "source": [
     "## Building the Torx circuit\n",
     "\n",
-    "For a Trotter resolution of $m$ steps, each layer applies one `PSWAP` per edge with the swap probability for the slice time $\\Delta t = t/m$.\n",
+    "Now we build the circuit whose job is to approximate that flow. For a Trotter resolution of $m$ steps, each layer applies one `PSWAP` per edge with the swap probability for the slice time $\\Delta t = t/m$, and the `DiscretePCircuit` constructor with `reps=m` repeats the whole layer $m$ times.\n",
     "\n",
-    "The `DiscretePCircuit` constructor with `reps=m` repeats the whole layer $m$ times, which is the product $T^m \\approx e^{tQ}p_0$ from the heat-flow construction above."
+    "That repetition is the product $T^m \\approx e^{tQ}p_0$ from the heat-flow construction above."
    ]
   },
   {
@@ -712,7 +696,7 @@
    "id": "2872dbe2",
    "metadata": {},
    "source": [
-    "A four-node ring shows the repeated-layer pattern compactly."
+    "The eight-node layer carries twelve gates, one per edge, which is more than a diagram can show clearly. A four-node ring uses the same repeated-layer pattern with few enough wires to follow."
    ]
   },
   {
@@ -783,7 +767,7 @@
    "id": "83f86370",
    "metadata": {},
    "source": [
-    "Sampling reads out where a single walker ends up. For a spread-out start, the helper `sample_pswap_product_formula` runs the circuit once per occupied source node and recombines the occupancies by the initial weights, using the linearity of heat flow in $p_0$."
+    "Sampling reads out where a single walker ends up, so one run cannot represent a start spread across three nodes. The helper `sample_pswap_product_formula` handles that by running the circuit once per occupied source node and recombining the occupancies by the initial weights, which is valid because heat flow is linear in $p_0$."
    ]
   },
   {
@@ -793,7 +777,7 @@
    "source": [
     "## Coarse and fine checks\n",
     "\n",
-    "We run the same edge layer at a coarse $m=2$ and a finer $m=32$, changing only the resolution: `reps` and the per-slice swap probability that goes with it. The exact $e^{tQ}p_0$ is the reference, and the printed errors compare both estimates.\n",
+    "The first question is whether the Trotter resolution matters at all, so we run the same edge layer at a coarse $m=2$ and a finer $m=32$, changing only the resolution: `reps` and the per-slice swap probability that goes with it. The exact $e^{tQ}p_0$ is the reference for both runs, and the printed $L_2$ errors say how far each estimate sits from it.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: L2 error</summary><p>The [$L_2$ norm](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html) is the Euclidean distance across all node occupancies. Zero means the two distributions agree at every node.</p></details>"
    ]
@@ -915,7 +899,7 @@
    "id": "007f4b8e",
    "metadata": {},
    "source": [
-    "Both estimates conserve probability, and for these fixed seeds the finer run is closer to exact."
+    "Two things should hold here, and the next cell asserts them separately. Each estimate must still sum to one within twice the binomial standard error, because sampling redistributes probability without creating or destroying it. The finer run must also come out closer to exact than the coarse one at these fixed seeds, which is the first hint that the error at $m=2$ is dominated by the splitting rather than by the sample count."
    ]
   },
   {
@@ -945,7 +929,7 @@
    "source": [
     "## Trotter convergence\n",
     "\n",
-    "Two error sources appear, and they behave differently.\n",
+    "Refining $m$ does not improve a sampled estimate forever, because two error sources contribute to the measured gap and they behave differently as $m$ grows.\n",
     "\n",
     "- **Trotter bias** is the gap between the product formula and exact $e^{tQ}p_0$. First-order Trotter shrinks it as $1/m$: slope $-1$ on a log-log plot.\n",
     "- **Monte Carlo noise** is the gap between the sampled estimate and the deterministic Trotter mean. By the central limit theorem its scale is $O(1/\\sqrt{N})$ in the sample count. It depends on the terminal probabilities, which vary with $m$, but is roughly flat here once the terminal distribution has stabilized.\n",
@@ -976,7 +960,7 @@
    "id": "240eeba3",
    "metadata": {},
    "source": [
-    "The deterministic product formula gives the pure-bias baseline, and we compute it exactly per edge."
+    "The next three cells build that pure-bias baseline in NumPy. Each layer walks the edge list in order and applies the same two-by-two mixing the gate performs, so the result carries the ordering error with no sampling scatter on top of it."
    ]
   },
   {
@@ -1133,7 +1117,7 @@
    "id": "98f83f5c",
    "metadata": {},
    "source": [
-    "The assertions capture the expected pattern: bias falls, the coarse sampled error matches the deterministic one, and the finest sampled error sits above the deterministic floor."
+    "Three claims follow from that two-error picture, and the next cell asserts each one on its own. The deterministic error has to fall at every refinement, because a larger $m$ means a shorter slice and the ordering error is all that is left to shrink. At the coarsest resolution $m=1$ the sampled error has to match the deterministic one within four binomial standard errors, because bias dominates so heavily there that the sampling scatter is invisible beside it. At the finest resolution $m=64$ the sampled error has to sit strictly above the deterministic one, which is the Monte Carlo noise floor described above showing up in the numbers: the bias has fallen below the scatter of a 12,000-sample estimate, so refining further no longer buys the sampled curve anything."
    ]
   },
   {
@@ -1231,7 +1215,7 @@
    "id": "dd8e655f",
    "metadata": {},
    "source": [
-    "One Strang layer applies the same edge gates forward and then backward, each for half the slice time."
+    "We write the symmetric layer out in NumPy first, so the order improvement shows up as a clean bias curve with no sampling noise in it. One Strang layer applies the same edge gates forward and then backward, each for half the slice time."
    ]
   },
   {
@@ -1313,7 +1297,7 @@
    "id": "090d5a26",
    "metadata": {},
    "source": [
-    "The same scheme runs in Torx: a Strang layer is the forward edge list followed by its reverse, each gate at the half-step probability. We sample it once to confirm the circuit tracks the exact flow."
+    "The same scheme runs in Torx, where a Strang layer is the forward edge list followed by its reverse, each gate carrying the half-step probability. We sample it once at the finest resolution $m=32$ to confirm that the circuit and the NumPy baseline describe the same scheme."
    ]
   },
   {
@@ -1390,7 +1374,7 @@
    "id": "a7bdf0c8",
    "metadata": {},
    "source": [
-    "We fit slopes to the deterministic curves to confirm the order: first-order decay sits near $1/m$, while Strang sits near $1/m^2$."
+    "A slope fit turns the order claim into a number we can check. We regress log error on log $m$ over the five finest resolutions and compare each fitted slope with its expected value, allowing 0.3 of slack: near $-1$ for the first-order product formula, near $-2$ for Strang. The next cell also asserts that Strang is the more accurate of the two at the finest resolution, which is what the steeper slope has to mean once $m$ is large enough."
    ]
   },
   {
@@ -1438,7 +1422,7 @@
    "id": "fc038516",
    "metadata": {},
    "source": [
-    "We overlay the two bias curves to show the order improvement directly."
+    "Putting the two bias curves on one log-log axis turns the order difference into a difference in slope."
    ]
   },
   {
@@ -1493,9 +1477,9 @@
    "id": "88693044",
    "metadata": {},
    "source": [
-    "The NumPy curves show the deterministic $1/m$ and $1/m^2$ bias rates. The Torx marker is the sampled Strang result already computed at $m=32$.\n",
+    "The two NumPy curves fall at the deterministic $1/m$ and $1/m^2$ bias rates, and the single Torx marker is the sampled Strang result already computed at $m=32$, which is where the sampled circuit can be read against the deterministic second-order curve.\n",
     "\n",
-    "The cost of the symmetric Torx circuit is one extra edge sweep per step, a constant factor that pays off whenever Trotter bias dominates the target error."
+    "The symmetric Torx circuit costs one extra edge sweep per step. That is a constant factor, so it pays off whenever Trotter bias rather than sample count dominates the target error."
    ]
   },
   {
@@ -1632,7 +1616,7 @@
    "id": "05f294ea",
    "metadata": {},
    "source": [
-    "We Trotterize with one `PJUMP` per directed edge and compare the sampled occupancy against the exact single-particle reference $e^{Q t} p_0$, sampling snapshot circuits at a few rep counts."
+    "The directed gate now gets the same treatment the symmetric one received. We Trotterize with one `PJUMP` per directed edge, sample snapshot circuits at a few rep counts, and compare each sampled occupancy against the exact single-particle reference $e^{Q t} p_0$, which comes from an eigendecomposition of $Q$ rather than from sampling."
    ]
   },
   {
@@ -1743,7 +1727,7 @@
    "id": "9bb4c706",
    "metadata": {},
    "source": [
-    "The sampled occupancies track the exact directed flow at every snapshot; the figure below overlays them."
+    "Across all five snapshots the largest occupancy gap is under 0.05, and every snapshot still sums to one within $5\\times10^{-3}$, so the sampled walk tracks the exact directed flow to within sampling scatter. The figure below overlays the two."
    ]
   },
   {

--- a/examples/02_random_walks_on_graphs.ipynb
+++ b/examples/02_random_walks_on_graphs.ipynb
@@ -193,7 +193,7 @@
     "p(t) \\;\\approx\\; \\underbrace{\\Big(\\textstyle\\prod_{\\{i,j\\}\\in E} e^{\\Delta t\\,Q_{ij}}\\Big)^{N}}_{\\vphantom{\\big|}\\text{the circuit}} p_0 \\;\\xrightarrow[N\\to\\infty]{}\\; \\underbrace{e^{-Lt}\\,p_0}_{\\vphantom{\\big|}\\text{exact heat flow}}, \\qquad \\Delta t = t/N\n",
     "$$\n",
     "\n",
-    "The edge generators do not commute, so the ordered product equals $e^{-Lt}$ only in the limit. This is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). The first-order expansion of one layer is $\\mathbb I - \\Delta t\\,L$ (one Euler step), which is where the $1/N$ Trotter bias studied below comes from."
+    "The edge generators don't commute, so the ordered product equals $e^{-Lt}$ only in the limit. This is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). The first-order expansion of one layer is $\\mathbb I - \\Delta t\\,L$ (one Euler step), which is where the $1/N$ Trotter bias studied below comes from."
    ]
   },
   {
@@ -767,7 +767,7 @@
    "id": "83f86370",
    "metadata": {},
    "source": [
-    "Sampling reads out where a single walker ends up, so one run cannot represent a start spread across three nodes. The helper `sample_pswap_product_formula` handles that by running the circuit once per occupied source node and recombining the occupancies by the initial weights, which is valid because heat flow is linear in $p_0$."
+    "Sampling reads out where a single walker ends up, so one run can't represent a start spread across three nodes. The helper `sample_pswap_product_formula` handles that by running the circuit once per occupied source node and recombining the occupancies by the initial weights, which is valid because heat flow is linear in $p_0$."
    ]
   },
   {
@@ -929,12 +929,12 @@
    "source": [
     "## Trotter convergence\n",
     "\n",
-    "Refining $m$ does not improve a sampled estimate forever, because two error sources contribute to the measured gap and they behave differently as $m$ grows.\n",
+    "Refining $m$ doesn't improve a sampled estimate forever, because two error sources contribute to the measured gap and they behave differently as $m$ grows.\n",
     "\n",
     "- **Trotter bias** is the gap between the product formula and exact $e^{tQ}p_0$. First-order Trotter shrinks it as $1/m$: slope $-1$ on a log-log plot.\n",
     "- **Monte Carlo noise** is the gap between the sampled estimate and the deterministic Trotter mean. By the central limit theorem its scale is $O(1/\\sqrt{N})$ in the sample count. It depends on the terminal probabilities, which vary with $m$, but is roughly flat here once the terminal distribution has stabilized.\n",
     "\n",
-    "The deterministic product formula, computed as an exact matrix product per edge, measures pure bias. The sampled Torx estimate uses 12k trajectories per occupied source, 36k total trajectories per seed, across four seeds. The band is the sample standard deviation of those four seeds, so it is an indicative spread rather than a tight confidence interval."
+    "The deterministic product formula, computed as an exact matrix product per edge, measures pure bias. The sampled Torx estimate uses 12k trajectories per occupied source, 36k total trajectories per seed, across four seeds. The band is the sample standard deviation of those four seeds, so it's an indicative spread rather than a tight confidence interval."
    ]
   },
   {
@@ -1203,7 +1203,7 @@
    "source": [
     "## Second-order splitting\n",
     "\n",
-    "Each `PSWAP` is the exact edge propagator $e^{Q_{ij}\\Delta t}$, so a single edge carries no bias. The $1/m$ error above comes from ordering: the edge generators do not commute, so applying them one after another reproduces $e^{\\sum_{ij} Q_{ij}\\,\\Delta t}$ only to first order in $\\Delta t$.\n",
+    "Each `PSWAP` is the exact edge propagator $e^{Q_{ij}\\Delta t}$, so a single edge carries no bias. The $1/m$ error above comes from ordering: the edge generators don't commute, so applying them one after another reproduces $e^{\\sum_{ij} Q_{ij}\\,\\Delta t}$ only to first order in $\\Delta t$.\n",
     "\n",
     "A symmetric sweep removes the leading piece of that error. Run the edges forward for a half step and then in reverse for a half step, and the layer becomes its own mirror image, which cancels the leading $O(\\Delta t^2)$ local splitting error from the non-commuting edge updates.\n",
     "\n",
@@ -1479,7 +1479,7 @@
    "source": [
     "The two NumPy curves fall at the deterministic $1/m$ and $1/m^2$ bias rates, and the single Torx marker is the sampled Strang result already computed at $m=32$, which is where the sampled circuit can be read against the deterministic second-order curve.\n",
     "\n",
-    "The symmetric Torx circuit costs one extra edge sweep per step. That is a constant factor, so it pays off whenever Trotter bias rather than sample count dominates the target error."
+    "The symmetric Torx circuit costs one extra edge sweep per step. That's a constant factor, so it pays off whenever Trotter bias rather than sample count dominates the target error."
    ]
   },
   {
@@ -1489,7 +1489,7 @@
    "source": [
     "## Directed transport: the PJUMP gate\n",
     "\n",
-    "The `PSWAP` edge above is symmetric: probability flows both ways along an edge. Its directed counterpart is the `PJUMP` gate, which moves a token along an *oriented* edge $a \\to b$ at rate $r$. Over a slice $\\Delta t$ it sends the token from $a$ to $b$ with probability $p = 1 - e^{-r\\,\\Delta t}$, but only when $a$ is occupied and $b$ is empty ($a = 1$, $b = 0$). Otherwise it does nothing.\n",
+    "The `PSWAP` edge above is symmetric: probability flows both ways along an edge. Its directed counterpart is the `PJUMP` gate, which moves a token along an *oriented* edge $a \\to b$ at rate $r$. Over a slice $\\Delta t$ it sends the token from $a$ to $b$ with probability $p = 1 - e^{-r\\,\\Delta t}$, and it fires only when $a$ is occupied and $b$ is empty ($a = 1$, $b = 0$), leaving the pair untouched in every other case.\n",
     "\n",
     "Like `PSWAP`, the gate is parametrised by the logit $\\theta = \\log\\!\\big(p / (1 - p)\\big)$, and the same Trotter-layer machinery carries over: one `PJUMP` per directed edge is a single layer, and `DiscretePCircuit(gates, reps=m)` repeats it to cover $[0, t]$. The only change from the rest of this tutorial is that the graph is now directed."
    ]
@@ -1791,7 +1791,7 @@
    "id": "89a268cc",
    "metadata": {},
    "source": [
-    "The Torx dots track the NumPy exact lines. With a single walker the destination node is always empty, so the jumps are an ordinary directed random walk. Add more walkers and the empty-target condition becomes binding: a token cannot hop onto an occupied node, so the walkers exclude one another. That turns the graph into an **exclusion process**: the directed, multi-walker analogue of the symmetric walk studied in this tutorial."
+    "The Torx dots track the NumPy exact lines. With a single walker the destination node is always empty, so the jumps are an ordinary directed random walk. Add more walkers and the empty-target condition becomes binding: a token can't hop onto an occupied node, so the walkers exclude one another. That turns the graph into an **exclusion process**: the directed, multi-walker analogue of the symmetric walk studied in this tutorial."
    ]
   },
   {

--- a/examples/03_bunny_graph_diffusion.ipynb
+++ b/examples/03_bunny_graph_diffusion.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "A sampled field on its own tells us nothing about how far it can be trusted, so once the full Torx circuit is built we compare its multi-seed sample mean against two NumPy references that answer different questions. The deterministic mean of the same ordered sweep runs the identical update rule without ever sampling, so it isolates how much of the gap is sampling error. The exact reference then shows how much of the gap the ordered sweep introduces on its own. We finish by checking the same primitive on a closed 32-vertex patch, which is small enough to read vertex by vertex.\n",
     "\n",
-    "One note on the word diffusion. We use only the unweighted connectivity graph, which records which vertices are adjacent and nothing else, so this construction does not model physical surface heat: edge lengths, triangle angles, vertex areas, and a mesh mass matrix play no part in it."
+    "One note on the word diffusion. We use only the unweighted connectivity graph, which records which vertices are adjacent and nothing else, so this construction doesn't model physical surface heat: edge lengths, triangle angles, vertex areas, and a mesh mass matrix play no part in it."
    ]
   },
   {
@@ -205,7 +205,7 @@
     "\\Delta t=t/N.\n",
     "$$\n",
     "\n",
-    "At finite $N$, Torx executes each product as a sequential sweep over the edge list, where each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$ for this unit-rate graph. Overlapping edge blocks share a vertex, so they do not commute and the ordered product misses the exact propagator at finite $N$. That residual difference is the splitting bias, and it is one of the two errors we measure later.\n",
+    "At finite $N$, Torx executes each product as a sequential sweep over the edge list, where each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$ for this unit-rate graph. Overlapping edge blocks share a vertex, so they don't commute and the ordered product misses the exact propagator at finite $N$. That residual difference is the splitting bias, and it's one of the two errors we measure later.\n",
     "\n",
     "Torx works with those per-edge factors alone and never forms the dense propagator $e^{-Lt}$, so both quantities we compare against come from NumPy: the exact eigensolution, and the deterministic mean of the same ordered sweep.\n"
    ]
@@ -217,7 +217,7 @@
    "source": [
     "## Diffusion on the bunny connectivity graph\n",
     "\n",
-    "Now we build the graph itself, and we set out what the two figures in this section can and cannot show.\n",
+    "Now we build the graph itself, and we set out what the two figures in this section can and can't show.\n",
     "\n",
     "All probability starts on one ear vertex and spreads through graph edges.\n",
     "\n",
@@ -586,7 +586,7 @@
    "source": [
     "The Torx multi-seed mean is our primary sampled result, and the panels above place it beside the NumPy exact field at the same $t=1.5$ on one shared color scale. Both keep the excitation concentrated near the source, with peaks of 0.040 and 0.037 and 9% of vertices above 15% of their own peak.\n",
     "\n",
-    "The three distances printed above say how close that agreement is and where the remaining difference comes from. The sampling L2 of 0.0051 compares the Torx mean with the NumPy mean of the same ordered sweep, which uses the identical edge order, repetition count, and swap probability but never samples, so that number is sampling error on its own. The splitting bias L2 of 0.0159 compares that deterministic mean with the exact NumPy graph diffusion, and it is the price of running the per-edge factors in sequence at finite $N$ rather than simultaneously. The total L2 of 0.0154 compares the Torx mean directly with the exact field, so it carries both effects at once, and because the two can partly cancel the three numbers need not add up."
+    "The three distances printed above say how close that agreement is and where the remaining difference comes from. The sampling L2 of 0.0051 compares the Torx mean with the NumPy mean of the same ordered sweep, which uses the identical edge order, repetition count, and swap probability but never samples, so that number is sampling error on its own. The splitting bias L2 of 0.0159 compares that deterministic mean with the exact NumPy graph diffusion, and it's the price of running the per-edge factors in sequence at finite $N$ rather than simultaneously. The total L2 of 0.0154 compares the Torx mean directly with the exact field, so it carries both effects at once, and because the two can partly cancel the three numbers need not add up."
    ]
   },
   {
@@ -594,7 +594,7 @@
    "id": "c2868609",
    "metadata": {},
    "source": [
-    "Diffusion on a connected graph has to end somewhere, so next we look at where it is heading, laying the three NumPy exact times out as a left-to-right row that is easier to read than a stack."
+    "Diffusion on a connected graph has to end somewhere, so next we look at where it's heading, laying the three NumPy exact times out as a left-to-right row that is easier to read than a stack."
    ]
   },
   {
@@ -741,7 +741,7 @@
     "\n",
     "A drawing shows the rule but not whether the repeated circuit implements it correctly, so we now compare Torx with the NumPy deterministic mean of the same ordered sweep on a 32-vertex patch grown outward from the source by breadth-first search (BFS).\n",
     "\n",
-    "We close the patch first, which means we remove every edge running from those 32 vertices to the rest of the bunny and keep only the edges among the 32 themselves. Graph theory calls the result an induced subgraph, and closing it earns its keep twice: no probability leaks out through a cut edge, and Torx and NumPy are guaranteed to run on exactly the same finite graph. That guarantee is what makes this an implementation-parity check, a test of whether the sampled circuit reproduces the deterministic mean of an identical update rule. It is not a cropped approximation to the full-graph field, because removing the boundary edges changes the diffusion inside the patch.\n",
+    "We close the patch first, which means we remove every edge running from those 32 vertices to the rest of the bunny and keep only the edges among the 32 themselves. Graph theory calls the result an induced subgraph, and closing it earns its keep twice: no probability leaks out through a cut edge, and Torx and NumPy are guaranteed to run on exactly the same finite graph. That guarantee is what makes this an implementation-parity check, a test of whether the sampled circuit reproduces the deterministic mean of an identical update rule, rather than an attempt to approximate the full-graph field on a smaller canvas, since removing the boundary edges changes the diffusion inside the patch.\n",
     "\n",
     "We use swap probability `0.12` for three repetitions. The code below converts it back to the equivalent unit-rate slice time and prints the patch's effective total time, which is a number of its own and distinct from the full-graph $t=1.5$ result."
    ]
@@ -1040,9 +1040,9 @@
     "\n",
     "We applied Torx graph diffusion to the Stanford bunny's unweighted mesh connectivity and measured how far the sampled field sits from the exact answer.\n",
     "\n",
-    "- The decimated mesh defines a 450-vertex, 1,352-edge graph built from adjacency alone, so it carries connectivity rather than mesh geometry and is not a geometry-aware physical heat model.\n",
+    "- The decimated mesh defines a 450-vertex, 1,352-edge graph built from adjacency alone, so it carries connectivity rather than mesh geometry and isn't a geometry-aware physical heat model.\n",
     "- Torx executes one `PSWAP` per edge for 11 repetitions and supplies the primary multi-seed sampled result at $t=1.5$.\n",
-    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references, which Torx does not sample because doing so would cost many more repetitions of every gate.\n",
+    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references, which Torx doesn't sample because doing so would cost many more repetitions of every gate.\n",
     "- The full-graph error report separates sampling error from splitting bias, and it can do so only because we compute the ordered-sweep mean, the one reference that shares Torx's update rule exactly. The total error follows from comparing Torx with the exact field.\n",
     "- The closed 32-vertex patch then checks one seeded Torx run against the matching NumPy ordered mean at its own effective time, which is where implementation parity is easiest to read directly.\n",
     "\n",

--- a/examples/03_bunny_graph_diffusion.ipynb
+++ b/examples/03_bunny_graph_diffusion.ipynb
@@ -13,8 +13,8 @@
    "id": "ded6c75a",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We scale the small graph walk's edge-local <code>PSWAP</code> rule up to diffusion on the Stanford bunny's mesh connectivity. Torx supplies the sampled full-graph result, while NumPy supplies the ordered-sweep mean and exact graph-diffusion references.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We scale the small graph walk's edge-local <code>PSWAP</code> rule up to diffusion on the Stanford bunny's mesh connectivity. Torx supplies the sampled full-graph result, and NumPy supplies the ordered-sweep mean plus the exact graph-diffusion reference, which is how we tell sampling noise apart from the error of the ordered sweep itself.</p>\n",
     "</div>"
    ]
   },
@@ -23,17 +23,15 @@
    "id": "139813e7",
    "metadata": {},
    "source": [
-    "In this tutorial, we diffuse a probability distribution on the connectivity graph induced by the Stanford bunny mesh.\n",
+    "In this tutorial, we diffuse a probability distribution on the connectivity graph induced by the Stanford bunny mesh. This is the mesh-scale version of [notebook 02](02_random_walks_on_graphs.ipynb): the same `PSWAP`-per-edge primitive, now on a few hundred vertices.\n",
     "\n",
-    "We map each unweighted mesh edge to one `PSWAP` gate. A single excitation starts at one ear vertex, and $x_i(t)$ is the probability that it occupies vertex $i$ after averaging repeated one-hot runs.\n",
+    "The setup is short to state. We map each unweighted mesh edge to one `PSWAP` gate, a single excitation starts at one ear vertex, and $x_i(t)$ is the probability that it occupies vertex $i$ after averaging repeated one-hot runs, each of which carries the excitation on exactly one vertex at a time.\n",
     "\n",
-    "The combinatorial graph Laplacian $L = D - A$ splits into one symmetric two-node term per edge. An ordered layer of `PSWAP` gates approximates the simultaneous graph evolution, and repeating that layer moves probability through the connectivity graph.\n",
+    "One gate per edge is enough because the combinatorial graph Laplacian $L = D - A$ splits into one symmetric two-node term per edge. An ordered layer of `PSWAP` gates therefore approximates the simultaneous graph evolution, and repeating that layer moves probability through the connectivity graph.\n",
     "\n",
-    "This construction does not model physical surface heat. It ignores edge lengths, triangle angles, vertex areas, and a mesh mass matrix.\n",
+    "A sampled field on its own tells us nothing about how far it can be trusted, so once the full Torx circuit is built we compare its multi-seed sample mean against two NumPy references that answer different questions. The deterministic mean of the same ordered sweep runs the identical update rule without ever sampling, so it isolates how much of the gap is sampling error. The exact reference then shows how much of the gap the ordered sweep introduces on its own. We finish by checking the same primitive on a closed 32-vertex patch, which is small enough to read vertex by vertex.\n",
     "\n",
-    "We build the full Torx circuit, compare its multi-seed sample mean with the deterministic mean of the same ordered sweep and a NumPy exact reference, then check the same primitive on a closed 32-vertex patch.\n",
-    "\n",
-    "This is the mesh-scale version of [notebook 02](02_random_walks_on_graphs.ipynb): the same `PSWAP`-per-edge primitive, now on a few hundred vertices.\n"
+    "One note on the word diffusion. We use only the unweighted connectivity graph, which records which vertices are adjacent and nothing else, so this construction does not model physical surface heat: edge lengths, triangle angles, vertex areas, and a mesh mass matrix play no part in it."
    ]
   },
   {
@@ -103,9 +101,9 @@
    "id": "966f2fcb",
    "metadata": {},
    "source": [
-    "The computation is split across the notebook and shared helpers.\n",
+    "Several actors contribute to the numbers below, so we say up front which one produces what.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx executes the repeated <code>PSWAP</code> circuits and returns sampled occupancies.</li><li>Notebook code exposes the full circuit and reports sampling error, splitting bias, and total error.</li><li><code>examples/helpers/_graph_diffusion.py</code> provides NumPy references and Torx sampling wrappers, while <code>examples/helpers/_stanford_bunny.py</code> loads, decimates, keeps the largest connected component, and plots the mesh.</li><li>The offline mesh is <code>examples/assets/stanford_bunny/bun_zipper_res3.ply</code>.</li></ul></details>"
+    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx executes the repeated <code>PSWAP</code> circuits and returns sampled occupancies.</li><li>Notebook code exposes the full circuit and reports the three error numbers: sampling error, splitting bias (what the ordered per-edge sweep gets wrong on its own), and total error.</li><li><code>examples/helpers/_graph_diffusion.py</code> provides NumPy references and Torx sampling wrappers, while <code>examples/helpers/_stanford_bunny.py</code> loads, decimates, keeps the largest connected component, and plots the mesh.</li><li>The offline mesh is <code>examples/assets/stanford_bunny/bun_zipper_res3.ply</code>.</li></ul></details>"
    ]
   },
   {
@@ -150,7 +148,7 @@
    "id": "0b62574d",
    "metadata": {},
    "source": [
-    "The plotting style and output path remain in the plotting helpers. Mesh preprocessing is imported from the mesh helper above."
+    "We keep the plotting style and the figure output path in the plotting helpers and import mesh preprocessing from the mesh helper above, which leaves the cells below free to talk about the graph itself."
    ]
   },
   {
@@ -187,7 +185,9 @@
    "source": [
     "## Graph connectivity, the Laplacian, and one swap per edge\n",
     "\n",
-    "A triangle mesh induces a graph $G = (V, E)$: each vertex is a [pbit](01_introduction_to_parametrised_stochastic_circuits.ipynb), and each triangle side contributes an unweighted edge. The **combinatorial graph Laplacian** $L = D - A$, built from the degree matrix $D$ and adjacency matrix $A$, defines\n",
+    "Before running anything on a few hundred vertices, this section establishes why a single two-site gate per edge is a legitimate way to diffuse probability on a graph.\n",
+    "\n",
+    "A triangle mesh induces a graph $G = (V, E)$: each vertex is a [pbit](01_introduction_to_parametrised_stochastic_circuits.ipynb), and each triangle side contributes an unweighted edge. The **combinatorial graph Laplacian** $L = D - A$, built from the degree matrix $D$ and adjacency matrix $A$, compares each vertex with its neighbors and defines\n",
     "\n",
     "$$\n",
     "\\dot x = -Lx,\n",
@@ -195,9 +195,9 @@
     "x(t) = e^{-Lt}x(0).\n",
     "$$\n",
     "\n",
-    "Probability flows between adjacent vertices. This is the master equation from [notebook 02](02_random_walks_on_graphs.ipynb) with generator $Q=-L$.\n",
+    "Under this equation probability flows between adjacent vertices and nowhere else, which is the master equation from [notebook 02](02_random_walks_on_graphs.ipynb) with generator $Q=-L$.\n",
     "\n",
-    "The Laplacian splits into one symmetric two-node block per edge, $L=\\sum_{(i,j)\\in E}L_{ij}$. [Lie-Trotter splitting](#ref-trotter-1959) rewrites the exact propagator as the limit of ordered per-edge products:\n",
+    "The structural fact we need is that the Laplacian splits into one symmetric two-node block per edge, $L=\\sum_{(i,j)\\in E}L_{ij}$. [Lie-Trotter splitting](#ref-trotter-1959) turns that sum into a product, rewriting the exact propagator as the limit of ordered per-edge products:\n",
     "\n",
     "$$\n",
     "x(t) = \\lim_{N\\to\\infty}\\Bigl(\\underbrace{\\textstyle\\prod_{(i,j)\\in E}e^{\\Delta t Q_{ij}}}_{\\vphantom{\\big|}\\text{ordered per-edge sweep}}\\Bigr)^N x(0),\n",
@@ -205,9 +205,9 @@
     "\\Delta t=t/N.\n",
     "$$\n",
     "\n",
-    "At finite $N$, Torx executes each product as a sequential sweep over the edge list. Each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$ for this unit-rate graph. Overlapping edge blocks do not commute, so the ordered product has splitting bias at finite $N$.\n",
+    "At finite $N$, Torx executes each product as a sequential sweep over the edge list, where each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$ for this unit-rate graph. Overlapping edge blocks share a vertex, so they do not commute and the ordered product misses the exact propagator at finite $N$. That residual difference is the splitting bias, and it is one of the two errors we measure later.\n",
     "\n",
-    "Torx never forms $e^{-Lt}$. NumPy computes the exact eigensolution and the deterministic ordered-sweep mean used below for comparison.\n"
+    "Torx works with those per-edge factors alone and never forms the dense propagator $e^{-Lt}$, so both quantities we compare against come from NumPy: the exact eigensolution, and the deterministic mean of the same ordered sweep.\n"
    ]
   },
   {
@@ -217,13 +217,15 @@
    "source": [
     "## Diffusion on the bunny connectivity graph\n",
     "\n",
+    "Now we build the graph itself, and we set out what the two figures in this section can and cannot show.\n",
+    "\n",
     "All probability starts on one ear vertex and spreads through graph edges.\n",
     "\n",
     "We load the `bun_zipper_res3` reconstruction from the [Stanford bunny dataset](#ref-stanford-bunny), keep its largest connected component, then coarsen it with `decimate_mesh` from `examples/helpers/_stanford_bunny.py`. The decimator snaps vertices to a uniform 3-D grid, replaces occupied cells with centroids, remaps faces, and drops collapsed triangles. This preprocessing determines the 450-vertex, 1,352-edge graph used below.\n",
     "\n",
-    "Torx samples the full graph at $t=1.5$. The $t=10$ and $t=40$ panels are expensive **NumPy exact references**, not Torx results.\n",
+    "Torx samples the full graph at $t=1.5$, and at that time only. Reaching $t=10$ or $t=40$ the same way would take many more repetitions of every gate in the layer, each with its own batch of samples, which is expensive, so the $t=10$ and $t=40$ panels are **NumPy exact references** rather than Torx results.\n",
     "\n",
-    "The same-time Torx and NumPy comparison uses one shared absolute color scale. The time progression uses per-panel peak normalization, with each raw peak printed in its title.\n"
+    "That division also decides how we color the panels, and the two figures use different conventions deliberately. The same-time Torx and NumPy comparison puts both panels on one shared absolute color scale, because a comparison is only fair when equal probabilities get equal colors. The time progression instead uses per-panel peak normalization, since the field flattens as it spreads and one shared scale would leave the late panels nearly blank. Per-panel normalization hides how much the absolute magnitude has shrunk, so we print each raw peak in its panel title."
    ]
   },
   {
@@ -336,7 +338,7 @@
    "id": "df097a98",
    "metadata": {},
    "source": [
-    "The full Torx construction stays visible: one structural `PSWAP` per mesh edge, one common logit for the unit-rate slice probability, and `reps=TORX_STEPS`. The shared sampler compiles and executes this same circuit for each seed."
+    "We build the circuit here in the notebook rather than inside a helper, so every ingredient stays visible: one structural `PSWAP` per mesh edge, one common logit for the unit-rate slice probability, and `reps=TORX_STEPS` for the repeated layer. The shared sampler compiles and executes this same circuit for each seed."
    ]
   },
   {
@@ -449,7 +451,11 @@
    },
    "outputs": [],
    "source": [
-    "# These three distances answer different questions and need not add exactly.\n",
+    "# Three distances, three questions, as described in the markdown cell below:\n",
+    "# sampling error is Torx against the same ordered sweep computed exactly,\n",
+    "# splitting bias is that ordered sweep against exact graph diffusion, and total\n",
+    "# error is Torx against exact. They measure different things and need not add\n",
+    "# exactly.\n",
     "sampling_l2 = float(np.linalg.norm(torx_field - ordered_mean))\n",
     "splitting_bias_l2 = float(\n",
     "    np.linalg.norm(ordered_mean - exact_fields[0])\n",
@@ -578,7 +584,9 @@
    "id": "8041e2fb",
    "metadata": {},
    "source": [
-    "The Torx multi-seed mean is the primary sampled result. The separate distances above compare it with the matching NumPy ordered-sweep mean, then compare that mean with the NumPy exact graph diffusion."
+    "The Torx multi-seed mean is our primary sampled result, and the panels above place it beside the NumPy exact field at the same $t=1.5$ on one shared color scale. Both keep the excitation concentrated near the source, with peaks of 0.040 and 0.037 and 9% of vertices above 15% of their own peak.\n",
+    "\n",
+    "The three distances printed above say how close that agreement is and where the remaining difference comes from. The sampling L2 of 0.0051 compares the Torx mean with the NumPy mean of the same ordered sweep, which uses the identical edge order, repetition count, and swap probability but never samples, so that number is sampling error on its own. The splitting bias L2 of 0.0159 compares that deterministic mean with the exact NumPy graph diffusion, and it is the price of running the per-edge factors in sequence at finite $N$ rather than simultaneously. The total L2 of 0.0154 compares the Torx mean directly with the exact field, so it carries both effects at once, and because the two can partly cancel the three numbers need not add up."
    ]
   },
   {
@@ -586,7 +594,7 @@
    "id": "c2868609",
    "metadata": {},
    "source": [
-    "The NumPy exact time progression is easier to read as a left-to-right row."
+    "Diffusion on a connected graph has to end somewhere, so next we look at where it is heading, laying the three NumPy exact times out as a left-to-right row that is easier to read than a stack."
    ]
   },
   {
@@ -645,7 +653,7 @@
    "id": "5c326c67",
    "metadata": {},
    "source": [
-    "The progression uses a separate relative scale in each panel. By $t=40$, the NumPy exact distribution is close to uniform across the connected graph, not a localized front."
+    "The peaks printed in the titles fall from 0.037 at $t=1.5$ to 0.004 at $t=40$, and by $t=40$ every vertex sits above 15% of that peak while the field is only 0.0172 away in L2 from the uniform distribution. What the last panel shows is therefore near-uniform occupancy across the connected graph rather than a localized front."
    ]
   },
   {
@@ -655,15 +663,9 @@
    "source": [
     "## The same Torx primitive, checked on a patch\n",
     "\n",
-    "Every mesh edge contributes exactly one `PSWAP`, identical to [notebook 02](02_random_walks_on_graphs.ipynb). The full circuit has 1,352 gates per repetition, so the figure below shows the primitive on one edge."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6722f7b1",
-   "metadata": {},
-   "source": [
-    "The structural two-pbit circuit carries the sites. Its parameter is the logit of $p$, where identity occurs with probability $1-p$ and the states $10$ and $01$ swap with probability $p$."
+    "Each repetition of the full circuit applies 1,352 `PSWAP` gates, far too many to check by reading a picture of them, so we split the checking in two: we draw the primitive on a single edge, then run it on a graph small enough to compare vertex by vertex.\n",
+    "\n",
+    "Every mesh edge contributes exactly one `PSWAP`, identical to [notebook 02](02_random_walks_on_graphs.ipynb). The gate is structural, meaning the two-pbit circuit fixes the sites it acts on while one parameter fixes what it does with them: that parameter is the logit of $p$, identity occurs with probability $1-p$, and the states $10$ and $01$ swap with probability $p$."
    ]
   },
   {
@@ -688,7 +690,7 @@
    "id": "d8b1fdfc",
    "metadata": {},
    "source": [
-    "Here is the single-edge gate."
+    "The schematic below draws that single gate, with the two sites it connects and the parameter that sets the swap probability."
    ]
   },
   {
@@ -735,19 +737,13 @@
    "id": "2fdf5984",
    "metadata": {},
    "source": [
-    "This is the Torx gate repeated once per graph edge in each ordered layer. The full construction and repetition count remain visible above."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "43abc74f",
-   "metadata": {},
-   "source": [
-    "We compare Torx with the NumPy deterministic mean of the same ordered sweep on a 32-vertex breadth-first search (BFS) patch.\n",
+    "That one gate is what Torx repeats once per graph edge in each ordered layer, and the full construction and repetition count remain visible above.\n",
     "\n",
-    "The patch is a closed induced graph: edges from its 32 vertices to the rest of the bunny are removed. It is an implementation-parity check, not a cropped approximation to the full-graph field.\n",
+    "A drawing shows the rule but not whether the repeated circuit implements it correctly, so we now compare Torx with the NumPy deterministic mean of the same ordered sweep on a 32-vertex patch grown outward from the source by breadth-first search (BFS).\n",
     "\n",
-    "We use swap probability `0.12` for three repetitions. The code below converts it back to the equivalent unit-rate slice time and prints the patch's effective total time, which is distinct from the full-graph $t=1.5$ result."
+    "We close the patch first, which means we remove every edge running from those 32 vertices to the rest of the bunny and keep only the edges among the 32 themselves. Graph theory calls the result an induced subgraph, and closing it earns its keep twice: no probability leaks out through a cut edge, and Torx and NumPy are guaranteed to run on exactly the same finite graph. That guarantee is what makes this an implementation-parity check, a test of whether the sampled circuit reproduces the deterministic mean of an identical update rule. It is not a cropped approximation to the full-graph field, because removing the boundary edges changes the diffusion inside the patch.\n",
+    "\n",
+    "We use swap probability `0.12` for three repetitions. The code below converts it back to the equivalent unit-rate slice time and prints the patch's effective total time, which is a number of its own and distinct from the full-graph $t=1.5$ result."
    ]
   },
   {
@@ -890,7 +886,7 @@
    "id": "0605e6c5",
    "metadata": {},
    "source": [
-    "Applying the same edge updates to probabilities instead of sampled bits gives the ordered-sweep mean. Because it uses the circuit's edge order, repetitions, and swap probability, the remaining gap to Torx is sampling error rather than a different update rule.\n"
+    "We apply the same edge updates to probabilities instead of to sampled bits, which gives the ordered-sweep mean. Because it reuses the circuit's edge order, repetitions, and swap probability, any gap left between it and Torx is sampling error rather than a different update rule."
    ]
   },
   {
@@ -940,7 +936,7 @@
    "id": "3541354b",
    "metadata": {},
    "source": [
-    "The `sample_pswap_product_formula` helper builds the matching ordered Torx `PSWAP` circuit and estimates each vertex occupancy."
+    "Now the sampled side: the `sample_pswap_product_formula` helper builds the matching ordered Torx `PSWAP` circuit and estimates each vertex occupancy from one seeded batch of runs."
    ]
   },
   {
@@ -1032,7 +1028,7 @@
    "id": "4b61a43d",
    "metadata": {},
    "source": [
-    "The scatter compares one seeded Torx run with the NumPy deterministic mean of the same closed-patch circuit. The orange ring marks the source vertex."
+    "Across the 32 patch vertices, one seeded Torx run and the NumPy deterministic mean of the same closed-patch circuit differ by 0.0159 in L2, and the scatter shows where that difference sits vertex by vertex. The orange ring marks the source vertex."
    ]
   },
   {
@@ -1042,13 +1038,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We applied Torx graph diffusion to the Stanford bunny's unweighted mesh connectivity.\n",
+    "We applied Torx graph diffusion to the Stanford bunny's unweighted mesh connectivity and measured how far the sampled field sits from the exact answer.\n",
     "\n",
-    "- The decimated mesh defines a 450-vertex, 1,352-edge graph. It is not a geometry-aware physical heat model.\n",
+    "- The decimated mesh defines a 450-vertex, 1,352-edge graph built from adjacency alone, so it carries connectivity rather than mesh geometry and is not a geometry-aware physical heat model.\n",
     "- Torx executes one `PSWAP` per edge for 11 repetitions and supplies the primary multi-seed sampled result at $t=1.5$.\n",
-    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references.\n",
-    "- The full-graph error report separates sampling error, splitting bias, and total error by computing the missing ordered-sweep mean.\n",
-    "- The closed 32-vertex patch checks one seeded Torx run against the matching NumPy ordered mean at its own effective time.\n",
+    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references, which Torx does not sample because doing so would cost many more repetitions of every gate.\n",
+    "- The full-graph error report separates sampling error from splitting bias, and it can do so only because we compute the ordered-sweep mean, the one reference that shares Torx's update rule exactly. The total error follows from comparing Torx with the exact field.\n",
+    "- The closed 32-vertex patch then checks one seeded Torx run against the matching NumPy ordered mean at its own effective time, which is where implementation parity is easiest to read directly.\n",
     "\n",
     "See also:\n",
     "\n",

--- a/examples/04_execution_interface_readouts.ipynb
+++ b/examples/04_execution_interface_readouts.ipynb
@@ -526,7 +526,7 @@
    "id": "f248d585",
    "metadata": {},
    "source": [
-    "The empirical-density bars track `exact_density`, and the `expval_all` cross sits against both the sample-mean and exact-expectation bars even though it comes from a separate `SEED + 1` draw. That is the observation that matters: the `sample_mean` reduction and `expval_all` are two routes to the same expectation, and here they agree within Monte Carlo error.\n"
+    "The empirical-density bars track `exact_density`, and the `expval_all` cross sits against both the sample-mean and exact-expectation bars even though it comes from a separate `SEED + 1` draw. That's the observation that matters: the `sample_mean` reduction and `expval_all` are two routes to the same expectation, and here they agree within Monte Carlo error.\n"
    ]
   },
   {
@@ -591,7 +591,7 @@
    "id": "b167978b",
    "metadata": {},
    "source": [
-    "For each $N$ we form the empirical density and the block-averaged total-variation distance from this one run, which means the estimates at different $N$ share samples. The block analysis below spells out that correlation and what it does and does not license."
+    "For each $N$ we form the empirical density and the block-averaged total-variation distance from this one run, which means the estimates at different $N$ share samples. The block analysis below spells out that correlation and what it does and doesn't license."
    ]
   },
   {
@@ -694,13 +694,13 @@
     "\n",
     "We now measure how the `sample_mean` error shrinks as the sample size grows, using a block analysis.\n",
     "\n",
-    "A single estimate cannot reveal a scaling law, because one number has no spread to read. So we cut one long run into blocks and treat each block as its own estimate of the same quantity, which turns the spread across blocks into a measurement of the error at that block size. We apply the block analysis to pbit 1:\n",
+    "A single estimate can't reveal a scaling law, because one number has no spread to read. So we cut one long run into blocks and treat each block as its own estimate of the same quantity, which turns the spread across blocks into a measurement of the error at that block size. We apply the block analysis to pbit 1:\n",
     "\n",
     "1. draw one long $32{,}000$-sample run,\n",
     "2. split it into non-overlapping blocks of size $N \\in \\{25, 50, 100, 200, 500, 1000\\}$,\n",
     "3. average pbit 1 within each block to form one estimator of $\\langle s_1 \\rangle$.\n",
     "\n",
-    "The blocks for a single $N$ are disjoint, but every per-$N$ estimator reuses a prefix of the same long run, so estimators across $N$ share samples and are correlated. That correlation is acceptable for visualizing the slope.\n",
+    "The blocks for a single $N$ are disjoint, but every per-$N$ estimator reuses a prefix of the same long run, so estimators across $N$ share samples and are correlated, which is acceptable here because we're reading the slope of the curve rather than testing any single point against a tolerance.\n",
     "\n",
     "With 32 blocks per $N$ we report the mean absolute error against the exact pbit-1 expectation. The shaded band is the **Monte Carlo standard error** of that mean across the 32 blocks, meaning how far the 32-block average would typically move if we redrew the run. The $N^{-1/2}$ reference is the [central limit theorem (CLT)](https://www.itl.nist.gov/div898/handbook/eda/section3/eda3661.htm) slope on a log-log plot."
    ]

--- a/examples/04_execution_interface_readouts.ipynb
+++ b/examples/04_execution_interface_readouts.ipynb
@@ -13,8 +13,8 @@
    "id": "22aca730",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We show Torx readouts in practice with a circuit with two <a href=\"https://doi.org/10.1063/1.5055860\">probabilistic bits (pbits)</a>, turning raw samples into histograms, expectations, and Monte Carlo error bars using ordinary array reductions. Both readouts converge at the expected $1/\\sqrt{N}$ rate.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We build a Torx circuit with two <a href=\"https://doi.org/10.1063/1.5055860\">probabilistic bits (pbits)</a> and turn its raw samples into histograms, expectations, and Monte Carlo error bars, all with ordinary array reductions. Both readouts converge at the expected $1/\\sqrt{N}$ rate.</p>\n",
     "</div>"
    ]
   },
@@ -29,14 +29,14 @@
     "\n",
     "The code uses Torx, JAX, NumPy, and Matplotlib. It assumes basic familiarity with probability distributions and expectations.\n",
     "\n",
-    "The `samples` array is the full stochastic output of `BranchingSimulator.sample`: a `(num_samples, num_pbits)` integer array. Histograms, sample means, and confidence summaries are standard NumPy reductions over the rows of `samples`.\n",
-    "\n",
     "By the end, you'll be able to:\n",
     "\n",
     "- build a two-pbit readout circuit,\n",
     "- compare an exact `StateVectorSimulator` density with reductions of `samples`,\n",
     "- plot histogram concentration toward the exact density, and\n",
     "- estimate the Monte Carlo rate $1/\\sqrt{N}$ from a block analysis.\n",
+    "\n",
+    "Every one of those readouts comes out of a single object, because `BranchingSimulator.sample` hands back the full stochastic output as a `(num_samples, num_pbits)` integer array. Histograms, sample means, and confidence summaries are then standard NumPy reductions over the rows of `samples`.\n",
     "\n",
     "We first build the circuit and compute the exact reference. Then we sample the circuit, compare two readout paths, and measure how the sampling error shrinks with $N$.\n",
     "\n"
@@ -163,7 +163,7 @@
    "id": "b4a2f1a7",
    "metadata": {},
    "source": [
-    "The next cell defines `empirical_two_pbit_density`, which reduces a batch of samples to a four-state density."
+    "The histogram readout and the convergence panels later on need the same reduction, so we write it once: the next cell defines `empirical_two_pbit_density`, which reduces a batch of samples to a four-state density."
    ]
   },
   {
@@ -213,7 +213,7 @@
     "\n",
     "If $f(s) = s_i$, the estimator gives the per-pbit expectation returned by `expval_all` (introduced below).\n",
     "\n",
-    "Both estimators concentrate at the Monte Carlo rate. The [**total-variation distance**](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures) between the empirical and exact densities scales as $\\mathrm{TV}(\\hat\\rho_N, \\rho) = O(N^{-1/2})$. A two-pbit circuit keeps the exact $\\rho$ cheap to enumerate, so we can compare every estimate with a ground-truth reference."
+    "Both estimators concentrate at the Monte Carlo rate. Saying so needs a single number for how far a sampled density sits from the exact one, and the [**total-variation distance**](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures) supplies it: half the absolute gap in probability, summed over the basis states. Between the empirical and exact densities it scales as $\\mathrm{TV}(\\hat\\rho_N, \\rho) = O(N^{-1/2})$. A two-pbit circuit keeps the exact $\\rho$ cheap to enumerate, so we can compare every estimate with a ground-truth reference."
    ]
   },
   {
@@ -372,7 +372,7 @@
    "id": "b6cee0f6",
    "metadata": {},
    "source": [
-    "Sampling returns raw terminal bitstrings without computing statistics. For example, one call to `BranchingSimulator.sample` draws 5,000 samples and returns a `(num_samples, num_pbits)` integer array."
+    "Sampling hands back raw material rather than finished statistics, which is what keeps every readout in this notebook explicit. One call to `BranchingSimulator.sample` draws 5,000 terminal bitstrings and returns them as a `(num_samples, num_pbits)` integer array."
    ]
   },
   {
@@ -426,11 +426,11 @@
    "source": [
     "## Histogram and expectation\n",
     "\n",
-    "Both readouts are NumPy reductions of the `samples` array.\n",
+    "Both readouts come out of the same array, because each one is an ordinary NumPy reduction of `samples`.\n",
     "\n",
-    "The histogram encodes each row as a basis-state index, counts with `np.bincount`, and divides by $N$. The per-pbit expectation is `samples.mean(axis=0)`.\n",
+    "For the density we encode each row as a basis-state index, count the indices with `np.bincount`, and divide by $N$. The per-pbit expectation is simpler still, since averaging the columns with `samples.mean(axis=0)` already gives $\\langle s_i \\rangle$.\n",
     "\n",
-    "Torx also exposes that second statistic directly as `BranchingSimulator.expval_all`, which draws a fresh sample internally and returns the mean. At $N = 5{,}000$, both estimators land within `atol = 0.04` of the `StateVectorSimulator` reference."
+    "Torx also exposes that second statistic directly as `BranchingSimulator.expval_all`, which draws a fresh sample internally and returns the mean. At $N = 5{,}000$ both estimators agree with the `StateVectorSimulator` reference to within `atol = 0.04`, the tolerance the next cell asserts."
    ]
   },
   {
@@ -526,7 +526,7 @@
    "id": "f248d585",
    "metadata": {},
    "source": [
-    "The empirical-density bars track `exact_density`. The independent `expval_all` cross lands close to both the sample-mean and exact-expectation bars, agreeing within Monte Carlo error even though it comes from an independent `SEED + 1` draw. The `sample_mean` reduction and `expval_all` are two routes to the same expectation.\n"
+    "The empirical-density bars track `exact_density`, and the `expval_all` cross sits against both the sample-mean and exact-expectation bars even though it comes from a separate `SEED + 1` draw. That is the observation that matters: the `sample_mean` reduction and `expval_all` are two routes to the same expectation, and here they agree within Monte Carlo error.\n"
    ]
   },
   {
@@ -536,13 +536,13 @@
    "source": [
     "## Histogram concentration\n",
     "\n",
-    "We draw the histogram at $N \\in \\{100, 500, 2000, 5000\\}$.\n",
+    "Concentration is easier to see than to assert, so we redraw the histogram at $N \\in \\{100, 500, 2000, 5000\\}$ and let the panels show how the estimate sharpens.\n",
     "\n",
-    "The $N = 100$ panel is visibly jagged. By $N = 5000$, the bars sit close to the exact density. Each panel reports the total-variation distance to `exact_density`, averaged over 16 non-overlapping blocks:\n",
+    "Each panel also reports the total-variation distance to `exact_density`, averaged over 16 non-overlapping blocks:\n",
     "\n",
     "$$\\overline{\\mathrm{TV}}(\\hat\\rho, \\rho) = \\underbrace{\\frac{1}{16} \\sum_{k=1}^{16}}_{\\vphantom{\\big|}\\text{block average}} \\underbrace{\\tfrac{1}{2} \\sum_{s} |\\hat\\rho_k(s) - \\rho(s)|}_{\\vphantom{\\big|}\\text{TV per block}}.$$\n",
     "\n",
-    "The inner sum is the total-variation distance of one block $\\hat\\rho_k$ to the exact density $\\rho$, and the outer factor averages it over the 16 blocks. That distance falls like $1/\\sqrt{N}$, the convergence measured in the next figure."
+    "The inner sum is the total-variation distance of one block $\\hat\\rho_k$ to the exact density $\\rho$, and the outer factor averages it over the 16 blocks, because a single block is itself noisy at small $N$. That averaged distance falls like $1/\\sqrt{N}$, the convergence measured in the next figure."
    ]
   },
   {
@@ -591,7 +591,7 @@
    "id": "b167978b",
    "metadata": {},
    "source": [
-    "For each $N$ we form the empirical density and the block-averaged total-variation distance from this one run (the blocks at a given $N$ are disjoint, but the per-$N$ estimators reuse prefixes of the same run and are correlated across $N$)."
+    "For each $N$ we form the empirical density and the block-averaged total-variation distance from this one run, which means the estimates at different $N$ share samples. The block analysis below spells out that correlation and what it does and does not license."
    ]
   },
   {
@@ -692,9 +692,9 @@
    "source": [
     "## Sample-mean concentration\n",
     "\n",
-    "Block analysis estimates how the `sample_mean` error scales with sample size.\n",
+    "We now measure how the `sample_mean` error shrinks as the sample size grows, using a block analysis.\n",
     "\n",
-    "A single estimate does not determine the error scaling, so we split one long run into many block estimators. We apply the block analysis to pbit 1:\n",
+    "A single estimate cannot reveal a scaling law, because one number has no spread to read. So we cut one long run into blocks and treat each block as its own estimate of the same quantity, which turns the spread across blocks into a measurement of the error at that block size. We apply the block analysis to pbit 1:\n",
     "\n",
     "1. draw one long $32{,}000$-sample run,\n",
     "2. split it into non-overlapping blocks of size $N \\in \\{25, 50, 100, 200, 500, 1000\\}$,\n",
@@ -702,7 +702,7 @@
     "\n",
     "The blocks for a single $N$ are disjoint, but every per-$N$ estimator reuses a prefix of the same long run, so estimators across $N$ share samples and are correlated. That correlation is acceptable for visualizing the slope.\n",
     "\n",
-    "With 32 blocks per $N$, the analysis reports the mean absolute error; the shaded band is the standard error of that mean across the 32 blocks. The $N^{-1/2}$ reference is the [central limit theorem (CLT)](https://www.itl.nist.gov/div898/handbook/eda/section3/eda3661.htm) slope on a log-log plot."
+    "With 32 blocks per $N$ we report the mean absolute error against the exact pbit-1 expectation. The shaded band is the **Monte Carlo standard error** of that mean across the 32 blocks, meaning how far the 32-block average would typically move if we redrew the run. The $N^{-1/2}$ reference is the [central limit theorem (CLT)](https://www.itl.nist.gov/div898/handbook/eda/section3/eda3661.htm) slope on a log-log plot."
    ]
   },
   {
@@ -848,7 +848,7 @@
     "This tutorial turned a Torx circuit's `samples` into densities, expectations, and a measured convergence rate.\n",
     "\n",
     "- `BranchingSimulator.sample` returns a `(num_samples, num_pbits)` integer array, and that array is the full stochastic output.\n",
-    "- `np.bincount` over the bitstrings approximates the exact `StateVectorSimulator` density to within sampling error (`atol = 0.04` at $N = 5000$). Separately, `samples.mean(axis=0)` and the independent `expval_all` draw are two estimators of the same expectation, both landing within that tolerance of the exact value.\n",
+    "- `np.bincount` over the bitstrings approximates the exact `StateVectorSimulator` density to within sampling error (`atol = 0.04` at $N = 5000$). Separately, `samples.mean(axis=0)` and the independent `expval_all` draw are two estimators of the same expectation, and both agree with the exact value to within that same tolerance.\n",
     "- The sampling error shrinks as $1/\\sqrt{N}$: a log-log fit of the block analysis on pbit 1 gives a slope near the $N^{-1/2}$ reference, consistent with the Monte Carlo rate.\n",
     "- The terminal bitstring readouts shown here are ordinary NumPy reductions on the returned `samples` array. Differentiable or `jit`-transformable readouts use `jnp` or the Torx expectation APIs instead.\n",
     "\n",

--- a/examples/05_chemical_reaction_networks.ipynb
+++ b/examples/05_chemical_reaction_networks.ipynb
@@ -29,9 +29,9 @@
     "\n",
     "We run two networks with deliberately different long-run behaviour. The irreversible water reaction $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ fires in a single direction until a reactant is exhausted, so its counts run toward completion. The reversible binding $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ runs forward and backward at once, so its counts settle into a mass-action equilibrium instead.\n",
     "\n",
-    "Neither network fits a single hopping excitation directly, because a reaction like $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ has two features such an excitation cannot express. It consumes and produces several molecules at once (stoichiometry), and its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$).\n",
+    "Neither network fits a single hopping excitation directly, because a reaction like $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ has two features such an excitation can't express. It consumes and produces several molecules at once (stoichiometry), and its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$).\n",
     "\n",
-    "The key step is therefore to enumerate the reachable **count configurations** and treat each one as a state in its own right. Each reaction event then moves the whole system from one configuration to another, and the nonlinear propensity becomes that edge's rate. What is left is a single token, one occupied bit hopping between one-hot configurations, walking on a directed configuration graph, so one `PJUMP` per edge applies, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Sequentially applying those edge kernels approximates the global CTMC evolution.\n",
+    "The key step is therefore to enumerate the reachable **count configurations** and treat each one as a state in its own right. Each reaction event then moves the whole system from one configuration to another, and the nonlinear propensity becomes that edge's rate. What's left is a single token, one occupied bit hopping between one-hot configurations, walking on a directed configuration graph, so one `PJUMP` per edge applies, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Sequentially applying those edge kernels approximates the global CTMC evolution.\n",
     "\n",
     "Two references keep that approximation honest. The matrix exponential $e^{Q t}$ solves the configuration chain exactly, and a Gillespie simulation, an exact event-driven simulation that samples which reaction fires next and when, samples the raw molecule counts without ever seeing the configuration graph.\n",
     "\n",
@@ -645,7 +645,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "If the configuration-graph encoding is faithful, two things have to hold: every edge must respect the chemistry it stands for, and every method that solves the same chain must agree at the sampled times. The next cell checks both.\n",
+    "If the configuration-graph encoding is faithful, two things have to hold: every edge must respect the chemistry it stands for, and every method that solves the same chain must agree at the sampled times, and the next cell tests both claims in the three passes described below.\n",
     "\n",
     "The first check tests the edges. We recompute the H and O atom totals at both endpoints of every reaction edge and require them to be equal, so a stoichiometry mistake in the enumeration fails the assertion outright instead of hiding as a small numerical drift.\n",
     "\n",
@@ -700,7 +700,7 @@
    "source": [
     "## A reversible reaction: binding equilibrium\n",
     "\n",
-    "The second network puts the same encoding to work on dynamics that never stop. The water reaction above is irreversible, firing in one direction until a reactant runs out, so its molecule counts run to completion. Binding behaves differently. The reaction $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ has a forward step $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ with propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$ and a reverse step $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ with propensity $k_r\\,n_{\\mathrm{C}}$, and because both directions stay active the network never absorbs. It relaxes instead to a stochastic mass-action equilibrium, meaning a steady distribution in which the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except that the configuration graph now carries edges in both directions.\n"
+    "The second network puts the same encoding to work on dynamics that never stop. The water reaction above is irreversible, firing in one direction until a reactant runs out, so its molecule counts run to completion. Binding behaves differently, and the reaction $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ shows why, because it has a forward step $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ with propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$ and a reverse step $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ with propensity $k_r\\,n_{\\mathrm{C}}$, and because both directions stay active the network never absorbs. It relaxes instead to a stochastic mass-action equilibrium, meaning a steady distribution in which the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except that the configuration graph now carries edges in both directions.\n"
    ]
   },
   {
@@ -1051,7 +1051,7 @@
    "id": "b610d9cd",
    "metadata": {},
    "source": [
-    "The counts do level off, well short of completion, which is the visible difference from the irreversible water reaction and the sign that this network reaches equilibrium instead of absorbing. $\\mathrm{A}$ and $\\mathrm{B}$ start equal and stay equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ along every reachable configuration, so they trace one curve. Their means settle near $2.19$ while the mean of $\\mathrm{C}$ settles near $1.81$. The residual panel again makes the small Torx and Gillespie deviations from the exact curves visible. One caution about reading those plateaus: the relation that actually holds at stochastic equilibrium is the ensemble identity $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$, which is not the same as substituting the mean counts into the rate law.\n"
+    "The counts do level off, well short of completion, which is the visible difference from the irreversible water reaction and the sign that this network reaches equilibrium instead of absorbing. $\\mathrm{A}$ and $\\mathrm{B}$ start equal and stay equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ along every reachable configuration, so they trace one curve. Their means settle near $2.19$ while the mean of $\\mathrm{C}$ settles near $1.81$. The residual panel again makes the small Torx and Gillespie deviations from the exact curves visible. One caution about reading those plateaus: the relation that actually holds at stochastic equilibrium is the ensemble identity $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$, which isn't the same as substituting the mean counts into the rate law.\n"
    ]
   },
   {
@@ -1122,7 +1122,7 @@
    "source": [
     "## The cost: configuration count\n",
     "\n",
-    "Both networks above were small. What decides whether this encoding scales is how fast the configuration count grows when they are not, because Torx spends one pbit per reachable configuration and the circuit width follows that count rather than the number of species. For the one-way water family measured below there is a single reaction extent to vary, so the count grows linearly. For the particular water-plus-ammonia family there are two independently variable extents, so it grows quadratically. Other networks scale differently, since conservation laws and feasibility constraints decide how much of the count lattice is reachable at all.\n"
+    "Both networks above were small. What decides whether this encoding scales is how fast the configuration count grows when they aren't, because Torx spends one pbit per reachable configuration and the circuit width follows that count rather than the number of species. For the one-way water family measured below there is a single reaction extent to vary, so the count grows linearly. For the particular water-plus-ammonia family there are two independently variable extents, so it grows quadratically. Other networks scale differently, since conservation laws and feasibility constraints decide how much of the count lattice is reachable at all.\n"
    ]
   },
   {

--- a/examples/05_chemical_reaction_networks.ipynb
+++ b/examples/05_chemical_reaction_networks.ipynb
@@ -13,8 +13,8 @@
    "id": "96329298",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We map molecule counts onto a single-token CTMC to run two mass-action reactions in Torx. Irreversible combustion runs toward completion and reversible binding relaxes to mass-action equilibrium. We compare Torx's split-step approximation with the exact matrix exponential and a Gillespie simulation.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We map molecule counts onto a continuous-time Markov chain carrying a single token, one occupied bit hopping between count configurations, which lets us run two mass-action reactions in Torx. Irreversible combustion runs toward completion, while reversible binding relaxes to mass-action equilibrium. In both cases we check Torx's split-step approximation against two independent references: the exact matrix exponential and an event-driven Gillespie simulation.</p>\n",
     "</div>\n"
    ]
   },
@@ -23,11 +23,17 @@
    "id": "06a4e27d",
    "metadata": {},
    "source": [
-    "In this tutorial, we run two mass-action reaction networks in Torx by mapping their count dynamics onto a continuous-time Markov chain carrying a single token (one occupied bit hopping between one-hot configurations). The irreversible water reaction $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ fires in a single direction until a reactant is exhausted, so its counts run toward completion. The reversible binding $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ runs forward and backward at once, so its counts settle into a mass-action equilibrium.\n",
+    "In this tutorial we run two mass-action reaction networks in Torx and check the result against two independent references.\n",
     "\n",
-    "A chemical reaction network is a continuous-time Markov chain on molecule counts. A reaction like $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ has two features a single hopping excitation cannot express: it consumes and produces several molecules at once (stoichiometry), and its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$).\n",
+    "A chemical reaction network is a continuous-time Markov chain on molecule counts. The state records how many molecules of each species are present, and each reaction event moves that state by a fixed amount. The rate attached to a reaction is its **propensity**, the probability per unit time that this reaction is the next one to fire, and under mass action the propensity counts how many distinct groups of reactant molecules are currently available to react.\n",
     "\n",
-    "The key step is to enumerate the reachable **count configurations**. Each reaction event moves the whole system from one configuration to another, and the nonlinear propensity becomes that edge's rate. The network is then a single token walking on a directed configuration graph, so one `PJUMP` per edge applies, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Sequentially applying those edge kernels approximates the global CTMC evolution.\n",
+    "We run two networks with deliberately different long-run behaviour. The irreversible water reaction $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ fires in a single direction until a reactant is exhausted, so its counts run toward completion. The reversible binding $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ runs forward and backward at once, so its counts settle into a mass-action equilibrium instead.\n",
+    "\n",
+    "Neither network fits a single hopping excitation directly, because a reaction like $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ has two features such an excitation cannot express. It consumes and produces several molecules at once (stoichiometry), and its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$).\n",
+    "\n",
+    "The key step is therefore to enumerate the reachable **count configurations** and treat each one as a state in its own right. Each reaction event then moves the whole system from one configuration to another, and the nonlinear propensity becomes that edge's rate. What is left is a single token, one occupied bit hopping between one-hot configurations, walking on a directed configuration graph, so one `PJUMP` per edge applies, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Sequentially applying those edge kernels approximates the global CTMC evolution.\n",
+    "\n",
+    "Two references keep that approximation honest. The matrix exponential $e^{Q t}$ solves the configuration chain exactly, and a Gillespie simulation, an exact event-driven simulation that samples which reaction fires next and when, samples the raw molecule counts without ever seeing the configuration graph.\n",
     "\n",
     "We assume basic familiarity with continuous-time Markov chains and JAX. The code uses Torx, JAX, NumPy, and SciPy. By the end, you'll be able to:\n",
     "\n",
@@ -43,7 +49,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "We configure the helper path, the shared plotting style, and the `savefig` utility used throughout the notebook.\n",
+    "We configure the helper path, the shared plotting style, and the `savefig` utility here so that the later cells can stay focused on the reaction networks themselves.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx builds and samples the sequential `PJUMP` circuits.</li><li>Notebook code builds configuration graphs, references, and checks.</li><li>Reaction plots live in <code>examples/helpers/_nb05_crn.py</code>.</li></ul></details>\n"
    ]
@@ -181,7 +187,9 @@
    "id": "f6c3c190",
    "metadata": {},
    "source": [
-    "For one isolated CTMC edge with rate $r$, the transition probability over `dt` is exactly $1 - e^{-r\\,dt}$. The `pjump_prob` function below computes that probability, and `PJUMP` reads it through a logit. Applying all edge kernels sequentially is a [Lie-Trotter operator splitting](https://doi.org/10.1090/S0002-9939-1959-0108732-6) of the global generator, so the product approximates $e^{Q\\,dt}$ and converges as `dt` decreases.\n"
+    "Before any chemistry appears, we need the one number that turns a reaction rate into a Torx gate parameter. For one isolated CTMC edge with rate $r$, the transition probability over a slice of length `dt` is exactly $1 - e^{-r\\,dt}$, so the `pjump_prob` function below computes that probability and `PJUMP` reads it through a logit.\n",
+    "\n",
+    "Each edge kernel is exact on its own, but neighbouring edges share configurations, which means applying them one after another is a [Lie-Trotter operator splitting](https://doi.org/10.1090/S0002-9939-1959-0108732-6) of the global generator: we replace one joint update with an ordered product of single-edge updates. The product therefore approximates $e^{Q\\,dt}$ rather than reproducing it, and the approximation improves as `dt` decreases.\n"
    ]
   },
   {
@@ -210,7 +218,7 @@
    "source": [
     "## The reaction and its configuration space\n",
     "\n",
-    "Start from four $\\mathrm{H_2}$ and two $\\mathrm{O_2}$. The single reaction can fire until either reactant runs out, so the reachable configurations form a short chain. The mass-action propensity drops sharply as $\\mathrm{H_2}$ is consumed."
+    "We start with the irreversible water reaction, because its configuration space is small enough to print in full and read. Starting from four $\\mathrm{H_2}$ and two $\\mathrm{O_2}$, the single reaction can fire until either reactant runs out, so the reachable configurations form a short chain rather than a branching graph. Along that chain the mass-action propensity drops sharply as $\\mathrm{H_2}$ is consumed, and carrying that drop faithfully is the whole point of the encoding.\n"
    ]
   },
   {
@@ -243,7 +251,7 @@
    "id": "56405dbd",
    "metadata": {},
    "source": [
-    "Three small functions describe the reaction: the mass-action propensity of a configuration, the state update when the reaction fires, and a search that collects every reachable configuration."
+    "Three small functions supply everything the encoding needs: the mass-action propensity of a configuration, the state update when the reaction fires, and a search that collects every reachable configuration.\n"
    ]
   },
   {
@@ -364,8 +372,8 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">Mass-action rates</span>\n",
-    "<p>From the initial configuration $(4, 2, 0)$ the reaction fires at $c\\,\\binom{4}{2}\\binom{2}{1} = 1.2$; after one firing, from $(2, 1, 2)$, the propensity drops to $c\\,\\binom{2}{2}\\binom{1}{1} = 0.1$. The twelve-fold drop is the nonlinearity that separates a reaction network from a plain random walk.</p>\n",
-    "</div>"
+    "<p>From the initial configuration $(4, 2, 0)$ the reaction fires at $c\\,\\binom{4}{2}\\binom{2}{1} = 1.2$. After a single firing, from $(2, 1, 2)$, the propensity drops to $c\\,\\binom{2}{2}\\binom{1}{1} = 0.1$. That twelve-fold drop across one event is the nonlinearity that separates a reaction network from a plain random walk, where every edge rate is fixed in advance.</p>\n",
+    "</div>\n"
    ]
   },
   {
@@ -375,7 +383,7 @@
    "source": [
     "## Dynamics: Torx against two references\n",
     "\n",
-    "We compare three trajectories of the expected molecule counts: the exact $e^{Qt}p_0$ on the configuration generator, a stochastic simulation on the raw counts using [Gillespie (1977)](https://doi.org/10.1021/j100540a008), and the Torx split-step sample mean from snapshot circuits.\n",
+    "With the configuration graph in hand, we can ask whether the encoding reproduces the reaction's dynamics. To answer that we compute three trajectories of the expected molecule counts, each a different way. The exact $e^{Qt}p_0$ on the configuration generator is what the encoding has to match, since it solves the same chain with no splitting and no sampling. A [Gillespie (1977)](https://doi.org/10.1021/j100540a008) simulation, an exact event-driven simulation that samples which reaction fires next and when, runs on the raw counts and never touches the configuration graph, so it serves as an independent reference sampler that would expose a mistake in the enumeration itself. The Torx split-step sample mean from snapshot circuits is the quantity under test, and it carries both split-step error and sampling error.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Gillespie stochastic simulation algorithm (SSA)</summary><p>The <a href=\"https://doi.org/10.1021/j100540a008\">Gillespie SSA</a> represents reactions as competing stochastic clocks. At each step, draw an exponential waiting time using the total propensity, choose a reaction in proportion to its propensity, update the counts, and repeat.</p></details>\n"
    ]
@@ -473,7 +481,7 @@
    "id": "7a8cc4d2",
    "metadata": {},
    "source": [
-    "Evaluate both references on a shared time grid, starting with all the probability on the initial configuration."
+    "We evaluate both references on a shared time grid, starting with all the probability on the initial configuration so that every method begins from the same state. The same cell also refines the split-step calculation once, halving `dt` to see whether the deterministic residual shrinks with it.\n"
    ]
   },
   {
@@ -523,7 +531,7 @@
    "id": "457b12cb",
    "metadata": {},
    "source": [
-    "Each slice applies one `PJUMP` per configuration edge, with parameter $\\mathrm{logit}(1 - e^{-r\\,dt})$ for rate $r$. Their ordered product is the split-step approximation, not the exact global CTMC kernel. The refinement check above shows the deterministic residual decreasing when `dt` is halved. Sampling circuits at selected repetition counts gives the Torx count estimates below.\n"
+    "Now we build the Torx circuit itself. Each slice applies one `PJUMP` per configuration edge, with parameter $\\mathrm{logit}(1 - e^{-r\\,dt})$ for rate $r$, and because those kernels are applied in sequence rather than jointly, their ordered product is the split-step approximation and not the exact global CTMC kernel. The refinement check just printed is what tells us the resulting gap is a timestep artifact rather than an error in the encoding: halving `dt` from $0.05$ to $0.025$ cut the deterministic residual at $T = 12$ from $0.000830$ to $0.000413$. Sampling these circuits at selected repetition counts gives the Torx count estimates below.\n"
    ]
   },
   {
@@ -572,7 +580,7 @@
    "id": "39155d5e",
    "metadata": {},
    "source": [
-    "Plot the expected counts from all three methods together."
+    "We plot the expected counts from all three methods together, with a residual panel underneath, because the disagreements are far too small to see in the trajectories alone.\n"
    ]
   },
   {
@@ -627,7 +635,7 @@
    "id": "4b21c35e",
    "metadata": {},
    "source": [
-    "The count trajectories nearly overlap. The residual panel exposes the smaller disagreement: dashed Gillespie means fluctuate around the exact solution, while shaped Torx markers include sampling error and split-step error at each snapshot. $\\mathrm{H_2}$ and $\\mathrm{O_2}$ are consumed as $\\mathrm{H_2O}$ builds up, and the falling propensity slows the reaction near absorption.\n"
+    "All three count trajectories sit on top of one another at this scale, so the residual panel is where the differences become legible. There the dashed Gillespie means fluctuate around the exact solution because they carry sampling error only, while the shaped Torx markers carry both sampling error and split-step error at each snapshot. The chemistry is visible in the upper panel: $\\mathrm{H_2}$ and $\\mathrm{O_2}$ are consumed as $\\mathrm{H_2O}$ builds up, and the falling propensity slows the reaction as it approaches absorption.\n"
    ]
   },
   {
@@ -637,7 +645,13 @@
    "source": [
     "## Verification\n",
     "\n",
-    "Atoms balance across every reaction edge. The printed residuals quantify Torx and Gillespie disagreement with the exact matrix exponential at the sampled times.\n"
+    "If the configuration-graph encoding is faithful, two things have to hold: every edge must respect the chemistry it stands for, and every method that solves the same chain must agree at the sampled times. The next cell checks both.\n",
+    "\n",
+    "The first check tests the edges. We recompute the H and O atom totals at both endpoints of every reaction edge and require them to be equal, so a stoichiometry mistake in the enumeration fails the assertion outright instead of hiding as a small numerical drift.\n",
+    "\n",
+    "The second check tests Torx. We compare the Torx snapshot counts against the exact matrix exponential at the same times and require the largest absolute deviation to stay under $0.05$, which bounds the combined split-step and sampling error.\n",
+    "\n",
+    "The third check tests the reference sampler the same way. We compare the Gillespie means against the exact matrix exponential under the same $0.05$ bound, so agreement here confirms that the raw-count simulation and the configuration-graph solution are describing one reaction rather than two.\n"
    ]
   },
   {
@@ -686,7 +700,7 @@
    "source": [
     "## A reversible reaction: binding equilibrium\n",
     "\n",
-    "The water reaction above is irreversible: it fires in one direction until a reactant runs out, so the molecule counts run to completion. Binding behaves differently. The reaction $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ has a forward step $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ with propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$ and a reverse step $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ with propensity $k_r\\,n_{\\mathrm{C}}$. With both directions active the network never absorbs, and it relaxes to a stochastic mass-action equilibrium where the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except the configuration graph now carries edges in both directions.\n"
+    "The second network puts the same encoding to work on dynamics that never stop. The water reaction above is irreversible, firing in one direction until a reactant runs out, so its molecule counts run to completion. Binding behaves differently. The reaction $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ has a forward step $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ with propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$ and a reverse step $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ with propensity $k_r\\,n_{\\mathrm{C}}$, and because both directions stay active the network never absorbs. It relaxes instead to a stochastic mass-action equilibrium, meaning a steady distribution in which the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except that the configuration graph now carries edges in both directions.\n"
    ]
   },
   {
@@ -694,7 +708,7 @@
    "id": "9be433ef",
    "metadata": {},
    "source": [
-    "Two reactions now, forward and reverse, each with its own rate constant. The propensity and update helpers take the reaction as an argument, generalizing the single-reaction versions above."
+    "We define two reactions now, forward and reverse, each with its own rate constant, so the propensity and update helpers take the reaction as an argument instead of reading a single global one. That generalizes the single-reaction versions from the water network without changing what they compute.\n"
    ]
   },
   {
@@ -808,7 +822,7 @@
    "id": "88f22d45",
    "metadata": {},
    "source": [
-    "Enumerating the reachable configurations now follows both directions, so the configuration graph carries forward and reverse edges."
+    "Enumeration follows both directions from here, which means the search reaches each configuration from either side and the configuration graph ends up carrying a forward and a reverse edge between every adjacent pair.\n"
    ]
   },
   {
@@ -858,7 +872,7 @@
    "id": "944dcee3",
    "metadata": {},
    "source": [
-    "The Gillespie step now chooses which reaction fires, with probability proportional to each reaction's propensity."
+    "Because two reactions now compete for the next event, the Gillespie step has to choose which one fires, and it does so with probability proportional to each reaction's propensity.\n"
    ]
   },
   {
@@ -901,7 +915,7 @@
    "id": "2cc598eb",
    "metadata": {},
    "source": [
-    "Run the exact CTMC and the Gillespie average for the binding network."
+    "We run the exact CTMC and the Gillespie average for the binding network on its own longer time grid, reusing `ctmc_reference` unchanged so that only the network and the horizon differ.\n"
    ]
   },
   {
@@ -934,7 +948,7 @@
    "id": "a1cd85db",
    "metadata": {},
    "source": [
-    "We build the same sequential split-step circuit for the binding graph, now including the reverse edges.\n"
+    "We build the same sequential split-step circuit for the binding graph, now including the reverse edges, so each slice applies one `PJUMP` per directed edge and the token can hop either way.\n"
    ]
   },
   {
@@ -983,7 +997,7 @@
    "id": "83b5138b",
    "metadata": {},
    "source": [
-    "Plot the binding trajectories from all three methods."
+    "We plot the binding trajectories from all three methods, and the thing to watch for is whether the counts level off rather than running to completion.\n"
    ]
   },
   {
@@ -1037,7 +1051,7 @@
    "id": "b610d9cd",
    "metadata": {},
    "source": [
-    "The residual panel makes the small Torx and Gillespie deviations from the exact curves visible. Unlike the irreversible water reaction, the counts do not run to completion. $\\mathrm{A}$ and $\\mathrm{B}$ start equal and stay equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ along every reachable configuration, so they trace one curve. Their means settle near $2.19$ while the mean of $\\mathrm{C}$ settles near $1.81$. At stochastic equilibrium the correct ensemble identity is $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$.\n"
+    "The counts do level off, well short of completion, which is the visible difference from the irreversible water reaction and the sign that this network reaches equilibrium instead of absorbing. $\\mathrm{A}$ and $\\mathrm{B}$ start equal and stay equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ along every reachable configuration, so they trace one curve. Their means settle near $2.19$ while the mean of $\\mathrm{C}$ settles near $1.81$. The residual panel again makes the small Torx and Gillespie deviations from the exact curves visible. One caution about reading those plateaus: the relation that actually holds at stochastic equilibrium is the ensemble identity $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$, which is not the same as substituting the mean counts into the rate law.\n"
    ]
   },
   {
@@ -1045,7 +1059,13 @@
    "id": "975661b4",
    "metadata": {},
    "source": [
-    "The conserved quantities are $n_{\\mathrm{A}} + n_{\\mathrm{C}}$ and $n_{\\mathrm{B}} + n_{\\mathrm{C}}$. The checks below quantify conservation, method residuals, and the equilibrium flux balance.\n"
+    "The same faithfulness question applies to the binding network, with one addition, because a reversible network has something to conserve and something to balance.\n",
+    "\n",
+    "Binding leaves $n_{\\mathrm{A}} + n_{\\mathrm{C}}$ and $n_{\\mathrm{B}} + n_{\\mathrm{C}}$ unchanged, so we recompute both totals at the endpoints of every edge and require them to match, which is the analogue of the atom balance from the water network.\n",
+    "\n",
+    "We then repeat the two method comparisons, requiring the largest deviation of the Torx snapshot counts and of the Gillespie means from the exact matrix exponential to stay below $0.05$ at the sampled times.\n",
+    "\n",
+    "Finally we test equilibrium directly, evaluating $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}]$ and $k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$ under the exact distribution at the final time and requiring their difference to fall below $10^{-6}$, so that a pass confirms the plateau in the plot is a genuine flux balance rather than a slow transient.\n"
    ]
   },
   {
@@ -1102,7 +1122,7 @@
    "source": [
     "## The cost: configuration count\n",
     "\n",
-    "One pbit per reachable configuration makes the encoding grow with the molecule budget. For the one-way water family below, one reaction extent gives linear growth. For the particular water-plus-ammonia family, two independently variable extents give quadratic growth. Other networks can have different counts because conservation laws and feasibility constraints restrict the reachable set.\n"
+    "Both networks above were small. What decides whether this encoding scales is how fast the configuration count grows when they are not, because Torx spends one pbit per reachable configuration and the circuit width follows that count rather than the number of species. For the one-way water family measured below there is a single reaction extent to vary, so the count grows linearly. For the particular water-plus-ammonia family there are two independently variable extents, so it grows quadratically. Other networks scale differently, since conservation laws and feasibility constraints decide how much of the count lattice is reachable at all.\n"
    ]
   },
   {
@@ -1110,7 +1130,7 @@
    "id": "9f4c4280",
    "metadata": {},
    "source": [
-    "Count the reachable configurations as the molecule budget grows, first for the single water reaction, then for two reactions that share a species."
+    "We count the reachable configurations as the molecule budget grows, first for the single water reaction and then for two reactions that share a species, which is the comparison that separates one free extent from two.\n"
    ]
   },
   {
@@ -1192,7 +1212,7 @@
    "id": "3deb7273",
    "metadata": {},
    "source": [
-    "In this constructed family, coupling the second reaction through shared $\\mathrm{H_2}$ produces a square grid of reaction extents. At the largest budget the water reaction reaches 33 configurations, while this joint network reaches $33^2 = 1089$.\n"
+    "Coupling the second reaction through shared $\\mathrm{H_2}$ in this constructed family produces a square grid of reaction extents, which is why the two columns differ by a power rather than by a factor. At the largest budget the water reaction reaches 33 configurations, while this joint network reaches $33^2 = 1089$.\n"
    ]
   },
   {
@@ -1202,9 +1222,9 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "The configuration-space mapping turns nonlinear mass-action propensities into rates on a single-token graph. Torx applies the per-edge `PJUMP` kernels as an operator-splitting approximation, while $e^{Qt}$ supplies the exact global CTMC reference. The residual panels expose both that split-step and sampling disagreement and the Gillespie sampling disagreement.\n",
+    "We turned two nonlinear mass-action networks into single-token graph walks by enumerating their reachable configurations, which moves the nonlinearity out of the dynamics and into the edge rates. Torx then applies the per-edge `PJUMP` kernels as an operator-splitting approximation, while $e^{Qt}$ on the same generator supplies the exact global CTMC reference, so the residual panels separate two distinct disagreements: the combined split-step and sampling error carried by the Torx markers, and the sampling error carried by the Gillespie means.\n",
     "\n",
-    "The one-hot encoding cost is the reachable configuration count, which is linear for the one-reaction family and quadratic for the two-reaction family measured above. Richer encodings become preferable when a network's reachable set grows large. The linear, single-token corner of this construction is a directed [graph random walk](02_random_walks_on_graphs.ipynb) with one walker.\n",
+    "The price of the one-hot encoding is the reachable configuration count, which grew linearly for the one-reaction family and quadratically for the two-reaction family measured above. Richer encodings become preferable once a network's reachable set grows large. In the linear, single-token corner of this construction the circuit is a directed [graph random walk](02_random_walks_on_graphs.ipynb) with one walker.\n",
     "\n",
     "See also:\n",
     "\n",

--- a/examples/06_ising_sampling_contrastive_divergence.ipynb
+++ b/examples/06_ising_sampling_contrastive_divergence.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "Second, does a full ring sampler reproduce the Boltzmann law? We answer this twice over, with two samplers that are both local but local in different ways. One runs every single-site draw through Torx as a manual-zero `PNOT` update, which hands the gate an exact zero state instead of resetting it. The other stays bond-local: it asks Torx to generate one two-spin transition matrix per edge with `PISING`, then walks those matrices on the host. Because the 8-site ring is small enough to enumerate all $2^8 = 256$ states, we have an exact Boltzmann reference and the gap between the two samplers becomes a measurement rather than an argument.\n",
     "\n",
-    "That gap is where the interesting failure lives. A bond matrix carries its own bond energy and half of each endpoint's field, but it cannot see the live energy each endpoint shares with its neighbor outside the pair, so the resulting pair update is not conditioned on the rest of the ring. Composing eight such updates therefore need not obey [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution, the condition that every pair of configurations exchanges probability equally in both directions, which is what pins a sampler to its target. The moment comparison makes that bias visible.\n",
+    "That gap is where the interesting failure lives. A bond matrix carries its own bond energy and half of each endpoint's field, but it can't see the live energy each endpoint shares with its neighbor outside the pair, so the resulting pair update isn't conditioned on the rest of the ring. Composing eight such updates therefore need not obey [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution, the condition that every pair of configurations exchanges probability equally in both directions, which is what pins a sampler to its target, and the moment comparison later in the notebook is what makes that bias visible.\n",
     "\n",
     "Third, can we recover the parameters from data? We fit the couplings and fields with persistent contrastive divergence. That fit is host-only: it runs in notebook NumPy, and Torx's contribution to it is the earlier evidence that the same update rule samples correctly.\n",
     "\n",
@@ -508,7 +508,7 @@
    "id": "c5297316",
    "metadata": {},
    "source": [
-    "We now run the sampler itself: 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This is case 3 from the reset list above, the ring's manual zero. Every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`, and because it does not execute `PReset`, there is no finite-reset leakage to account for here.\n",
+    "We now run the sampler itself: 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This is case 3 from the reset list above, the ring's manual zero. Every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`, and because it doesn't execute `PReset`, there's no finite-reset leakage to account for here.\n",
     "\n",
     "Its claim-bearing core is:\n",
     "\n",
@@ -597,7 +597,7 @@
     "\n",
     "where $Q$ is the single-spin-flip generator of the bond energy $E(s_i, s_j) = -J s_i s_j - h_i s_i - h_j s_j$. Here $\\Delta t$ is `pising_dt` in the next cell.\n",
     "\n",
-    "We generate one matrix for each ring edge and split each site's field in half so its two incident bonds sum to $h_i$. The fields therefore add up correctly, but these two-spin matrices still omit the live energy contribution from the external neighbor of each endpoint. A block-Gibbs pair update would condition on those neighbors, and this bond matrix does not, so the composed host walk need not preserve the ring Boltzmann law, meaning the distribution the walk would leave unchanged once mixed is not guaranteed to be the one we want."
+    "We generate one matrix for each ring edge and split each site's field in half so its two incident bonds sum to $h_i$. The fields therefore add up correctly, but these two-spin matrices still omit the live energy contribution from the external neighbor of each endpoint. A block-Gibbs pair update would condition on those neighbors, and this bond matrix doesn't, so the composed host walk need not preserve the ring Boltzmann law, meaning the distribution the walk would leave unchanged once mixed isn't guaranteed to be the one we want."
    ]
   },
   {
@@ -701,7 +701,7 @@
    "id": "8b6fe159",
    "metadata": {},
    "source": [
-    "To sample from those matrices we call `pising_ring_samples` in `examples/helpers/_plots_sampling.py`. It is a NumPy loop that walks each Torx-generated transition matrix in turn and draws the next pair state, returning the 4000 chains we need for the moment and total-variation comparisons:"
+    "To sample from those matrices we call `pising_ring_samples` in `examples/helpers/_plots_sampling.py`. It's a NumPy loop that walks each Torx-generated transition matrix in turn and draws the next pair state, returning the 4000 chains we need for the moment and total-variation comparisons:"
    ]
   },
   {
@@ -813,7 +813,7 @@
    "id": "7ba820bd",
    "metadata": {},
    "source": [
-    "The smaller magnitudes are not a generic cost of local updates. Each bond matrix omits the current external-neighbor energy, so the pair transitions do not satisfy detailed balance for the full ring Boltzmann distribution. Chromatic Gibbs is also local, but its one-site conditional includes both live neighbors and preserves the target law."
+    "The smaller magnitudes come from a specific defect in these bond kernels rather than from locality itself. Each bond matrix omits the current external-neighbor energy, so the pair transitions don't satisfy detailed balance for the full ring Boltzmann distribution. Chromatic Gibbs is also local, but its one-site conditional includes both live neighbors and preserves the target law."
    ]
   },
   {

--- a/examples/06_ising_sampling_contrastive_divergence.ipynb
+++ b/examples/06_ising_sampling_contrastive_divergence.ipynb
@@ -13,8 +13,8 @@
    "id": "7dfdb21e",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We compare Torx chromatic Gibbs sampling with a host sampler that walks Torx-generated <code>PISING</code> matrices, then fit the ring with host-only persistent contrastive divergence. The comparison exposes the omitted-neighbor bias in the bond kernels, and the fit recovers every coupling and field to within 0.05.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We compare Torx chromatic Gibbs sampling with a host sampler that walks Torx-generated <code>PISING</code> matrices, one bond kernel per ring edge, where a bond kernel is a two-spin transition matrix carrying only the energy of its own edge. Because a bond kernel never sees the spin sitting just outside its edge, the comparison prices that omitted-neighbor bias: the host walk sits at total variation 0.4020 from the exact law against 0.0634 for chromatic Gibbs. We then fit the ring with persistent contrastive divergence that is host-only, meaning it runs in notebook NumPy from start to finish rather than through Torx, and it recovers every coupling and field to within 0.05.</p>\n",
     "</div>"
    ]
   },
@@ -25,11 +25,21 @@
    "source": [
     "In this tutorial, we study Ising sampling with Torx's single-site and bond-local kernels.\n",
     "\n",
-    "We validate a finite `PReset` + `PNOT` probe through `BranchingSimulator`, run the ring's manual-zero `PNOT` Gibbs updates through Torx, and compare them with a host sampler using Torx-generated `PISING` matrices. The parameter fit is host-only.\n",
+    "An [**Ising model**](https://www.scholarpedia.org/article/Ising_model) is a graph with a coupling on every edge and a field at every site. It defines the Boltzmann distribution $\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})}$ over all $2^N$ spin configurations, and that distribution is the target every sampler in this notebook is trying to reproduce.\n",
     "\n",
-    "An [**Ising model**](https://www.scholarpedia.org/article/Ising_model) is a graph with a coupling on every edge and a field at every site. It defines the Boltzmann distribution $\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})}$ over all $2^N$ spin configurations.\n",
+    "This is also a Boltzmann machine ([Ackley et al. 1985](#ref-ackley)): a network whose joint distribution is set by pairwise couplings and per-site biases. So the same object serves twice here, first as something to sample from and later as something to learn.\n",
     "\n",
-    "This is also a Boltzmann machine ([Ackley et al. 1985](#ref-ackley)): a network whose joint distribution is set by pairwise couplings and per-site biases.\n",
+    "Locality makes fast sampling possible. Each spin's conditional depends only on its graph neighbors, so a whole color class of conditionally independent sites can update at once. This parallel single-site sampler is **chromatic Gibbs sampling**.\n",
+    "\n",
+    "Three experiments follow, and each answers a different question.\n",
+    "\n",
+    "First, does one site behave like the ideal Gibbs conditional when we run it as a real circuit? We build a small probe from Torx's reset and conditional-flip operations, `PReset` and `PNOT`, run it on the `BranchingSimulator`, and check its sampled mean against a target probability. The reset strength is finite rather than infinite, so the probe tests a close approximation of the ideal update instead of the ideal update itself.\n",
+    "\n",
+    "Second, does a full ring sampler reproduce the Boltzmann law? We answer this twice over, with two samplers that are both local but local in different ways. One runs every single-site draw through Torx as a manual-zero `PNOT` update, which hands the gate an exact zero state instead of resetting it. The other stays bond-local: it asks Torx to generate one two-spin transition matrix per edge with `PISING`, then walks those matrices on the host. Because the 8-site ring is small enough to enumerate all $2^8 = 256$ states, we have an exact Boltzmann reference and the gap between the two samplers becomes a measurement rather than an argument.\n",
+    "\n",
+    "That gap is where the interesting failure lives. A bond matrix carries its own bond energy and half of each endpoint's field, but it cannot see the live energy each endpoint shares with its neighbor outside the pair, so the resulting pair update is not conditioned on the rest of the ring. Composing eight such updates therefore need not obey [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution, the condition that every pair of configurations exchanges probability equally in both directions, which is what pins a sampler to its target. The moment comparison makes that bias visible.\n",
+    "\n",
+    "Third, can we recover the parameters from data? We fit the couplings and fields with persistent contrastive divergence. That fit is host-only: it runs in notebook NumPy, and Torx's contribution to it is the earlier evidence that the same update rule samples correctly.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: the finite-reset probe and every chromatic-Gibbs site draw.</li><li>Notebook code: exact enumeration, <code>PISING</code> matrix construction, moments, and parameter updates.</li><li><code>examples/helpers/_plots_sampling.py</code>: the Torx chromatic loop, host <code>PISING</code> matrix walker, and host PCD loop.</li></ul></details>\n",
     "\n",
@@ -37,13 +47,7 @@
     "\n",
     "- distinguish the ideal infinite reset from the finite probe and the ring's manual-zero implementation,\n",
     "- compare Torx chromatic Gibbs with host sampling from Torx-generated `PISING` matrices against an exact 8-site reference, and\n",
-    "- fit Ising parameters with host-only persistent contrastive divergence.\n",
-    "\n",
-    "Locality makes fast sampling possible here. Each spin's conditional depends only on its graph neighbors, so a whole color class of conditionally independent sites can update at once. This parallel single-site sampler is **chromatic Gibbs sampling**.\n",
-    "\n",
-    "A bond `PISING` matrix includes its bond energy and split site fields but omits the current energy contribution from each spin's neighbor outside that bond. The resulting pair update is not conditioned on the rest of the ring, so composing those matrices need not obey [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution. The moment comparison makes that bias visible.\n",
-    "\n",
-    "The 8-site ring is small enough to enumerate all $2^8 = 256$ states, which provides an exact Boltzmann reference for each sampler."
+    "- fit Ising parameters with host-only persistent contrastive divergence."
    ]
   },
   {
@@ -89,7 +93,7 @@
    "id": "5e0a4a29",
    "metadata": {},
    "source": [
-    "With the helper path set, import Torx, the numerical libraries, and the notebook helpers:"
+    "With the helper path set, we import Torx, the numerical libraries, and the notebook helpers:"
    ]
   },
   {
@@ -135,7 +139,7 @@
    "id": "e0f7cef7",
    "metadata": {},
    "source": [
-    "Apply the notebook style, set `SEED`, and wrap figure export:"
+    "We apply the shared style, fix `SEED` so every draw below is reproducible, and wrap figure export:"
    ]
   },
   {
@@ -171,6 +175,8 @@
    "source": [
     "## The Ising model\n",
     "\n",
+    "Before any Torx call, we fix the two objects the rest of the notebook keeps referring back to: the energy of a spin configuration, and the one-site conditional a Gibbs sampler draws from.\n",
+    "\n",
     "A spin configuration $\\mathbf{s} \\in \\{-1, +1\\}^N$ has energy\n",
     "\n",
     "$$\n",
@@ -183,7 +189,7 @@
     "\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})} .\n",
     "$$\n",
     "\n",
-    "Single-site Gibbs sampling resamples one spin at a time from its exact conditional. For site $i$ with neighbors $N(i)$, we write the local field\n",
+    "Because the energy is a sum of purely local terms, we never have to touch the whole configuration at once. Single-site Gibbs sampling resamples one spin at a time from its exact conditional. For site $i$ with neighbors $N(i)$, we write the local field\n",
     "\n",
     "$$\n",
     "\\ell_i = h_i + \\underbrace{\\sum_{j \\in N(i)} J_{ij}\\,(2\\sigma_j - 1)}_{\\vphantom{\\big|}\\text{neighbor sum}},\n",
@@ -193,7 +199,7 @@
     "\n",
     "using bits $\\sigma \\in \\{0, 1\\}$ with $s = 2\\sigma - 1$. The neighbor sum runs only over $N(i)$.\n",
     "\n",
-    "The conditional is a Bernoulli whose logit (the log-odds of the spin being up) is $2\\beta\\ell_i$, and this one-site conditional is all the sampler needs."
+    "The conditional is a Bernoulli whose logit (the log-odds of the spin being up) is $2\\beta\\ell_i$, and this one-site conditional is all the sampler needs. Everything that follows is a question about how faithfully some piece of machinery reproduces it."
    ]
   },
   {
@@ -203,13 +209,17 @@
    "source": [
     "## The per-site update\n",
     "\n",
-    "An ideal Gibbs update discards the current spin, then draws a Bernoulli bit from the conditional above. In Torx notation that identity is\n",
+    "Our first job is to get one site right, because a ring sampler is only as trustworthy as the single update it repeats. An ideal Gibbs update discards the current spin, then draws a Bernoulli bit from the conditional above. In Torx notation that identity is\n",
     "\n",
     "$$\n",
     "\\mathsf{PColor}_i = \\mathsf{PNOT}(2\\beta\\ell_i) \\circ \\mathsf{PReset}(\\infty).\n",
     "$$\n",
     "\n",
-    "`PReset(∞)` is the ideal infinite-strength reset. The executable probe below uses the finite value `12.0`, so it tests a close approximation with a small reset-leak contribution. The ring implementation later uses neither reset: it supplies an exact zero initial state and applies only `PNOT`.\n",
+    "That identity is stated with an infinite reset, which no circuit can execute, so the notebook works with three distinct reset cases in total. We name all three now, because later sections refer back to this list:\n",
+    "\n",
+    "1. **The ideal infinite reset**, `PReset(∞)`, which appears in the identity above and is a mathematical statement rather than something we run.\n",
+    "2. **The finite reset**, `PReset(12.0)`, used by the probe in this section. It drives the input close to zero rather than exactly to zero, so it tests a close approximation of case 1 with a small reset-leak contribution.\n",
+    "3. **The ring's manual zero**, used from the chromatic Gibbs section onward. It supplies an exact zero initial state and applies only `PNOT`, so it uses no reset gate at all and leaks nothing.\n",
     "\n",
     "For the finite probe, choose a target probability $p = 0.73$:"
    ]
@@ -251,7 +261,7 @@
    "id": "59c41cd2",
    "metadata": {},
    "source": [
-    "Draw the finite-reset probe. It shows `PReset(12)` followed by the conditional `PNOT` flip:"
+    "We draw the probe circuit first, so the executable shape of case 2 is visible before we sample from it:"
    ]
   },
   {
@@ -302,7 +312,7 @@
    "id": "55d63773",
    "metadata": {},
    "source": [
-    "The finite reset drives the input close to zero, then `PNOT` resamples it. This probe approximates the ideal infinite-reset identity above."
+    "Two gates on one wire is the whole probe: the finite reset drives $\\sigma_i$ close to zero, then `PNOT` resamples it at the conditional's log-odds."
    ]
   },
   {
@@ -310,7 +320,7 @@
    "id": "edeadbb6",
    "metadata": {},
    "source": [
-    "Sample the finite-reset probe to check that its empirical mean matches `p_one` within a tolerance of `0.04`:"
+    "The claim to test is that this approximation is already good enough to stand in for the ideal identity. We draw 2000 samples and compare the empirical mean against the target `p_one` with a tolerance of `0.04`, so agreement at that level tells us the reset leak is too small to matter at the resolution we sample it:"
    ]
   },
   {
@@ -356,7 +366,7 @@
    "source": [
     "## Chromatic Gibbs sampling on a ring\n",
     "\n",
-    "The ring has $N = 8$ sites, one pbit per site, one $J_{ij}$ per edge, and one $h_i$ per site.\n",
+    "With one site validated, we scale the same update out to a whole graph. The ring has $N = 8$ sites, one pbit per site, one $J_{ij}$ per edge, and one $h_i$ per site.\n",
     "\n",
     "We color the sites by parity: evens in one color, odds in the other. No neighboring sites share a color, so all sites of one color can update at once while conditioned on the other color."
    ]
@@ -388,7 +398,7 @@
    "id": "e34d5176",
    "metadata": {},
    "source": [
-    "Enumerate all 256 states to build the exact Boltzmann reference and its moments:"
+    "Every comparison from here on needs a ground truth, so we enumerate all 256 states to build the exact Boltzmann reference and its moments:"
    ]
   },
   {
@@ -443,7 +453,7 @@
    "id": "435e1961",
    "metadata": {},
    "source": [
-    "Draw the ring to see the two-color structure used by the parallel Gibbs sweep. The even and odd color classes use distinct outlines, and the dark incident edges mark the local field for $s_2$:"
+    "Before running the sweep, we draw the ring to see why two colors are enough:"
    ]
   },
   {
@@ -490,7 +500,7 @@
    "id": "00d62908",
    "metadata": {},
    "source": [
-    "The highlighted edges at $s_2$ show how narrow each conditional is: a site only reads its two ring neighbors."
+    "The even and odd classes carry distinct outlines and never touch, which is what lets a whole class update in parallel, and the dark incident edges marking the local field for $s_2$ show how narrow each conditional is: a site only reads its two ring neighbors."
    ]
   },
   {
@@ -498,7 +508,7 @@
    "id": "c5297316",
    "metadata": {},
    "source": [
-    "Run 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This is the ring's third, distinct reset case: every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`. It does not execute `PReset`, so it has no finite-reset leakage.\n",
+    "We now run the sampler itself: 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This is case 3 from the reset list above, the ring's manual zero. Every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`, and because it does not execute `PReset`, there is no finite-reset leakage to account for here.\n",
     "\n",
     "Its claim-bearing core is:\n",
     "\n",
@@ -522,7 +532,7 @@
     "    sample_bits = jax.vmap(sample_bit)\n",
     "```\n",
     "\n",
-    "Each chain's conditional logit $2\\beta\\ell_i$ is folded into the `PNOT` gate theta and `sample_bit` is vmapped over every chain and color site. Then compare its empirical distribution and moments with the exact reference through total variation distance, which measures how far apart two distributions are:"
+    "Each chain's conditional logit $2\\beta\\ell_i$ is folded into the `PNOT` gate theta and `sample_bit` is vmapped over every chain and color site, so one batched Torx call draws an entire color class. We then compare the empirical distribution and moments with the exact reference through total variation distance, which measures how far apart two distributions are, and we require it to come in under 0.08:"
    ]
   },
   {
@@ -577,7 +587,7 @@
    "source": [
     "## Host sampling from Torx-generated PISING matrices\n",
     "\n",
-    "The bond-local alternative updates one edge at a time.\n",
+    "Chromatic Gibbs is one way to be local. This section builds the other, so that we can measure what changes when locality is drawn around a bond instead of a site. The bond-local alternative updates one edge at a time.\n",
     "\n",
     "The Torx `PISING` operation, constructed as `PISING([i, j])` with theta `[J, h_i, h_j, beta, dt]`, generates a column-stochastic Glauber matrix for the two incident spins. Column-stochastic means every column of transition probabilities sums to one. Its transition matrix is\n",
     "\n",
@@ -587,7 +597,7 @@
     "\n",
     "where $Q$ is the single-spin-flip generator of the bond energy $E(s_i, s_j) = -J s_i s_j - h_i s_i - h_j s_j$. Here $\\Delta t$ is `pising_dt` in the next cell.\n",
     "\n",
-    "We generate one matrix for each ring edge and split each site's field in half so its two incident bonds sum to $h_i$. These two-spin matrices still omit the live energy contribution from the external neighbor of each endpoint. A block-Gibbs pair update would condition on those neighbors, but this bond matrix does not, so the composed host walk need not preserve the ring Boltzmann law."
+    "We generate one matrix for each ring edge and split each site's field in half so its two incident bonds sum to $h_i$. The fields therefore add up correctly, but these two-spin matrices still omit the live energy contribution from the external neighbor of each endpoint. A block-Gibbs pair update would condition on those neighbors, and this bond matrix does not, so the composed host walk need not preserve the ring Boltzmann law, meaning the distribution the walk would leave unchanged once mixed is not guaranteed to be the one we want."
    ]
   },
   {
@@ -630,7 +640,7 @@
    "id": "e6befb22",
    "metadata": {},
    "source": [
-    "Draw a representative circuit slice, showing the first three of eight bond gates for legibility. This diagram shows the matrix-generating gate structure only. The notebook does not send this circuit through a Torx simulator:"
+    "We draw a representative slice of the bond sweep, the first three of eight gates for legibility, to show the gate structure the matrices come from. Torx's role at this stage is generation: we ask each `PISING` gate for its matrix and then sample on the host, so this circuit is never handed to a Torx simulator:"
    ]
   },
   {
@@ -683,7 +693,7 @@
    "id": "3493811d",
    "metadata": {},
    "source": [
-    "The full structural sweep places one two-spin bond gate on every ring edge. Sampling from the generated matrices happens on the host below."
+    "The full structural sweep places one two-spin bond gate on every ring edge, which is exactly the eight matrices assembled above."
    ]
   },
   {
@@ -691,7 +701,7 @@
    "id": "8b6fe159",
    "metadata": {},
    "source": [
-    "Call `pising_ring_samples` in `examples/helpers/_plots_sampling.py`. This NumPy loop walks the Torx-generated transition matrices on the host, draws each next pair state, then returns samples for the moment and total-variation comparisons:"
+    "To sample from those matrices we call `pising_ring_samples` in `examples/helpers/_plots_sampling.py`. It is a NumPy loop that walks each Torx-generated transition matrix in turn and draws the next pair state, returning the 4000 chains we need for the moment and total-variation comparisons:"
    ]
   },
   {
@@ -743,13 +753,11 @@
    "id": "7dda24bb",
    "metadata": {},
    "source": [
-    "In total variation, the host sampler using Torx-generated `PISING` matrices sits about six times farther from the exact Boltzmann distribution than Torx chromatic Gibbs (0.4020 against 0.0634). That number summarizes the omitted-neighbor bias.\n",
+    "The distance puts a number on the difference. The host sampler using Torx-generated `PISING` matrices sits at total variation 0.4020 from the exact Boltzmann distribution, about six times the 0.0634 that Torx chromatic Gibbs reaches, and that ratio is what the omitted-neighbor bias costs.\n",
     "\n",
     "### Comparing the moments\n",
     "\n",
-    "The plot compares the per-site magnetizations $\\langle s_i\\rangle$, the average spin at each site, and per-edge correlations $\\langle s_i s_j\\rangle$, the average neighboring-spin product. It shows the exact reference, Torx chromatic Gibbs, and the host sampler using Torx-generated `PISING` matrices.\n",
-    "\n",
-    "Torx chromatic Gibbs tracks the exact moments. The host matrix walker gets most signs right but underestimates the magnitudes. At $s_6$, where the exact magnetization is nearly zero, even the sign flips."
+    "One distance tells us the samplers differ but not where, so we look at the statistics the difference lives in: the per-site magnetizations $\\langle s_i\\rangle$, the average spin at each site, and per-edge correlations $\\langle s_i s_j\\rangle$, the average neighboring-spin product. The panels place the exact reference, Torx chromatic Gibbs, and the host sampler using Torx-generated `PISING` matrices side by side. Torx chromatic Gibbs tracks the exact moments, while the host matrix walker gets most signs right but underestimates the magnitudes, far enough that at $s_6$, where the exact magnetization is nearly zero, even the sign flips."
    ]
   },
   {
@@ -815,7 +823,9 @@
    "source": [
     "## Host-only persistent contrastive divergence\n",
     "\n",
-    "[**Persistent contrastive divergence** (Tieleman 2008)](#ref-tieleman) keeps Gibbs chains running instead of resetting them from data. At each step, it contrasts their moments with the data moments. The log-likelihood gradients are the moment differences:\n",
+    "So far the parameters were given and we sampled from them. Now we run that backwards: given samples, recover the parameters.\n",
+    "\n",
+    "Contrastive divergence learns by comparison. It measures a few statistics of the data, measures the same statistics on samples the current model produces, and moves the parameters until the two agree. [**Persistent contrastive divergence** (Tieleman 2008)](#ref-tieleman) makes one change to that recipe: it keeps Gibbs chains running instead of resetting them from data, so at each step it contrasts the moments of long-lived chains with the data moments. The log-likelihood gradients are the moment differences:\n",
     "\n",
     "$$\n",
     "\\partial_{J_{ij}}\\log\\mathcal{L} = \\beta\\bigl(\\langle s_i s_j\\rangle_{\\text{data}} - \\langle s_i s_j\\rangle_{\\text{model}}\\bigr),\n",
@@ -823,7 +833,7 @@
     "\\partial_{h_i}\\log\\mathcal{L} = \\beta\\bigl(\\langle s_i\\rangle_{\\text{data}} - \\langle s_i\\rangle_{\\text{model}}\\bigr).\n",
     "$$\n",
     "\n",
-    "We draw 2048 training samples from the exact Boltzmann distribution."
+    "Because the exact ring law is enumerable, we can draw honest training data from it directly: 2048 training samples from the exact Boltzmann distribution."
    ]
   },
   {
@@ -854,7 +864,7 @@
    "id": "9f3aaed3",
    "metadata": {},
    "source": [
-    "Start the chains from a flat model, $J = h = 0$, with learning rate $0.08$:"
+    "We start the model deliberately uninformed, a flat $J = h = 0$, so whatever structure appears at the end came from the data and not from the initialization. The learning rate is $0.08$:"
    ]
   },
   {
@@ -882,7 +892,7 @@
    "id": "92d379c4",
    "metadata": {},
    "source": [
-    "Each step calls the host NumPy `chromatic_gibbs` loop in `examples/helpers/_plots_sampling.py` for two sweeps, then the notebook updates $J$ and $h$ from the data-minus-model moment gap. No Torx operation runs in this fit:"
+    "Each step calls the host NumPy `chromatic_gibbs` loop in `examples/helpers/_plots_sampling.py` for two sweeps, then the notebook updates $J$ and $h$ from the data-minus-model moment gap. This fit runs entirely on the host: Torx's contribution came earlier, when the chromatic sweep it executed reproduced the exact Boltzmann distribution to 0.0634 in total variation, which is what lets us use the fast NumPy mirror of the same update rule inside the training loop:"
    ]
   },
   {
@@ -915,7 +925,7 @@
    "id": "b2219106",
    "metadata": {},
    "source": [
-    "After 300 steps, check the learned parameters against the truth:"
+    "The claim is that 300 steps of this loop are enough to identify the model, so we compare every learned coupling and field against the true values that generated the data, with a tolerance of 0.05:"
    ]
   },
   {
@@ -954,7 +964,7 @@
    "source": [
     "### Parameter recovery\n",
     "\n",
-    "The parity panels plot the learned couplings and fields against the true values after 300 persistent contrastive divergence steps. Points on the dotted diagonal indicate exact recovery."
+    "Assertions confirm the fit succeeded, and the parity panels show how it succeeded. They plot the learned couplings and fields against the true values after 300 persistent contrastive divergence steps, so points on the dotted diagonal indicate exact recovery."
    ]
   },
   {
@@ -1001,7 +1011,7 @@
    "id": "1afc1888",
    "metadata": {},
    "source": [
-    "Points hugging the diagonal show that this host-only fit recovered both the couplings and the fields."
+    "Both panels hug the diagonal to within the printed maxima of 0.0373 for the couplings and 0.0386 for the fields, so this host-only fit recovered the full parameter set well inside the 0.05 tolerance."
    ]
   },
   {
@@ -1011,7 +1021,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "The quantitative checks ran as inline assertions above; print their summary in one place:"
+    "Each quantitative claim was asserted where it was made, so the closing cell reprints the whole set in one place:"
    ]
   },
   {
@@ -1060,9 +1070,9 @@
     "We compared the exact ring law, Torx chromatic Gibbs, a host walk over Torx-generated `PISING` matrices, and a host-trained Ising model.\n",
     "\n",
     "- The ideal per-site identity uses `PReset(∞)` then `PNOT`. The executable probe uses finite reset strength 12, while the ring manually supplies zero and runs only `PNOT`.\n",
-    "- The two-color ring sweep runs every site draw through Torx and lands within total variation 0.08 of the exact Boltzmann distribution.\n",
-    "- The host `PISING` matrix walker is biased because each two-spin matrix omits live external-neighbor energy and therefore need not satisfy detailed balance for the full ring.\n",
-    "- Host-only persistent contrastive divergence recovers the couplings and fields to within 0.05 in 300 steps.\n",
+    "- The two-color ring sweep runs every site draw through Torx and reproduces the exact Boltzmann distribution to total variation 0.0634, inside the 0.08 bound we asserted.\n",
+    "- The host `PISING` matrix walker reaches only 0.4020 because each two-spin matrix omits live external-neighbor energy and therefore need not satisfy detailed balance for the full ring.\n",
+    "- Host-only persistent contrastive divergence recovers the couplings and fields to within 0.05 in 300 steps, with worst-case errors of 0.0373 and 0.0386.\n",
     "\n",
     "Next, [`07_discrete_diffusion.ipynb`](07_discrete_diffusion.ipynb) uses `PNOT` gates for posterior per-pixel denoising, and [`08_stochastic_convolutional_networks.ipynb`](08_stochastic_convolutional_networks.ipynb) carries stochastic primitives into a convolutional network.\n",
     "\n",

--- a/examples/07_discrete_diffusion.ipynb
+++ b/examples/07_discrete_diffusion.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "A **forward process** corrupts a clean binary image by flipping pixels at random, so the reverse step has to guess which pixels were flipped. The posterior denoiser estimates $\\hat p_i = P(x_{0,i}=1 \\mid x_t)$ from the corrupted image $x_t$.\n",
     "\n",
-    "We treat each pixel as a probabilistic bit, or **pbit**, because that is the unit Torx samples. One `PNOT` gate turns the current pixel into a Bernoulli draw with parameter $\\hat p_i$.\n",
+    "We treat each pixel as a probabilistic bit, or **pbit**, because that's the unit Torx samples. One `PNOT` gate turns the current pixel into a Bernoulli draw with parameter $\\hat p_i$.\n",
     "\n",
     "The [UNet](https://arxiv.org/abs/1505.04597) that supplies those probabilities has 472,545 parameters and was trained offline, so we load its committed weights and evaluation artifacts and the page stays fast. The training and FID evaluation script is not in the repository, which is why nothing here reproduces the checkpoint's training split or its FID protocol.\n",
     "\n",
@@ -175,7 +175,7 @@
     "\n",
     "Everything the denoiser knows was learned before this page ran, so the first job is to load it. The committed artifacts under `assets/nb07/` hold the UNet parameters, the saved training loss, the evaluation grids, and sparse run metadata.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: 784 <code>PNOT</code> gates and stochastic sampling.</li><li>Notebook code: probability-to-logit mapping, display-batch metrics, and PCA-space comparison.</li><li><code>examples/helpers/_nb07_diffusion.py</code>: host UNet inference and PCA/Fréchet calculations. <code>examples/helpers/_plots_training.py</code>: figures only.</li><li>Offline assets: <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/meta.json\">metadata</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/eval_grids.npz\">evaluation grids</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/loss_history.npy\">loss history</a>, and <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/unet_mnist.msgpack\">UNet weights</a>. Their generator is not committed.</li></ul></details>\n",
+    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: 784 <code>PNOT</code> gates and stochastic sampling.</li><li>Notebook code: probability-to-logit mapping, display-batch metrics, and PCA-space comparison.</li><li><code>examples/helpers/_nb07_diffusion.py</code>: host UNet inference and PCA/Fréchet calculations. <code>examples/helpers/_plots_training.py</code>: figures only.</li><li>Offline assets: <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/meta.json\">metadata</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/eval_grids.npz\">evaluation grids</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/loss_history.npy\">loss history</a>, and <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/unet_mnist.msgpack\">UNet weights</a>, all committed to the repository without the script that produced them.</li></ul></details>\n",
     "\n",
     "The helper `load_unet_params` in `examples/helpers/_nb07_diffusion.py` rebuilds the UNet from those committed weights."
    ]
@@ -432,9 +432,9 @@
    "source": [
     "## Posterior clean-bit probabilities\n",
     "\n",
-    "No gate can sample anything until something tells it what a clean pixel probably was, and that is the host denoiser's job.\n",
+    "No gate can sample anything until something tells it what a clean pixel probably was, and that's the host denoiser's job.\n",
     "\n",
-    "It is a 472k-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections, where each block uses two `GroupNorm`-normalized $3\\times3$ convolutions. Its per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. The model definition and loader live in `examples/helpers/_nb07_diffusion.py`. That fixes the division of labor for the rest of the page: the offline UNet contributes the per-pixel probabilities, and Torx contributes every random bit that comes out.\n",
+    "It's a 472k-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections, where each block uses two `GroupNorm`-normalized $3\\times3$ convolutions. Its per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. The model definition and loader live in `examples/helpers/_nb07_diffusion.py`. That fixes the division of labor for the rest of the page: the offline UNet contributes the per-pixel probabilities, and Torx contributes every random bit that comes out.\n",
     "\n",
     "A gate needs a flip probability rather than a clean probability, so for current pixel $x_{t,i}$ we set the `PNOT` flip probability to\n",
     "\n",
@@ -444,7 +444,7 @@
     "\\theta^{(i)} = \\log \\frac{p^{(i)}_{\\text{flip}}}{1 - p^{(i)}_{\\text{flip}}}.\n",
     "$$\n",
     "\n",
-    "If the input is 0, the output is 1 exactly when `PNOT` flips. If the input is 1, the output stays 1 exactly when it does not flip. Either way the output bit is Bernoulli($\\hat p_i$).\n",
+    "If the input is 0, the output is 1 exactly when `PNOT` flips. If the input is 1, the output stays 1 exactly when it doesn't flip. Either way the output bit is Bernoulli($\\hat p_i$).\n",
     "\n",
     "That makes this posterior per-pixel denoising rather than a joint time-transition kernel derived from the forward process, and the trade is worth naming. We give up any account of how neighboring pixels move together within one reverse step. What we buy is a reverse step that costs one gate per pbit."
    ]
@@ -503,7 +503,7 @@
    "id": "cell-17",
    "metadata": {},
    "source": [
-    "The curve flattens toward that final value, which tells us the offline run had stopped changing much by step 30,000. It does not tell us the model converged or generalizes, because no validation loss, stopping rule, or training script was committed with it."
+    "The curve flattens toward that final value, which tells us the offline run had stopped changing much by step 30,000 and little else, because the committed artifact arrived without a validation loss, a stopping rule, or the training script that would let us speak to convergence or generalization."
    ]
   },
   {
@@ -606,7 +606,7 @@
    "id": "cell-29",
    "metadata": {},
    "source": [
-    "Now we assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once and every image reuses it, so the build cost is paid a single time. The `num_draws` argument decides what the returned mean means: with one draw it is the binary sample itself, and with many draws it is a Monte Carlo estimate of each pixel's posterior marginal, that is, the average over independent draws."
+    "Now we assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once and every image reuses it, so the build cost is paid a single time. The `num_draws` argument decides what the returned mean means: with one draw it's the binary sample itself, and with many draws it's a Monte Carlo estimate of each pixel's posterior marginal, that is, the average over independent draws."
    ]
   },
   {
@@ -811,7 +811,7 @@
     "\n",
     "[Fréchet inception distance](https://arxiv.org/abs/1706.08500) compares Gaussians fitted to Inception features from two image sets, and a lower value means the two sets look more alike to that feature extractor.\n",
     "\n",
-    "The committed metadata records 19.21 for the corrupted images and 2.63 for the offline UNet-denoised images. Both numbers score the UNet checkpoint's own outputs, and neither scores a Torx draw, because no Torx output was ever put through an FID evaluation. The evaluation split, sample count, preprocessing, and FID implementation were not committed either, so read the figure below as checkpoint metadata rather than as a result this notebook reproduced."
+    "The committed metadata records 19.21 for the corrupted images and 2.63 for the offline UNet-denoised images. Both numbers score the UNet checkpoint's own outputs, and neither scores a Torx draw, because no Torx output was ever put through an FID evaluation. The evaluation split, sample count, preprocessing, and FID implementation weren't committed either, so read the figure below as checkpoint metadata rather than as a result this notebook reproduced."
    ]
   },
   {
@@ -875,7 +875,7 @@
    "id": "cell-39",
    "metadata": {},
    "source": [
-    "Inception features come from ImageNet-like RGB images, which makes FID a poor fit for binary MNIST. As a descriptive stand-in we build a feature space the data actually occupies: we fit 16 principal components to 32 clean reference images, then compare clean, corrupted, and denoised versions of the other 32 in that space. The Fréchet distance we compute there measures how far a set's mean and covariance in those 16 coordinates sit from the clean reference set's, so it scores a distribution rather than any single image. Because the reference images are never evaluated, the two sets stay disjoint and leakage cannot flatter the result."
+    "Inception features come from ImageNet-like RGB images, which makes FID a poor fit for binary MNIST. As a descriptive stand-in we build a feature space the data actually occupies: we fit 16 principal components to 32 clean reference images, then compare clean, corrupted, and denoised versions of the other 32 in that space. The Fréchet distance we compute there measures how far a set's mean and covariance in those 16 coordinates sit from the clean reference set's, so it scores a distribution rather than any single image. Because the reference images are never evaluated, the two sets stay disjoint and leakage can't flatter the result."
    ]
   },
   {

--- a/examples/07_discrete_diffusion.ipynb
+++ b/examples/07_discrete_diffusion.ipynb
@@ -13,8 +13,8 @@
    "id": "cell-01",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>An offline UNet supplies clean-pixel probabilities, and Torx draws each output pixel through one <code>PNOT</code> gate. We show one genuine Torx draw separately from a thresholded 64-draw ensemble estimator. Offline FID metadata belongs only to the UNet artifacts.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>An offline UNet supplies clean-pixel probabilities, and Torx draws each output pixel through one <code>PNOT</code> gate. We show one genuine Torx draw separately from a thresholded 64-draw ensemble estimator. The committed FID numbers (Fréchet inception distance, a standard score for generated images) describe the offline UNet checkpoint and not anything Torx produced here.</p>\n",
     "</div>"
    ]
   },
@@ -23,13 +23,13 @@
    "id": "cell-02",
    "metadata": {},
    "source": [
-    "This tutorial uses the independent bit-flip corruption from discrete diffusion ([Austin et al. 2021](#ref-austin)) and its continuous-time Markov-chain form ([Campbell et al. 2022](#ref-campbell)) as the forward-process context. The executed method is narrower: a host UNet predicts each clean pixel's posterior probability, and Torx independently resamples the pixels from those probabilities.\n",
+    "In this tutorial we take the corrupted-image side of discrete diffusion and hand the reverse step to Torx. The forward process is the independent bit-flip corruption of [Austin et al. 2021](#ref-austin) in the continuous-time Markov-chain form of [Campbell et al. 2022](#ref-campbell), which sets the context rather than the method we execute. What we actually run is narrower: a host UNet predicts each clean pixel's posterior probability, and Torx independently resamples the pixels from those probabilities.\n",
     "\n",
-    "A **forward process** corrupts a clean binary image by flipping pixels at random. The posterior denoiser estimates $\\hat p_i = P(x_{0,i}=1 \\mid x_t)$ from the corrupted image $x_t$.\n",
+    "A **forward process** corrupts a clean binary image by flipping pixels at random, so the reverse step has to guess which pixels were flipped. The posterior denoiser estimates $\\hat p_i = P(x_{0,i}=1 \\mid x_t)$ from the corrupted image $x_t$.\n",
     "\n",
-    "We treat each pixel as a probabilistic bit, or **pbit**. One `PNOT` gate turns the current pixel into a Bernoulli draw with parameter $\\hat p_i$.\n",
+    "We treat each pixel as a probabilistic bit, or **pbit**, because that is the unit Torx samples. One `PNOT` gate turns the current pixel into a Bernoulli draw with parameter $\\hat p_i$.\n",
     "\n",
-    "The [UNet](https://arxiv.org/abs/1505.04597) checkpoint has 472,545 parameters and was trained offline. We load the committed weights and evaluation artifacts so the notebook stays fast. The repository does not include the training or FID evaluation script, so this page does not claim a reproducible training split or FID protocol.\n",
+    "The [UNet](https://arxiv.org/abs/1505.04597) that supplies those probabilities has 472,545 parameters and was trained offline, so we load its committed weights and evaluation artifacts and the page stays fast. The training and FID evaluation script is not in the repository, which is why nothing here reproduces the checkpoint's training split or its FID protocol.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -46,7 +46,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "We import the local helpers, set the plotting style, and fix the random seed."
+    "We import the local helpers, set the plotting style, and fix the random seed so every draw below repeats exactly."
    ]
   },
   {
@@ -173,11 +173,11 @@
    "source": [
     "## Loading the checkpoint and evaluation grids\n",
     "\n",
-    "The committed artifacts under `assets/nb07/` hold the UNet parameters, saved training loss, evaluation grids, and sparse run metadata.\n",
+    "Everything the denoiser knows was learned before this page ran, so the first job is to load it. The committed artifacts under `assets/nb07/` hold the UNet parameters, the saved training loss, the evaluation grids, and sparse run metadata.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: 784 <code>PNOT</code> gates and stochastic sampling.</li><li>Notebook code: probability-to-logit mapping, display-batch metrics, and PCA-space comparison.</li><li><code>examples/helpers/_nb07_diffusion.py</code>: host UNet inference and PCA/Fréchet calculations. <code>examples/helpers/_plots_training.py</code>: figures only.</li><li>Offline assets: <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/meta.json\">metadata</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/eval_grids.npz\">evaluation grids</a>, <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/loss_history.npy\">loss history</a>, and <a href=\"https://github.com/extropic-ai/torx/blob/main/examples/assets/nb07/unet_mnist.msgpack\">UNet weights</a>. Their generator is not committed.</li></ul></details>\n",
     "\n",
-    "The helper `load_unet_params` in `examples/helpers/_nb07_diffusion.py` rebuilds the UNet from the committed weights."
+    "The helper `load_unet_params` in `examples/helpers/_nb07_diffusion.py` rebuilds the UNet from those committed weights."
    ]
   },
   {
@@ -284,7 +284,7 @@
    "source": [
     "## Binarized pixels as pbits\n",
     "\n",
-    "We represent a binary image as one pbit per pixel.\n",
+    "A reverse step is only as good as the corruption model it inverts, so we start by writing that model down. We represent a binary image as one pbit per pixel.\n",
     "\n",
     "The forward process is a continuous-time Markov chain, a random process that jumps between states at random times. It flips every bit independently using the uniform rate matrix, which sets a single flip rate shared by all pixels:\n",
     "\n",
@@ -303,7 +303,7 @@
     "\n",
     "The off-diagonal entry $\\tfrac12(1 - e^{-2\\sigma})$ is the chance a bit has flipped by time $\\sigma$, and the diagonal $\\tfrac12(1 + e^{-2\\sigma})$ is the chance it stayed put. At $\\sigma = 0$ no bits have flipped, and as $\\sigma \\to \\infty$ the flip probability rises toward $\\tfrac12$, which is pure noise.\n",
     "\n",
-    "The committed `noisy` grids are clean MNIST images corrupted at the checkpoint's evaluation level: a per-bit flip probability `forward_p = 0.30`, meaning each pixel is flipped independently with probability 0.30. The next cell selects a display batch of eight images; the checks after it compare this rate against the observed bit error."
+    "The committed `noisy` grids are clean MNIST images corrupted at the checkpoint's evaluation level, a per-bit flip probability `forward_p = 0.30`, meaning each pixel is flipped independently with probability 0.30. The next cell selects a display batch of eight images, and the check after it compares that stated rate against the bit error we actually observe."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "id": "cell-09",
    "metadata": {},
    "source": [
-    "Before building circuits, check that the eight-image display batch is binary $28\\times28$. All bit-error values below use only this display batch."
+    "Before building any circuit we confirm that the eight-image display batch really is binary and $28\\times28$, and that the observed corruption matches the stated rate. Every bit-error value in this notebook is measured on these eight images alone."
    ]
   },
   {
@@ -375,7 +375,7 @@
    "id": "cell-11",
    "metadata": {},
    "source": [
-    "The flip-probability curve shows how a single bit approaches the pure-noise limit as the noise time increases."
+    "We plot the flip probability against noise time to see where the checkpoint's corruption level sits relative to pure noise."
    ]
   },
   {
@@ -422,7 +422,7 @@
    "id": "cell-13",
    "metadata": {},
    "source": [
-    "The marked corruption level stays below the 0.5 pure-noise limit, so the corrupted images still carry enough signal for the reverse step."
+    "At the marked level of 0.30 the curve is still well below the 0.5 pure-noise limit, so the corrupted images retain enough signal for the reverse step to work with."
    ]
   },
   {
@@ -432,11 +432,11 @@
    "source": [
     "## Posterior clean-bit probabilities\n",
     "\n",
-    "The host denoiser supplies the clean-pixel posterior probabilities that drive every gate.\n",
+    "No gate can sample anything until something tells it what a clean pixel probably was, and that is the host denoiser's job.\n",
     "\n",
-    "It is a 472k-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections. Each block uses two `GroupNorm`-normalized $3\\times3$ convolutions. Its per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. The model definition and loader live in `examples/helpers/_nb07_diffusion.py`.\n",
+    "It is a 472k-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections, where each block uses two `GroupNorm`-normalized $3\\times3$ convolutions. Its per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. The model definition and loader live in `examples/helpers/_nb07_diffusion.py`. That fixes the division of labor for the rest of the page: the offline UNet contributes the per-pixel probabilities, and Torx contributes every random bit that comes out.\n",
     "\n",
-    "For current pixel $x_{t,i}$, set the `PNOT` flip probability to\n",
+    "A gate needs a flip probability rather than a clean probability, so for current pixel $x_{t,i}$ we set the `PNOT` flip probability to\n",
     "\n",
     "$$\n",
     "p^{(i)}_{\\text{flip}} = \\begin{cases} 1 - \\hat p_i & x_{t,i} = 1 \\\\ \\hat p_i & x_{t,i} = 0. \\end{cases}\n",
@@ -444,7 +444,9 @@
     "\\theta^{(i)} = \\log \\frac{p^{(i)}_{\\text{flip}}}{1 - p^{(i)}_{\\text{flip}}}.\n",
     "$$\n",
     "\n",
-    "If the input is 0, the output is 1 exactly when `PNOT` flips. If the input is 1, the output stays 1 exactly when it does not flip. In both cases the output bit is therefore Bernoulli($\\hat p_i$). This is posterior per-pixel denoising. It does not derive a joint time-transition kernel."
+    "If the input is 0, the output is 1 exactly when `PNOT` flips. If the input is 1, the output stays 1 exactly when it does not flip. Either way the output bit is Bernoulli($\\hat p_i$).\n",
+    "\n",
+    "That makes this posterior per-pixel denoising rather than a joint time-transition kernel derived from the forward process, and the trade is worth naming. We give up any account of how neighboring pixels move together within one reverse step. What we buy is a reverse step that costs one gate per pbit."
    ]
   },
   {
@@ -454,7 +456,7 @@
    "source": [
     "## Saved training loss\n",
     "\n",
-    "The artifact metadata records 30,000 offline gradient steps. We plot the committed training loss; the dashed line marks its final saved value."
+    "The checkpoint's metadata records 30,000 offline gradient steps, and the loss history from that run is committed alongside the weights. We plot it to see how the offline training ended, with the dashed line marking the final saved value of 0.183."
    ]
   },
   {
@@ -501,7 +503,7 @@
    "id": "cell-17",
    "metadata": {},
    "source": [
-    "The saved training loss plateaus near the end. Without validation loss, a stopping rule, or the training script, this curve does not establish convergence or generalization."
+    "The curve flattens toward that final value, which tells us the offline run had stopped changing much by step 30,000. It does not tell us the model converged or generalizes, because no validation loss, stopping rule, or training script was committed with it."
    ]
   },
   {
@@ -511,7 +513,7 @@
    "source": [
     "## The posterior per-pixel circuit\n",
     "\n",
-    "One `PNOT` gate per pixel independently draws from the UNet's clean-bit marginal. The circuit does not include a time-step size or neighbor-conditioned joint transition.\n",
+    "Now we build the circuit that turns those probabilities into pixels. One `PNOT` gate per pixel draws independently from the UNet's clean-bit marginal, which is why the reverse step here has no time-step size and no neighbor-conditioned joint transition to configure.\n",
     "\n",
     "The cell below wraps the helper's host UNet forward pass, `denoise_logits`, into a per-pixel clean-probability function."
    ]
@@ -542,7 +544,7 @@
    "id": "cell-25",
    "metadata": {},
    "source": [
-    "This compact four-wire circuit shows the gate pattern used for posterior per-pixel draws."
+    "We draw four wires instead of 784 so the repeating gate pattern stays legible."
    ]
   },
   {
@@ -596,7 +598,7 @@
    "id": "cell-27",
    "metadata": {},
    "source": [
-    "Each wire carries one independent posterior draw. The full circuit tiles this pattern across all 784 pixels."
+    "Each wire carries one independent posterior draw, and the full circuit tiles this same pattern across all 784 pixels."
    ]
   },
   {
@@ -604,7 +606,7 @@
    "id": "cell-29",
    "metadata": {},
    "source": [
-    "Now assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once, and each image reuses it. The `num_draws` argument controls whether the returned mean represents one genuine draw or a Monte Carlo ensemble mean."
+    "Now we assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once and every image reuses it, so the build cost is paid a single time. The `num_draws` argument decides what the returned mean means: with one draw it is the binary sample itself, and with many draws it is a Monte Carlo estimate of each pixel's posterior marginal, that is, the average over independent draws."
    ]
   },
   {
@@ -741,7 +743,7 @@
    "source": [
     "## Draw and ensemble grid\n",
     "\n",
-    "Each row shows the same eight $28\\times28$ binary digits. The fourth row is one genuine stochastic Torx draw. The fifth row thresholds the mean of 64 separate Torx draws, so it is an ensemble posterior-mode estimator rather than one sample. Every printed bit-error value is scoped to these eight displayed images."
+    "The point of the grid below is to keep one honest sample visually separate from an estimator assembled out of many samples. Each row shows the same eight $28\\times28$ binary digits at a different stage: clean, forward corrupted, the offline UNet threshold, one genuine stochastic Torx draw, and the mean of 64 separate Torx draws thresholded at 0.5. That last row is an ensemble posterior-mode estimator rather than a sample, so by construction it should look tidier than the single draw. Every printed bit-error value is scoped to these eight displayed images."
    ]
   },
   {
@@ -795,7 +797,7 @@
    "id": "cell-36",
    "metadata": {},
    "source": [
-    "On this eight-image display batch, both Torx outputs reduce bit error. The single draw retains visible sampling variation, while the 64-draw estimator follows the UNet threshold more closely."
+    "Both Torx outputs cut the bit error on this eight-image display batch, from 0.301 after corruption to 0.127 for the single draw and 0.082 for the 64-draw ensemble. The gap between those two is the sampling variation visible in the fourth row, and averaging it away is what carries the ensemble toward the 0.058 of the offline UNet threshold."
    ]
   },
   {
@@ -805,9 +807,11 @@
    "source": [
     "## Offline UNet artifact metric\n",
     "\n",
-    "[Fréchet inception distance](https://arxiv.org/abs/1706.08500) compares Gaussians fitted to Inception features from two image sets.\n",
+    "The checkpoint was scored offline with FID and those numbers travel with the artifacts, so the first thing to settle is what they describe.\n",
     "\n",
-    "The committed metadata records 19.21 for corrupted images and 2.63 for offline UNet-denoised images. These values do not score either Torx output. The evaluation split, sample count, preprocessing, and FID implementation are not committed, so the figure reports checkpoint metadata rather than a notebook-reproduced result."
+    "[Fréchet inception distance](https://arxiv.org/abs/1706.08500) compares Gaussians fitted to Inception features from two image sets, and a lower value means the two sets look more alike to that feature extractor.\n",
+    "\n",
+    "The committed metadata records 19.21 for the corrupted images and 2.63 for the offline UNet-denoised images. Both numbers score the UNet checkpoint's own outputs, and neither scores a Torx draw, because no Torx output was ever put through an FID evaluation. The evaluation split, sample count, preprocessing, and FID implementation were not committed either, so read the figure below as checkpoint metadata rather than as a result this notebook reproduced."
    ]
   },
   {
@@ -871,7 +875,7 @@
    "id": "cell-39",
    "metadata": {},
    "source": [
-    "Inception features are trained on ImageNet-like RGB images, so their FID is a poor fit for binary MNIST. As a separate descriptive check, we fit 16 principal components to 32 clean reference images, then compare clean, corrupted, and denoised versions of the other 32 in that feature space. Keeping the reference and evaluation images separate avoids leakage; this score is not FID.\n"
+    "Inception features come from ImageNet-like RGB images, which makes FID a poor fit for binary MNIST. As a descriptive stand-in we build a feature space the data actually occupies: we fit 16 principal components to 32 clean reference images, then compare clean, corrupted, and denoised versions of the other 32 in that space. The Fréchet distance we compute there measures how far a set's mean and covariance in those 16 coordinates sit from the clean reference set's, so it scores a distribution rather than any single image. Because the reference images are never evaluated, the two sets stay disjoint and leakage cannot flatter the result."
    ]
   },
   {
@@ -924,7 +928,7 @@
    "id": "cell-41",
    "metadata": {},
    "source": [
-    "The offline UNet-denoised evaluation grids have lower PCA-space Fréchet distance than their corrupted counterparts. With only 32 reference and 32 evaluation images, this check is descriptive and is not FID."
+    "Corruption pushes the evaluation set out to 29.64 in this space, while the offline UNet-denoised grids come back to 14.20, close to the 13.86 that the untouched clean images score. With 32 reference and 32 evaluation images each value is noisy, so the ordering is the part to read."
    ]
   },
   {
@@ -934,14 +938,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We ran posterior per-pixel denoising on binarized MNIST with Torx stochastic circuits.\n",
+    "We ran posterior per-pixel denoising on binarized MNIST with Torx stochastic circuits, using an offline UNet for the probabilities and Torx for the randomness.\n",
     "\n",
     "- Each $28\\times28$ image uses 784 `PNOT` gates, one per pixel.\n",
-    "- A host UNet supplies clean-pixel posterior probabilities, which the notebook maps to `PNOT` flip logits.\n",
-    "- One genuine Torx draw is shown separately from the thresholded 64-draw ensemble estimator.\n",
-    "- Bit-error values cover only the eight-image display batch.\n",
-    "- The committed FID values belong only to offline UNet artifacts. Torx outputs were not evaluated with FID.\n",
-    "- A leakage-free, equal-size PCA-space Fréchet check on committed grids is descriptive, not FID.\n",
+    "- The host UNet supplies clean-pixel posterior probabilities, and the notebook maps them to `PNOT` flip logits.\n",
+    "- One genuine Torx draw is shown separately from the thresholded 64-draw ensemble estimator, because only the first is a sample.\n",
+    "- Bit error on the eight-image display batch falls from 0.301 after corruption to 0.127 for the single draw and 0.082 for the ensemble.\n",
+    "- The committed FID values of 19.21 and 2.63 belong to the offline UNet artifacts, and the PCA-space Fréchet check is descriptive, not FID, so no number here scores a Torx output on a generative metric.\n",
     "\n",
     "A natural next step is [`08_stochastic_convolutional_networks.ipynb`](08_stochastic_convolutional_networks.ipynb), which trains stochastic image circuits with parameter-shift gradients."
    ]

--- a/examples/08_stochastic_convolutional_networks.ipynb
+++ b/examples/08_stochastic_convolutional_networks.ipynb
@@ -13,8 +13,8 @@
    "id": "896f4473",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We train a shared stochastic kernel to classify 4x4 bars-and-stripes images: <code>param_map</code> ties 60 physical gates to 5 logits, and <code>param_shift_inf</code> supplies sample-based gradients. We check one shared-logit gradient against a finite-difference probe and record a six-example validation trace with seed 123.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We train a shared stochastic kernel to classify 4x4 bars-and-stripes images. <code>param_map</code> ties 60 physical gates to 5 trainable logits, and <code>param_shift_inf</code> supplies gradients estimated from samples, so the whole layer trains through the sampler. We check one shared-logit gradient against a finite-difference probe and record a six-example validation trace with seed 123.</p>\n",
     "</div>"
    ]
   },
@@ -25,9 +25,9 @@
    "source": [
     "In this tutorial, we build a stochastic convolution layer: a small probabilistic kernel that slides across a $4\\times4$ bars-and-stripes image. It plays the same role as a CNN filter, with gates that fire randomly in place of a fixed dot product.\n",
     "\n",
-    "Each image has 16 **[probabilistic bits (p-bits)](https://doi.org/10.1063/1.4975355)**, Bernoulli-valued states with one state per pixel. The layer is a parametrised stochastic circuit over those p-bits. Its defining property is weight sharing: the same local kernel is reused at every horizontal pixel pair.\n",
+    "Each image has 16 **[probabilistic bits (p-bits)](https://doi.org/10.1063/1.4975355)**, Bernoulli-valued states with one state per pixel, so the layer is a parametrised stochastic circuit over those p-bits. What makes it convolutional is weight sharing: one small set of parameters is reused at every position instead of each position learning its own. Here that means the same local kernel runs on every horizontal pixel pair.\n",
     "\n",
-    "Two `PCNOT` pooling stages then funnel the state into a small set of readout sites. Because we reuse the same horizontal-pair kernel across columns, the layer applies a convolution-like stencil with horizontal weight sharing.\n",
+    "Two `PCNOT` pooling stages then funnel the state into a small set of readout sites. Because the reuse runs across columns only, the layer applies a convolution-like stencil with horizontal weight sharing.\n",
     "\n",
     "This tutorial uses Torx, JAX, Equinox, Optax, NumPy, and Matplotlib. It assumes basic familiarity with binary classifiers and gradients.\n",
     "\n",
@@ -134,7 +134,7 @@
    "id": "4381a151",
    "metadata": {},
    "source": [
-    "These imports support circuit construction, optimization, and the fixed data split."
+    "The second import block brings in the gate primitives from `torx.psc` together with Equinox, JAX, and Optax, and it fixes `SEED = 123`. That single seed drives the data split, the classifier initialization, and every sampler key below, so every number this notebook prints is reproducible."
    ]
   },
   {
@@ -200,9 +200,9 @@
    "source": [
     "## The dataset\n",
     "\n",
-    "Bars-and-stripes is a small binary image set whose two classes differ only in whether rows or columns are constant.\n",
+    "Bars-and-stripes is a small binary image set whose two classes differ only in whether rows or columns are constant, which makes it a fair test for a layer built out of horizontal neighbour interactions.\n",
     "\n",
-    "Each image either has constant rows (bars: every row is uniform, so the image is horizontal bands) or constant columns (stripes: every column is uniform, so the image is vertical stripes). The all-zero and all-one images belong to both families. This helper keeps those duplicates as bars by convention, yielding 16 bars and 14 stripes. With seed 123, we split the 30 distinct patterns into 24 training examples and 6 validation examples. The same six validation examples are evaluated after every epoch, and no untouched test set is reported.\n"
+    "An image is a bar when every row is uniform, so it reads as horizontal bands, and a stripe when every column is uniform, so it reads as vertical stripes. The all-zero and all-one images satisfy both definitions, and the helper below keeps those duplicates as bars by convention, which yields 16 bars and 14 stripes. With seed 123 we split the 30 distinct patterns into 24 training examples and 6 validation examples, and the same six validation examples are scored after every epoch.\n"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "id": "1490b08e",
    "metadata": {},
    "source": [
-    "The `bars_and_stripes` function below builds the labeled image set by enumerating every constant-row pattern (bars) and every constant-column pattern (stripes)."
+    "`bars_and_stripes` builds the labeled set by enumerating every constant-row pattern as a bar and every constant-column pattern as a stripe, skipping images it has already seen so the two uniform patterns are counted once. We then fix `N_SIDE = 4` and materialize the flattened `patterns` and `labels` arrays."
    ]
   },
   {
@@ -251,14 +251,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "31468c8c",
-   "metadata": {},
-   "source": [
-    "Set `N_SIDE` and materialize the `patterns` and `labels` arrays."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 7,
    "id": "830b54e6",
@@ -282,7 +274,7 @@
    "id": "038480a0",
    "metadata": {},
    "source": [
-    "Before training, check that `patterns`, `labels`, and `N_PBITS` describe the expected 30 images."
+    "The class counts are the first thing a bug in that enumeration would break, so we assert them before anything else uses the data: 30 distinct patterns, 16 pixels each, 16 bars and 14 stripes. Double-counted uniform images fail here rather than surface later as a mislabeled batch."
    ]
   },
   {
@@ -325,17 +317,15 @@
    "source": [
     "## Building the kernel circuit\n",
     "\n",
-    "The local kernel applies four gates to each adjacent horizontal pixel pair: `PJUMP`, `PReset`, `PNOT`, and `PJUMP`.\n",
+    "Weight sharing is the whole point of this layer, so we should be precise about what is shared. The local kernel applies four gates to each adjacent horizontal pixel pair, `PJUMP`, `PReset`, `PNOT`, and `PJUMP`, and `param_map` points all 12 horizontal-pair applications of that kernel at the same logits, which is the stochastic analogue of weight tying in a CNN. The reuse runs across columns only, so we get horizontal weight sharing (a convolution-like stencil) rather than an exact shift symmetry, and there is no vertical shared kernel.\n",
     "\n",
-    "The two `PJUMP` gates in the four-gate kernel share logit 0, so the kernel uses 3 logits. Across 12 horizontal-pair applications, `param_map` reuses those same 3 logits, the stochastic analogue of weight tying in a CNN. This gives horizontal weight sharing (a convolution-like stencil) without an exact shift symmetry; there is no vertical shared kernel.\n",
+    "After the convolution comes column-then-row `PCNOT` pooling, which reduces the 16 pbits to 4 readout sites and adds two more shared logits of its own.\n",
     "\n",
-    "Column-then-row `PCNOT` pooling reduces 16 pbits to 4 readout sites, adding two more shared logits.\n",
-    "\n",
-    "Each gate is a convex combination (a probability-weighted blend) of the identity and a deterministic operation $B$, applied with probability $\\sigma(\\theta)$:\n",
+    "To count the logits, look at what a single one controls. Each gate is a convex combination (a probability-weighted blend) of the identity and a deterministic operation $B$, applied with probability $\\sigma(\\theta)$:\n",
     "\n",
     "$$G(\\theta)=\\underbrace{(1-\\sigma(\\theta))\\,I}_{\\vphantom{\\big|}\\text{do nothing}}+\\underbrace{\\sigma(\\theta)\\,B}_{\\vphantom{\\big|}\\text{apply }B}.$$\n",
     "\n",
-    "The mixing weight is the logistic $\\sigma(\\theta)=1/(1+e^{-\\theta})$, the gate-on probability. All told, the 4 kernel gates use 3 logits, the two pooling stages use 2 more, and 60 physical gates run on 5 trainable logits."
+    "The mixing weight is the logistic $\\sigma(\\theta)=1/(1+e^{-\\theta})$, the gate-on probability, so one logit sets one gate-on probability and nothing else. The two `PJUMP` gates in the kernel share logit 0, which means the 4 kernel gates need only 3 logits, and the two pooling stages contribute 2 more. That is 5 trainable logits driving 60 physical gates.\n"
    ]
   },
   {
@@ -343,15 +333,7 @@
    "id": "8c189139",
    "metadata": {},
    "source": [
-    "When we pick the initial gate-on probabilities below, `jax.scipy.special.logit` (the inverse sigmoid) converts them to logits."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "e1ff55e6",
-   "metadata": {},
-   "source": [
-    "The `build_scnn_circuit` function lays out the shared kernel and the two pooling stages."
+    "`build_scnn_circuit` lays out the shared kernel and the two pooling stages in one pass, appending a `param_map` entry next to every gate it creates, so the tying is written down in the same place as the wiring instead of being reconstructed afterwards."
    ]
   },
   {
@@ -412,7 +394,7 @@
    "id": "62441990",
    "metadata": {},
    "source": [
-    "Create `circuit`, `param_map`, and `readout_sites`, then choose the five initial shared logits."
+    "Building the circuit hands us the gate list, the `param_map`, and the 4 readout sites. We then choose the five starting values as gate-on probabilities, because probabilities are easier to reason about than logits, and pass them through `jax.scipy.special.logit`, the inverse sigmoid, to get the logits the model actually trains."
    ]
   },
   {
@@ -440,7 +422,7 @@
    "id": "fabec975",
    "metadata": {},
    "source": [
-    "Check the gate count, `readout_sites`, and number of shared logits before plotting."
+    "The logit accounting above is easy to get wrong, so we assert it against the circuit we just built: 60 physical gates, 4 readout sites, and 5 distinct entries in `param_map`. A miscounted loop shows up here as a failed assertion instead of a silent shape mismatch further down."
    ]
   },
   {
@@ -479,7 +461,7 @@
    "id": "b49f65a0",
    "metadata": {},
    "source": [
-    "This figure shows the four-gate stochastic kernel applied to one adjacent pixel pair. Orange marks the two-site `PJUMP` coupling gates, and slate marks the single-site gates, `PReset` and `PNOT`."
+    "Before wiring up the whole grid, we look at the kernel on its own, so the four-gate sequence is legible in one picture. Orange marks the two-site `PJUMP` coupling gates, and slate marks the single-site gates, `PReset` and `PNOT`."
    ]
   },
   {
@@ -527,9 +509,9 @@
    "id": "3c7953b1",
    "metadata": {},
    "source": [
-    "The weight-sharing schematic shows where the five logits appear in the full `circuit`. The next cells recover the spatial wiring from `circuit` and `param_map`, then draw it.\n",
+    "The kernel picture says nothing about where that kernel is reused, so we now draw the full `circuit` and show where its five logits appear. We recover the spatial wiring from `circuit` and `param_map` themselves rather than redeclaring it, which means the schematic can only show sharing the circuit actually has.\n",
     "\n",
-    "The 16 pbits are laid out on the $4\\times4$ grid. Each horizontal pair receives the same local kernel, and the two-stage `PCNOT` pooling funnels the state into 4 readout sites. Gold and copper distinguish the two `PCNOT` pooling stages."
+    "The 16 pbits sit on the $4\\times4$ grid, each horizontal pair receives the same local kernel, and the two-stage `PCNOT` pooling funnels the state into 4 readout sites. Gold and copper distinguish the two `PCNOT` pooling stages."
    ]
   },
   {
@@ -643,7 +625,7 @@
    "id": "41a4fd72",
    "metadata": {},
    "source": [
-    "The five line- and color-encoded parameter groups are free. Dark nodes mark the four readout sites. Every gate position sharing an encoding uses the same logit."
+    "Every gate position drawn with the same line style and color is driven by the same logit, so only five parameter groups are free in the entire layer, and the dark nodes mark the four readout sites the classifier will see."
    ]
   },
   {
@@ -653,9 +635,9 @@
    "source": [
     "## Training the kernel\n",
     "\n",
-    "To train through the sampler, we need a derivative that works with samples.\n",
+    "To train through the sampler, we need a derivative that works with samples. A parameter-shift estimator supplies one without differentiating the sampling step itself: it re-runs the circuit with a gate parameter forced to special values, then combines the resulting expectations into the derivative.\n",
     "\n",
-    "`BranchingSimulator` with `diff_method=\"param_shift_inf\"` and `num_samples=256` gives differentiable expected readouts. For a gate $G(\\theta)=(1-\\sigma(\\theta))I+\\sigma(\\theta)B$, the method evaluates the branches by clamping the gate logit to $-\\infty$ and $+\\infty$. Those limits force the identity branch and the $B$ branch deterministically.\n",
+    "`BranchingSimulator` with `diff_method=\"param_shift_inf\"` and `num_samples=256` gives differentiable expected readouts. For a gate $G(\\theta)=(1-\\sigma(\\theta))I+\\sigma(\\theta)B$, those special values are the two extremes of the logit, so the method evaluates the branches by clamping the gate logit to $-\\infty$ and $+\\infty$. Those limits force the identity branch and the $B$ branch deterministically.\n",
     "\n",
     "For a readout $O$, the derivative of the expected readout with respect to the gate logit is\n",
     "\n",
@@ -663,7 +645,7 @@
     "\\frac{\\mathrm{d}}{\\mathrm{d}\\theta}\\,\\mathbb E[O]\\;=\\;\\sigma(\\theta)\\,\\bigl(\\mathbb E[O\\mid B]-\\mathbb E[O]\\bigr),\n",
     "$$\n",
     "\n",
-    "where the $\\pm\\infty$ clamps supply the branch expectations $\\mathbb E[O\\mid I]$ and $\\mathbb E[O\\mid B]$, and $\\mathbb E[O]=(1-\\sigma(\\theta))\\,\\mathbb E[O\\mid I]+\\sigma(\\theta)\\,\\mathbb E[O\\mid B]$ is the expectation under the current circuit. Each expectation is estimated from samples. Unlike the finite-shift quantum rules in [Mitarai et al. (2018)](#ref-mitarai-2018) and [Schuld et al. (2019)](#ref-schuld-2019), this classical stochastic rule evaluates the two deterministic branches directly.\n"
+    "where the $\\pm\\infty$ clamps supply the branch expectations $\\mathbb E[O\\mid I]$ and $\\mathbb E[O\\mid B]$, and $\\mathbb E[O]=(1-\\sigma(\\theta))\\,\\mathbb E[O\\mid I]+\\sigma(\\theta)\\,\\mathbb E[O\\mid B]$ is the expectation under the current circuit. Each expectation is estimated from samples, which is why the gradient carries Monte Carlo noise and why we probe it with a finite difference later. Unlike the finite-shift quantum rules in [Mitarai et al. (2018)](#ref-mitarai-2018) and [Schuld et al. (2019)](#ref-schuld-2019), this classical stochastic rule evaluates the two deterministic branches directly.\n"
    ]
   },
   {
@@ -671,7 +653,7 @@
    "id": "467e1f7a",
    "metadata": {},
    "source": [
-    "Build the differentiable sampler `sim` and compile the circuit once into `scnn_template`. Each forward pass uses [`eqx.tree_at`](https://docs.kidger.site/equinox/api/manipulation/#equinox.tree_at) to swap the shared logits into that template instead of rebuilding the circuit."
+    "Rebuilding the circuit on every forward pass would repeat work that never changes, so we build the differentiable sampler `sim` once and compile the circuit once into `scnn_template`. Each forward pass then uses [`eqx.tree_at`](https://docs.kidger.site/equinox/api/manipulation/#equinox.tree_at) to swap the current shared logits into that template, which keeps the gate thetas tied to the trainable logits."
    ]
   },
   {
@@ -701,7 +683,7 @@
    "id": "b039e3c2",
    "metadata": {},
    "source": [
-    "The `SCNN` module broadcasts the 5 shared logits to all 60 gate positions, reads out 4 sites, and feeds them to a linear sigmoid classifier."
+    "`SCNN` is where weight sharing becomes an array operation. Indexing the 5 shared logits by `param_map` broadcasts them onto all 60 gate positions, so a gradient arriving at any position accumulates back into its shared logit, and the 4 readout sites are the only features the linear sigmoid classifier ever sees."
    ]
   },
   {
@@ -742,7 +724,7 @@
    "id": "433a37db",
    "metadata": {},
    "source": [
-    "Use `rng` to make a fixed seed-123 split of `patterns` into training and validation sets."
+    "We draw the split once, from `rng` and seed 123, so the same 6 images serve as validation for every epoch and the trace is never disturbed by a shifting split. The cell also prints the validation majority baseline, the accuracy you would get by always predicting whichever class is more common in those 6 images, which is the floor real learning has to clear."
    ]
   },
   {
@@ -787,14 +769,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "7b051feb",
-   "metadata": {},
-   "source": [
-    "Initialize the `SCNN` model from the structure-only `circuit` and the shared-logit wiring."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 19,
    "id": "def61d00",
@@ -821,7 +795,7 @@
    "id": "254e275c",
    "metadata": {},
    "source": [
-    "`optax.adam` updates only the trainable arrays in the Equinox model."
+    "Adam at a learning rate of 5e-2 does the updating, and `eqx.filter(model, eqx.is_inexact_array)` decides what it may touch: the 5 shared logits and the linear head, but not the integer `param_map` and readout indices, which are structure rather than parameters."
    ]
   },
   {
@@ -847,7 +821,9 @@
    "id": "f70c4286",
    "metadata": {},
    "source": [
-    "`bce_loss` computes binary cross-entropy over the batch; `loss_fn` wraps it with `eqx.filter_value_and_grad` to add the parameter-shift gradient."
+    "The objective is ordinary binary cross-entropy over the batch, with predictions clipped away from 0 and 1 so the logarithm stays finite. Wrapping `bce_loss` in `eqx.filter_value_and_grad` is what pulls the parameter-shift gradient back through the sampler, so `loss_fn` returns the loss and the gradient with respect to the shared logits together, and the undecorated `bce_loss` stays available because the finite-difference check later needs loss values only.\n",
+    "\n",
+    "Two thin wrappers finish the loop: `train_step` takes one Adam step, computing the loss and gradients and then applying the updates, and `evaluate` returns validation loss and accuracy for each epoch without changing the parameters."
    ]
   },
   {
@@ -880,14 +856,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "5dadf443",
-   "metadata": {},
-   "source": [
-    "`train_step` takes one Adam step: compute the loss and gradients, then apply the updates."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 22,
    "id": "8e2400be",
@@ -909,14 +877,6 @@
     "    )\n",
     "    model = eqx.apply_updates(model, updates)\n",
     "    return model, opt_state, loss"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d1f66568",
-   "metadata": {},
-   "source": [
-    "`evaluate` returns validation loss and accuracy for each epoch."
    ]
   },
   {
@@ -950,7 +910,7 @@
    "id": "7d03e1a2",
    "metadata": {},
    "source": [
-    "`fit_model` runs 90 full-batch epochs and records the six-example validation trace with seed 123."
+    "Training runs 90 full-batch epochs, and the one subtlety is randomness. `fit_model` splits the seed-123 key once per epoch so the sampler noise in the training step is independent of the noise in the evaluation, which keeps the recorded six-example validation trace from echoing the training samples. We then run it and report the final validation loss and accuracy for n=6."
    ]
   },
   {
@@ -979,14 +939,6 @@
     "        loss_history.append(val_loss)\n",
     "        acc_history.append(val_acc)\n",
     "    return model, opt_state, np.asarray(loss_history), np.asarray(acc_history)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d2780de6",
-   "metadata": {},
-   "source": [
-    "Run `fit_model`, then report the final validation loss and accuracy for n=6."
    ]
   },
   {
@@ -1025,7 +977,7 @@
    "id": "cba5c0b0",
    "metadata": {},
    "source": [
-    "For this fixed seed, the six-item validation set ends at 100% accuracy. Its accuracy changes in increments of $1/6$."
+    "For this fixed seed, the six-item validation set ends at 100% accuracy, which is a coarser claim than it sounds, because with six examples accuracy can only change in increments of $1/6$."
    ]
   },
   {
@@ -1035,15 +987,7 @@
    "source": [
     "### Gradient check\n",
     "\n",
-    "As a sanity check on one shared `PJUMP` logit (`LOGIT_IDX = 0`), the `param_shift_inf` gradient should agree with a finite-difference estimate up to Monte Carlo noise, the random scatter from finite sampling. In the next cells, we compute both gradients on one small batch and report the relative error. The check covers only one of the five logits, at 30% tolerance."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2f56e430",
-   "metadata": {},
-   "source": [
-    "Compute the analytic gradient for one shared `PJUMP` logit using a small bars-plus-stripes batch."
+    "A gradient that flows and a gradient that is correct are different things, and so far we have only seen the first. So we test one shared `PJUMP` logit (`LOGIT_IDX = 0`), whose `param_shift_inf` gradient should agree with a finite-difference estimate up to Monte Carlo noise, the random scatter that comes from estimating expectations with finitely many samples. In the next cells we compute the analytic gradient on one small batch of 4 bars and 4 stripes, probe the same logit numerically, and report the relative error. The check covers only one of the five logits, at 30% tolerance, so it is evidence that the differentiable path is wired correctly rather than a verification of all five."
    ]
   },
   {
@@ -1076,7 +1020,7 @@
    "id": "21e2752f",
    "metadata": {},
    "source": [
-    "`fd_grad` probes the same logit with a central finite difference, using a fresh `BranchingSimulator` at the requested sample count."
+    "The reference is a central finite difference on the same logit, a cruder estimate but one that never runs the parameter-shift code, so agreement between the two is real evidence rather than a tautology. `fd_grad` builds a fresh `BranchingSimulator` at the requested sample count for each probe, because the cure for a noisy comparison is more samples."
    ]
   },
   {
@@ -1118,7 +1062,7 @@
    "id": "c92cbfdc",
    "metadata": {},
    "source": [
-    "Compare the analytic gradient with a finite-difference estimate, retrying with more samples if Monte Carlo noise dominates."
+    "Now we compare the two numbers. The finite difference is itself a sample estimate, so a single probe can fail on noise alone, which is why we walk a ladder of probes at 256, 1024, and 2048 samples per side and stop at the first relative error under `REL_ERR_TOL = 0.30`. The assertion that follows uses that same tolerance, so a genuinely broken gradient path fails the notebook instead of passing quietly."
    ]
   },
   {
@@ -1160,14 +1104,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "8d6cb3fd",
-   "metadata": {},
-   "source": [
-    "Assert against the named tolerance used by the probe ladder."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 29,
    "id": "ebf0936a",
@@ -1202,7 +1138,7 @@
    "source": [
     "## Kernel parameter shifts\n",
     "\n",
-    "A nonzero shift shows that the gradient reached the shared kernel. The table lists the initial logit, trained logit, and shift for each shared gate."
+    "A model can reach good accuracy by training the linear head alone and leaving the kernel where it started, so accuracy on its own does not tell us the gradient reached the shared gates. The table lists the initial logit, the trained logit, and the shift for each shared gate, and a nonzero shift is what shows that the gradient reached the shared kernel. The cell asserts that the movement is real: an L2 shift above 1e-3, a maximum absolute shift above 0.05, and a final accuracy of at least 0.75."
    ]
   },
   {
@@ -1278,7 +1214,7 @@
    "source": [
     "## Training curve\n",
     "\n",
-    "The figure shows validation BCE and validation accuracy on the same six examples after every epoch. Accuracy moves in $1/6$ increments, and the 67% line is the seed-specific validation majority baseline. The inset encodes black pixels as 1 and white pixels as 0. This repeated validation trace is an optimization diagnostic, not an estimate from an untouched test set."
+    "Finally we look at what the optimizer was scored on: validation BCE and validation accuracy on the same six examples after every epoch. Accuracy moves in $1/6$ increments, so that panel climbs as a staircase, and the 67% line is the seed-specific validation majority baseline a trivial classifier would already reach. The inset encodes black pixels as 1 and white pixels as 0. Because those six images are scored every epoch rather than held back, this repeated validation trace is an optimization diagnostic, not an estimate from an untouched test set."
    ]
   },
   {
@@ -1373,9 +1309,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "You have now built a stochastic convolution layer that classifies bars-and-stripes images by taking gradients through the sampler.\n",
-    "\n",
-    "The image uses 16 p-bits, one per pixel, and the layer is a stochastic circuit over those p-bits.\n",
+    "You have now built a stochastic convolution layer over 16 p-bits, one per pixel, that classifies bars-and-stripes images by taking gradients through the sampler.\n",
     "\n",
     "- A four-gate kernel (`PJUMP`, `PReset`, `PNOT`, `PJUMP`) runs on every horizontal adjacent pixel pair, with `PCNOT` pooling down to 4 readout sites.\n",
     "- `param_map` ties all 60 physical gates to 5 shared logits, giving a convolution-like horizontal stencil rather than an exact shift symmetry.\n",
@@ -1387,7 +1321,7 @@
     "## References\n",
     "\n",
     "1. <span id=\"ref-mitarai-2018\"></span>Mitarai, K., Negoro, M., Kitagawa, M., Fujii, K. 2018. [*Quantum circuit learning*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.98.032309). Phys. Rev. A 98, 032309.\n",
-    "2. <span id=\"ref-schuld-2019\"></span>Schuld, M., Bergholm, V., Gogolin, C., Izaac, J., Killoran, N. 2019. [*Evaluating analytic gradients on quantum hardware*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.99.032331). Phys. Rev. A 99, 032331.\n"
+    "2. <span id=\"ref-schuld-2019\"></span>Schuld, M., Bergholm, V., Gogolin, C., Izaac, J., Killoran, N. 2019. [*Evaluating analytic gradients on quantum hardware*](https://journals.aps.org/pra/abstract/10.1103/PhysRevA.99.032331). Phys. Rev. A 99, 032331."
    ]
   }
  ],

--- a/examples/08_stochastic_convolutional_networks.ipynb
+++ b/examples/08_stochastic_convolutional_networks.ipynb
@@ -317,7 +317,7 @@
    "source": [
     "## Building the kernel circuit\n",
     "\n",
-    "Weight sharing is the whole point of this layer, so we should be precise about what is shared. The local kernel applies four gates to each adjacent horizontal pixel pair, `PJUMP`, `PReset`, `PNOT`, and `PJUMP`, and `param_map` points all 12 horizontal-pair applications of that kernel at the same logits, which is the stochastic analogue of weight tying in a CNN. The reuse runs across columns only, so we get horizontal weight sharing (a convolution-like stencil) rather than an exact shift symmetry, and there is no vertical shared kernel.\n",
+    "Weight sharing is the whole point of this layer, so we should be precise about what is shared. The local kernel applies four gates to each adjacent horizontal pixel pair, `PJUMP`, `PReset`, `PNOT`, and `PJUMP`, and `param_map` points all 12 horizontal-pair applications of that kernel at the same logits, which is the stochastic analogue of weight tying in a CNN. The reuse runs across columns only, so we get horizontal weight sharing (a convolution-like stencil) rather than an exact shift symmetry, and there's no vertical shared kernel.\n",
     "\n",
     "After the convolution comes column-then-row `PCNOT` pooling, which reduces the 16 pbits to 4 readout sites and adds two more shared logits of its own.\n",
     "\n",
@@ -325,7 +325,7 @@
     "\n",
     "$$G(\\theta)=\\underbrace{(1-\\sigma(\\theta))\\,I}_{\\vphantom{\\big|}\\text{do nothing}}+\\underbrace{\\sigma(\\theta)\\,B}_{\\vphantom{\\big|}\\text{apply }B}.$$\n",
     "\n",
-    "The mixing weight is the logistic $\\sigma(\\theta)=1/(1+e^{-\\theta})$, the gate-on probability, so one logit sets one gate-on probability and nothing else. The two `PJUMP` gates in the kernel share logit 0, which means the 4 kernel gates need only 3 logits, and the two pooling stages contribute 2 more. That is 5 trainable logits driving 60 physical gates.\n"
+    "The mixing weight is the logistic $\\sigma(\\theta)=1/(1+e^{-\\theta})$, the gate-on probability, so one logit sets one gate-on probability and nothing else. The two `PJUMP` gates in the kernel share logit 0, which means the 4 kernel gates need only 3 logits, and the two pooling stages contribute 2 more. That's 5 trainable logits driving 60 physical gates.\n"
    ]
   },
   {
@@ -987,7 +987,7 @@
    "source": [
     "### Gradient check\n",
     "\n",
-    "A gradient that flows and a gradient that is correct are different things, and so far we have only seen the first. So we test one shared `PJUMP` logit (`LOGIT_IDX = 0`), whose `param_shift_inf` gradient should agree with a finite-difference estimate up to Monte Carlo noise, the random scatter that comes from estimating expectations with finitely many samples. In the next cells we compute the analytic gradient on one small batch of 4 bars and 4 stripes, probe the same logit numerically, and report the relative error. The check covers only one of the five logits, at 30% tolerance, so it is evidence that the differentiable path is wired correctly rather than a verification of all five."
+    "A gradient that flows and a gradient that is correct are different things, and so far we have only seen the first. So we test one shared `PJUMP` logit (`LOGIT_IDX = 0`), whose `param_shift_inf` gradient should agree with a finite-difference estimate up to Monte Carlo noise, the random scatter that comes from estimating expectations with finitely many samples. In the next cells we compute the analytic gradient on one small batch of 4 bars and 4 stripes, probe the same logit numerically, and report the relative error. The check covers only one of the five logits, at 30% tolerance, so it's evidence that the differentiable path is wired correctly rather than a verification of all five."
    ]
   },
   {
@@ -1138,7 +1138,7 @@
    "source": [
     "## Kernel parameter shifts\n",
     "\n",
-    "A model can reach good accuracy by training the linear head alone and leaving the kernel where it started, so accuracy on its own does not tell us the gradient reached the shared gates. The table lists the initial logit, the trained logit, and the shift for each shared gate, and a nonzero shift is what shows that the gradient reached the shared kernel. The cell asserts that the movement is real: an L2 shift above 1e-3, a maximum absolute shift above 0.05, and a final accuracy of at least 0.75."
+    "A model can reach good accuracy by training the linear head alone and leaving the kernel where it started, so accuracy on its own doesn't tell us the gradient reached the shared gates. The table lists the initial logit, the trained logit, and the shift for each shared gate, and a nonzero shift is what shows that the gradient reached the shared kernel. The cell asserts that the movement is real: an L2 shift above 1e-3, a maximum absolute shift above 0.05, and a final accuracy of at least 0.75."
    ]
   },
   {

--- a/examples/09_stochastic_graph_networks.ipynb
+++ b/examples/09_stochastic_graph_networks.ipynb
@@ -23,13 +23,13 @@
    "id": "c48d4bf6",
    "metadata": {},
    "source": [
-    "In this tutorial, we train a **stochastic graph network** for MaxCut. MaxCut asks us to split a graph's nodes into two groups so that as many edges as possible have one endpoint in each group, and the number of such crossing edges is the cut we are trying to make large.\n",
+    "In this tutorial, we train a **stochastic graph network** for MaxCut. MaxCut asks us to split a graph's nodes into two groups so that as many edges as possible have one endpoint in each group, and the number of such crossing edges is the cut we're trying to make large.\n",
     "\n",
     "One **[probabilistic bit (p-bit)](https://doi.org/10.1063/1.4975355)**, a Bernoulli-valued state, sits on each graph node and records which of the two groups that node currently belongs to. The circuit places one edge-local `PISING` gate on each of the graph's 12 edges. A sweep applies those 12 gates sequentially in fixed edge-list order, and the circuit repeats that sweep 20 times.\n",
     "\n",
-    "The cut of any single sampled partition is a count rather than a differentiable function of the couplings, so we train them with the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992), a rule for learning from distributions you can sample but cannot differentiate through: draw samples from the circuit, score each one by its cut, and raise the probability of the samples that scored above the batch average. In this demonstration, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
+    "The cut of any single sampled partition is a count rather than a differentiable function of the couplings, so we train them with the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992), a rule for learning from distributions you can sample but can't differentiate through: draw samples from the circuit, score each one by its cut, and raise the probability of the samples that scored above the batch average. In this demonstration, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
     "\n",
-    "This tutorial uses Torx, JAX, Optax, and NumPy. The graph helper uses NetworkX. It assumes basic graph and probability notation.\n",
+    "This tutorial uses Torx, JAX, Optax, and NumPy, with NetworkX behind the graph helper, and it assumes you're comfortable with basic graph and probability notation.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li><strong>Torx:</strong> <code>StateVectorSimulator</code> computes the full classical probability vector for the 8-node circuit.</li><li><strong>Notebook code:</strong> JAX differentiates exact log probabilities in the REINFORCE surrogate, and Optax applies Adam updates.</li><li><strong>Computational helper:</strong> <code>examples/helpers/_nb09_maxcut.py</code> builds the circuit, exact diagnostic, graph reference, and result figures.</li><li><strong>Plot helper:</strong> <code>examples/helpers/_plots_schematics.py</code> draws the edge-local circuit primitive.</li></ul></details>\n",
     "\n",
@@ -263,7 +263,7 @@
    "source": [
     "## One PISING per edge\n",
     "\n",
-    "Before assembling the network, we look at the single gate it is tiled from and at the loss that gate has to lower.\n",
+    "Before assembling the network, we look at the single gate it's tiled from and at the loss that gate has to lower.\n",
     "\n",
     "We write each spin as $s_i = 2\\sigma_i - 1 \\in \\{-1, +1\\}$, so that maximizing the expected cut is the same as minimizing the loss\n",
     "\n",
@@ -273,9 +273,9 @@
     "\n",
     "where $\\langle s_i s_j\\rangle_{p_\\theta}$ is the spin-spin correlation under the circuit. A cut edge ($s_i \\neq s_j$) contributes $1$ and an aligned edge contributes $0$, so lowering $\\mathcal{L}$ makes endpoints disagree, which is exactly what an antiferromagnetic coupling does.\n",
     "\n",
-    "The primitive is the `PISING` operation: we construct `gate = PISING([i, j])` and supply the theta `[J, h_i, h_j, beta, dt]` separately to `get_matrix` or `build_circuit`. It is a $4\\times4$ column-stochastic [Glauber kernel](#ref-glauber-1963), a single-spin thermal flip rule, on a pair of p-bits. With local fields $h=0$ it biases the joint state toward agreement when $J>0$ and disagreement when $J<0$.\n",
+    "The primitive is the `PISING` operation: we construct `gate = PISING([i, j])` and supply the theta `[J, h_i, h_j, beta, dt]` separately to `get_matrix` or `build_circuit`. It's a $4\\times4$ column-stochastic [Glauber kernel](#ref-glauber-1963), a single-spin thermal flip rule, on a pair of p-bits. With local fields $h=0$ it biases the joint state toward agreement when $J>0$ and disagreement when $J<0$.\n",
     "\n",
-    "How hard each update pushes is set by the inverse temperature $\\beta$, where higher is greedier, together with the timestep $\\Delta t$. For this 3-regular 8-node graph, one sweep applies 12 `PISING` gates sequentially in the printed `edges` order, and the same fixed order repeats for 20 sweeps. The order matters because these stochastic matrices generally do not commute.\n",
+    "How hard each update pushes is set by the inverse temperature $\\beta$, where higher is greedier, together with the timestep $\\Delta t$. For this 3-regular 8-node graph, one sweep applies 12 `PISING` gates sequentially in the printed `edges` order, and the same fixed order repeats for 20 sweeps. The order matters because these stochastic matrices generally don't commute.\n",
     "\n",
     "The next cell constructs one edge-local kernel and inspects its stochastic matrix."
    ]
@@ -573,7 +573,7 @@
     "\n",
     "The code multiplies the centered same-batch surrogate by $M/(M-1)$, which exactly corrects the finite-batch factor introduced by reusing the samples in their own baseline and leaves the estimator unbiased.\n",
     "\n",
-    "The first curve is the batch-mean cut. That is the number the optimizer actually sees, so it is our evidence that training is working. The second curve is the exact expected cut, which we compute separately from the full 256-entry probability vector, never feed to a gradient, and plot only to confirm that the sampled objective is telling the truth."
+    "The first curve is the batch-mean cut. That's the number the optimizer actually sees, so it's our evidence that training is working. The second curve is the exact expected cut, which we compute separately from the full 256-entry probability vector, never feed to a gradient, and plot only to confirm that the sampled objective is telling the truth."
    ]
   },
   {
@@ -917,7 +917,7 @@
     "- The final exact expected cut exceeds both its value at initialization and the uniform baseline, which establishes that REINFORCE training, and not the circuit's starting point, produced the improvement.\n",
     "- More than half the trained probability mass sits on cuts within one edge of the optimum, which shows the circuit concentrates on good partitions instead of only shifting its average.\n",
     "- The most probable trained bitstring attains the brute-force optimum, so the mode of the learned distribution is an exact solution.\n",
-    "- Three further graph seeds (11, 23, and 41) each finish above their own initial and uniform values and reach at least 80% of their brute-force optimum, which shows the result does not depend on the single graph drawn with `GRAPH_SEED`."
+    "- Three further graph seeds (11, 23, and 41) each finish above their own initial and uniform values and reach at least 80% of their brute-force optimum, which shows the result doesn't depend on the single graph drawn with `GRAPH_SEED`."
    ]
   },
   {

--- a/examples/09_stochastic_graph_networks.ipynb
+++ b/examples/09_stochastic_graph_networks.ipynb
@@ -13,8 +13,8 @@
    "id": "107bd7b6",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We train MaxCut with 12 sequential <code>PISING</code> edge updates per sweep. A finite-batch-corrected REINFORCE estimator weights sampled cuts, while the exact Torx simulator supplies and differentiates the full probability vector used for each score.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We train a graph circuit for MaxCut, the problem of splitting a graph's nodes into two groups so that as many edges as possible run between the groups. One sweep applies 12 sequential <code>PISING</code> edge updates, and the circuit repeats that sweep 20 times. Training uses REINFORCE, which raises the probability of the sampled partitions that cut more edges than the batch average, and because the graph has only 8 nodes the exact Torx simulator supplies and differentiates the full probability vector behind every score.</p>\n",
     "</div>"
    ]
   },
@@ -23,11 +23,11 @@
    "id": "c48d4bf6",
    "metadata": {},
    "source": [
-    "In this tutorial, we train a **stochastic graph network** for MaxCut.\n",
+    "In this tutorial, we train a **stochastic graph network** for MaxCut. MaxCut asks us to split a graph's nodes into two groups so that as many edges as possible have one endpoint in each group, and the number of such crossing edges is the cut we are trying to make large.\n",
     "\n",
-    "One **[probabilistic bit (p-bit)](https://doi.org/10.1063/1.4975355)**, a Bernoulli-valued state, sits on each graph node. The circuit places one edge-local `PISING` gate on each of the graph's 12 edges. A sweep applies those 12 gates sequentially in fixed edge-list order, and the circuit repeats that sweep 20 times.\n",
+    "One **[probabilistic bit (p-bit)](https://doi.org/10.1063/1.4975355)**, a Bernoulli-valued state, sits on each graph node and records which of the two groups that node currently belongs to. The circuit places one edge-local `PISING` gate on each of the graph's 12 edges. A sweep applies those 12 gates sequentially in fixed edge-list order, and the circuit repeats that sweep 20 times.\n",
     "\n",
-    "We train the couplings with the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992): draw samples from the circuit, score each by its cut, and follow the score-function gradient. In this demonstration, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
+    "The cut of any single sampled partition is a count rather than a differentiable function of the couplings, so we train them with the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992), a rule for learning from distributions you can sample but cannot differentiate through: draw samples from the circuit, score each one by its cut, and raise the probability of the samples that scored above the batch average. In this demonstration, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
     "\n",
     "This tutorial uses Torx, JAX, Optax, and NumPy. The graph helper uses NetworkX. It assumes basic graph and probability notation.\n",
     "\n",
@@ -36,8 +36,8 @@
     "By the end, you'll be able to:\n",
     "\n",
     "- build a circuit with 12 sequential `PISING` edge updates per sweep and repeat it for 20 sweeps,\n",
-    "- estimate the expected-cut gradient with the corrected likelihood-based REINFORCE estimator used here, and\n",
-    "- train the edge couplings so the circuit puts more probability on high-cut partitions.\n"
+    "- estimate the expected-cut gradient from sampled bitstrings, using the batch's own mean cut as the baseline, and\n",
+    "- train the edge couplings so the circuit puts more probability on high-cut partitions."
    ]
   },
   {
@@ -53,15 +53,7 @@
     "- The readout is the cut value, the number of edges whose endpoints disagree.\n",
     "- Training raises the expected cut.\n",
     "\n",
-    "We estimate its gradient with REINFORCE. For a batch of $M>1$ bitstrings $x_m\\sim p_\\theta$, let $\\bar c$ be the same-batch mean cut. The unbiased finite-batch-corrected estimator is\n",
-    "\n",
-    "$$\n",
-    "\\nabla_\\theta\\,\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]\n",
-    "\\;\\approx\\;\n",
-    "\\frac{1}{M-1}\\sum_{m=1}^{M}\\bigl(\\mathrm{cut}(x_m)-\\bar c\\bigr)\\,\\nabla_\\theta\\log p_\\theta(x_m).\n",
-    "$$\n",
-    "\n",
-    "The factor $M/(M-1)$ corrects the bias introduced when each sample also contributes to the same-batch baseline. An `optax` optimizer then updates the couplings."
+    "The quantity we want to raise is an average over sampled bitstrings, and the cut of any one bitstring is a discrete count, which is the situation REINFORCE was designed for. It scores each sampled bitstring by its cut, subtracts the mean cut of the same batch as a baseline, and uses the difference to weight the gradient of that sample's log probability, so partitions that beat the batch average become more likely and the rest become less likely. Subtracting a baseline that those same samples produced would bias the estimate slightly, so we scale the result by a small correction factor that removes the bias exactly. We write the estimator out in full where the training loop implements it. An `optax` optimizer then applies the updates."
    ]
   },
   {
@@ -71,7 +63,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "The setup cells wire up the helper path and apply the shared figure style; the MaxCut utilities come from `examples/helpers/_nb09_maxcut.py`."
+    "The setup cells wire up the helper path and apply the shared figure style. The MaxCut utilities come from `examples/helpers/_nb09_maxcut.py`."
    ]
   },
   {
@@ -271,19 +263,19 @@
    "source": [
     "## One PISING per edge\n",
     "\n",
-    "A `PISING` gate gives the pairwise update on one graph edge.\n",
+    "Before assembling the network, we look at the single gate it is tiled from and at the loss that gate has to lower.\n",
     "\n",
-    "We write each spin as $s_i = 2\\sigma_i - 1 \\in \\{-1, +1\\}$. MaxCut maximizes the expected cut. Equivalently, we minimize the loss\n",
+    "We write each spin as $s_i = 2\\sigma_i - 1 \\in \\{-1, +1\\}$, so that maximizing the expected cut is the same as minimizing the loss\n",
     "\n",
     "$$\n",
     "\\mathcal{L} = \\underbrace{-\\,\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]}_{\\vphantom{\\big|}\\text{negative cut}} = -\\sum_{(i,j)\\in\\mathcal{E}}\\underbrace{\\frac{1 - \\langle s_i s_j\\rangle_{p_\\theta}}{2}}_{\\vphantom{\\big|}\\text{per-edge cut}},\n",
     "$$\n",
     "\n",
-    "where $\\langle s_i s_j\\rangle_{p_\\theta}$ is the spin-spin correlation under the circuit. A cut edge ($s_i \\neq s_j$) contributes $1$ and an aligned edge contributes $0$, so lowering $\\mathcal{L}$ makes endpoints disagree, which an antiferromagnetic coupling does.\n",
+    "where $\\langle s_i s_j\\rangle_{p_\\theta}$ is the spin-spin correlation under the circuit. A cut edge ($s_i \\neq s_j$) contributes $1$ and an aligned edge contributes $0$, so lowering $\\mathcal{L}$ makes endpoints disagree, which is exactly what an antiferromagnetic coupling does.\n",
     "\n",
     "The primitive is the `PISING` operation: we construct `gate = PISING([i, j])` and supply the theta `[J, h_i, h_j, beta, dt]` separately to `get_matrix` or `build_circuit`. It is a $4\\times4$ column-stochastic [Glauber kernel](#ref-glauber-1963), a single-spin thermal flip rule, on a pair of p-bits. With local fields $h=0$ it biases the joint state toward agreement when $J>0$ and disagreement when $J<0$.\n",
     "\n",
-    "The inverse temperature $\\beta$, where higher is greedier, and timestep $\\Delta t$ set how hard each update pushes. For this 3-regular 8-node graph, one sweep applies 12 `PISING` gates sequentially in the printed `edges` order. Their stochastic matrices generally do not commute, so order matters. The same fixed order repeats for 20 sweeps.\n",
+    "How hard each update pushes is set by the inverse temperature $\\beta$, where higher is greedier, together with the timestep $\\Delta t$. For this 3-regular 8-node graph, one sweep applies 12 `PISING` gates sequentially in the printed `edges` order, and the same fixed order repeats for 20 sweeps. The order matters because these stochastic matrices generally do not commute.\n",
     "\n",
     "The next cell constructs one edge-local kernel and inspects its stochastic matrix."
    ]
@@ -398,7 +390,7 @@
    "id": "1f44f291",
    "metadata": {},
    "source": [
-    "The schematic isolates one edge-local update. The full sweep is the fixed ordered list of 12 edges printed below, not 12 simultaneous gates."
+    "The schematic isolates the one edge-local update that the rest of the circuit is built from. A sweep is the fixed ordered list of 12 edges printed below rather than 12 simultaneous gates, so the picture shows a primitive, not a layer."
    ]
   },
   {
@@ -406,7 +398,7 @@
    "id": "fe7209a3",
    "metadata": {},
    "source": [
-    "At this size, the exact classical probability vector has only $2^8 = 256$ entries. We can compute the full distribution, the brute-force optimum, and the exact log-probability scores directly."
+    "The instance is small enough that we never have to guess at a reference. With 8 nodes the exact classical probability vector has only $2^8 = 256$ entries, so we can compute the full distribution, the brute-force optimum, and the exact log-probability scores directly, and every later claim can be checked against an exact number instead of an estimate."
    ]
   },
   {
@@ -484,6 +476,8 @@
    "source": [
     "## The exact classical probability vector\n",
     "\n",
+    "Everything downstream, both the training gradient and the diagnostic curve, comes out of one helper, so we build that helper first.\n",
+    "\n",
     "`make_expected_cut` returns two pure-`jax` functions of the couplings: `density(J)`, the circuit's exact 256-entry classical probability vector, and `expected_cut(J)`, the cut averaged over it. Its core is excerpted from `examples/helpers/_nb09_maxcut.py`:\n",
     "\n",
     "```python\n",
@@ -517,11 +511,11 @@
     "    return expected_cut, density\n",
     "```\n",
     "\n",
-    "Within each sweep, `DiscretePCircuit` applies the 12 `PISING` gates sequentially in `edges` order. It repeats that ordered sweep `REPS` times.\n",
+    "Within each sweep, `DiscretePCircuit` applies the 12 `PISING` gates sequentially in `edges` order, then repeats that ordered sweep `REPS` times.\n",
     "\n",
-    "Training draws samples from `density` and differentiates the selected entries of its exact full log-probability vector. `expected_cut` is not differentiated for updates. It records the exact simulator diagnostic plotted beside the sampled batch objective.\n",
+    "Training draws samples from `density` and differentiates the selected entries of its exact full log-probability vector, so gradients reach the couplings only through those sampled log probabilities, whereas `expected_cut` never touches an update and is evaluated purely to record the exact simulator diagnostic that we plot beside the sampled batch objective.\n",
     "\n",
-    "Before training, we evaluate that diagnostic at the initial couplings and compare it with the mean cut of a uniform random assignment and the brute-force optimum."
+    "Before training starts, we evaluate that diagnostic at the initial couplings and compare it with the mean cut of a uniform random assignment and with the brute-force optimum, which gives us the two reference levels the training curves are read against."
    ]
   },
   {
@@ -566,9 +560,9 @@
    "source": [
     "## Training by REINFORCE\n",
     "\n",
-    "We maximize $\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]$ with a likelihood-based REINFORCE estimator and `optax.adam`.\n",
+    "We now run the training loop and watch two curves, one that drives the optimizer and one that checks it.\n",
     "\n",
-    "Each step computes the exact full vector `density_fn(J)`, draws `NUM_SAMPLES` bitstrings from it, and differentiates the selected exact log probabilities. With $\\bar c$ as the same-batch mean cut, the implemented estimator is\n",
+    "We maximize $\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]$ with a likelihood-based REINFORCE estimator and `optax.adam`. Each step computes the exact full vector `density_fn(J)`, draws `NUM_SAMPLES` bitstrings from it, and differentiates the selected exact log probabilities. For a batch of $M>1$ bitstrings with $\\bar c$ the same-batch mean cut, the implemented estimator is\n",
     "\n",
     "$$\n",
     "\\nabla_\\theta\\,\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]\n",
@@ -577,7 +571,9 @@
     "\\qquad x_m\\sim p_\\theta.\n",
     "$$\n",
     "\n",
-    "The code multiplies the centered same-batch surrogate by $M/(M-1)$, exactly correcting its finite-batch factor. The sampled batch mean is recorded as training-objective evidence. The separately computed exact expected cut is recorded only as a diagnostic."
+    "The code multiplies the centered same-batch surrogate by $M/(M-1)$, which exactly corrects the finite-batch factor introduced by reusing the samples in their own baseline and leaves the estimator unbiased.\n",
+    "\n",
+    "The first curve is the batch-mean cut. That is the number the optimizer actually sees, so it is our evidence that training is working. The second curve is the exact expected cut, which we compute separately from the full 256-entry probability vector, never feed to a gradient, and plot only to confirm that the sampled objective is telling the truth."
    ]
   },
   {
@@ -711,7 +707,7 @@
    "id": "1ded9776",
    "metadata": {},
    "source": [
-    "The exact simulator diagnostic starts at step zero. The second curve is the sampled batch-mean objective observed before each update."
+    "Both curves rise together from about 6.5 to 9.99 against an optimum of 10, which is the agreement we wanted: the sampled objective the optimizer follows tracks the exact expected cut rather than drifting away from it. The exact diagnostic carries one extra point because we evaluate it at the initial couplings before any update, while the sampled batch mean is recorded from the batch drawn at each step."
    ]
   },
   {
@@ -721,9 +717,7 @@
    "source": [
     "## What the circuit learned\n",
     "\n",
-    "Training reshapes the whole output distribution.\n",
-    "\n",
-    "We compare the cut distribution of the trained circuit against the uniform baseline to see where each one puts its probability mass."
+    "Raising an average says nothing about where the probability went, so we now compare the exact cut distribution of the trained circuit against the uniform baseline."
    ]
   },
   {
@@ -814,7 +808,7 @@
    "id": "61594d92",
    "metadata": {},
    "source": [
-    "The learned distribution puts most of its probability on the highest cut values. The uniform baseline stays spread out well below the optimum."
+    "The trained circuit places 0.996 of its probability on the optimum itself and 0.997 within one edge of it, so training concentrated the distribution rather than merely nudging its mean. The uniform baseline stays spread around a mean cut of 6.00, far below the optimum of 10."
    ]
   },
   {
@@ -822,7 +816,7 @@
    "id": "ca77445c",
    "metadata": {},
    "source": [
-    "The most probable trained bitstring is the partition the circuit favors. We draw it with its cut edges highlighted."
+    "The distribution has a clear mode, so the natural question is which partition it is. We decode the most probable trained bitstring and draw it on the graph with its cut edges highlighted."
    ]
   },
   {
@@ -907,7 +901,7 @@
    "id": "48666211",
    "metadata": {},
    "source": [
-    "The partition plot shows the most probable learned bitstring. Gold edges cross the cut, and neutral gray edges remain uncut."
+    "Ten of the 12 edges are gold, which equals the brute-force optimum, so the mode of the trained distribution is an exact MaxCut solution. Gold edges cross the cut, and neutral gray edges join two nodes on the same side."
    ]
   },
   {
@@ -917,9 +911,13 @@
    "source": [
     "## Verification\n",
     "\n",
-    "The final checks collect the assumptions used above.\n",
+    "Each check below tests one claim the figures rest on against a reference we can compute exactly.\n",
     "\n",
-    "We check that the trained kernels are stochastic, REINFORCE training improved the expected cut past the uniform baseline, the trained distribution puts more than half its mass within one edge of the optimum, the most probable bitstring is optimal, and three additional graph seeds improve past their initial and uniform values and reach an explicit 80% of optimum threshold."
+    "- Every trained `PISING` matrix still has columns summing to one, which confirms the learned couplings describe a valid stochastic update rather than an arbitrary matrix.\n",
+    "- The final exact expected cut exceeds both its value at initialization and the uniform baseline, which establishes that REINFORCE training, and not the circuit's starting point, produced the improvement.\n",
+    "- More than half the trained probability mass sits on cuts within one edge of the optimum, which shows the circuit concentrates on good partitions instead of only shifting its average.\n",
+    "- The most probable trained bitstring attains the brute-force optimum, so the mode of the learned distribution is an exact solution.\n",
+    "- Three further graph seeds (11, 23, and 41) each finish above their own initial and uniform values and reach at least 80% of their brute-force optimum, which shows the result does not depend on the single graph drawn with `GRAPH_SEED`."
    ]
   },
   {
@@ -1048,12 +1046,12 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We built a stochastic graph network for MaxCut with one `PISING` gate per edge, then trained its couplings with a finite-batch-corrected REINFORCE estimator.\n",
+    "We built a stochastic graph network for MaxCut with one `PISING` gate per edge, then trained its couplings with REINFORCE.\n",
     "\n",
     "- Each sweep applies 12 column-stochastic Glauber updates sequentially in fixed edge-list order, then repeats that sweep 20 times.\n",
     "- The estimator samples from the exact Torx probability vector and differentiates its selected exact log probabilities. Multiplying the same-batch centered surrogate by $M/(M-1)$ removes its finite-batch bias.\n",
-    "- The figure separates the sampled batch objective from the exact expected-cut diagnostic, which starts at step zero.\n",
-    "- The exact learned distribution concentrates on high-cut partitions. Three additional graph seeds print initial, uniform, final, optimum, and final-to-optimum values.\n",
+    "- The training figure keeps the sampled batch objective, which is what the optimizer sees, separate from the exact expected-cut diagnostic, which we evaluate before the first update and so starts at step zero.\n",
+    "- The exact learned distribution concentrates on high-cut partitions, and three additional graph seeds print their initial, uniform, final, optimum, and final-to-optimum values so the result can be judged beyond one graph.\n",
     "\n",
     "See also:\n",
     "\n",

--- a/examples/10_pmode_gaussian_gates.ipynb
+++ b/examples/10_pmode_gaussian_gates.ipynb
@@ -13,8 +13,8 @@
    "id": "a3113be5",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We propagate a pmode's mean and covariance exactly through affine Gaussian stacks, while <code>MixtureGaussianGate</code> introduces discrete control and a non-Gaussian density. We check every gate with point clouds, analytic moments, and closed-form conditioning.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We propagate a pmode's mean and covariance exactly through affine Gaussian stacks, while <code>MixtureGaussianGate</code> introduces discrete control and a non-Gaussian density. We check the gates three ways: sampled point clouds, exact moment propagation, and closed-form conditioning.</p>\n",
     "</div>"
    ]
   },
@@ -23,13 +23,13 @@
    "id": "37852692",
    "metadata": {},
    "source": [
-    "In this tutorial, we build Torx's continuous **pmode** gate set and check it from a few angles.\n",
+    "In this tutorial we build Torx's continuous **pmode** gate set and check it three ways: sampled point clouds, exact moment propagation, and closed-form conditioning.\n",
     "\n",
-    "The pmode is Torx's continuous data primitive. A pmode site has a value in $\\mathbb{R}^N$, and we track its mean and [covariance](https://www.itl.nist.gov/div898/handbook/pmc/section5/pmc541.htm). The gates in this tutorial act on pmode sites.\n",
+    "The pmode is Torx's continuous data primitive. A pmode site has a value in $\\mathbb{R}^N$, and because a Gaussian is fixed by its first two moments, the mean and [covariance](https://www.itl.nist.gov/div898/handbook/pmc/section5/pmc541.htm) are all we track. Every gate in this tutorial acts on pmode sites.\n",
     "\n",
-    "The most general gate is `AffineGaussianGate`. It takes a point, applies a linear map, adds a bias, and adds Gaussian noise. The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` cover common choices of those parameters.\n",
+    "The most general of them is `AffineGaussianGate`, which takes a point, applies a linear map, adds a bias, and adds Gaussian noise. The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` fix some of those parameters to cover common choices.\n",
     "\n",
-    "A Gaussian stays Gaussian under this map, so it is enough to carry the mean and covariance through the circuit and let each gate update those two moments directly.\n",
+    "A Gaussian stays Gaussian under this map, so we never have to carry a density around. Carrying the mean and covariance through the circuit and letting each gate update those two moments is enough.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -38,7 +38,7 @@
     "- condition the joint distribution on one site in closed form, and\n",
     "- use `MixtureGaussianGate` with a discrete control to leave the Gaussian family.\n",
     "\n",
-    "These same primitives drive the linear-Gaussian state-space model (SSM) of [`11_gaussian_hierarchical_ssm.ipynb`](11_gaussian_hierarchical_ssm.ipynb) and the regime-switching diffusion process of [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb); [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb) builds a custom nonlinear Langevin gate on the same continuous pmode site.\n",
+    "These same primitives drive the linear-Gaussian state-space model (SSM) of [`11_gaussian_hierarchical_ssm.ipynb`](11_gaussian_hierarchical_ssm.ipynb) and the regime-switching diffusion process of [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb). On the same continuous pmode site, [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb) builds a custom nonlinear Langevin gate.\n",
     "\n"
    ]
   },
@@ -49,9 +49,9 @@
    "source": [
     "## Setup\n",
     "\n",
-    "We import Torx, JAX, and the notebook plotting helpers, then apply the shared figure style.\n",
+    "We import Torx, JAX, and the notebook plotting helpers, then apply the shared figure style so every figure below reads on the same palette.\n",
     "\n",
-    "The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` are public `torx.psc` gates, imported here alongside the general `AffineGaussianGate`.\n",
+    "The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` are public `torx.psc` gates, so we import them here alongside the general `AffineGaussianGate` instead of assembling them by hand.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul>\n",
     "<li>Torx gates sample, propagate moments, and compute the exact point-conditioned posterior.</li>\n",
@@ -161,7 +161,7 @@
    "id": "80b4c35d",
    "metadata": {},
    "source": [
-    "The next helpers sample a gate on many input points and compare empirical moments with analytic ones."
+    "Every check in this tutorial has the same shape: push a cloud of points through a gate, then compare the sampled mean and covariance against the analytic prediction. The helpers below do that work once so the gate cells stay short."
    ]
   },
   {
@@ -309,7 +309,7 @@
    "source": [
     "## The gate set\n",
     "\n",
-    "Here is the full affine Gaussian gate. It maps a point $x$ to a new point $x'$:\n",
+    "We start with the one gate that contains all the others. `AffineGaussianGate` maps a point $x$ to a new point $x'$:\n",
     "\n",
     "$$\n",
     "x' = \\underbrace{M x}_{\\vphantom{\\big|}\\text{linear map}} + \\mathbf{d} + \\varepsilon,\n",
@@ -323,7 +323,7 @@
     "\\mu \\mapsto M\\mu + \\mathbf{d}, \\qquad \\Sigma \\mapsto \\underbrace{M\\Sigma M^\\top}_{\\vphantom{\\big|}\\text{covariance}} + \\Delta .\n",
     "$$\n",
     "\n",
-    "The mean transforms affinely. The diagonal noise covariance $\\Delta$ adds straight into $\\Sigma$; correlated covariance can come through the $M\\Sigma M^\\top$ term.\n",
+    "The mean transforms affinely, and because the gate's own noise is diagonal, the noise covariance $\\Delta$ adds straight into $\\Sigma$ without correlating anything. Correlations arrive through the other term instead: the linear map folds the whole input covariance through $M\\Sigma M^\\top$, so composing gates can correlate coordinates that started out independent.\n",
     "\n",
     "Gates compose by the affine composition law:\n",
     "\n",
@@ -342,9 +342,9 @@
     "| `Mix` ($\\theta$) | $R(\\theta)$ | $0$ | $0$ | rotate two sites |\n",
     "| `Diffuse` ($\\theta = \\log(2 D\\, dt)$) | $I$ | $0$ | $2 D\\, dt\\, I$ | Brownian diffusion, following [Einstein (1905)](#ref-einstein-1905) |\n",
     "\n",
-    "`Displace`, `Scale`, and `Mix` are deterministic affine-Gaussian channels (no added noise); `Diffuse` is the additive Brownian-noise channel. All four are public `torx.psc` gates that specialize `AffineGaussianGate`.\n",
+    "Three of those four are deterministic affine-Gaussian channels that add no noise at all: `Displace`, `Scale`, and `Mix`. `Diffuse` is the one additive Brownian-noise channel. All four are public `torx.psc` gates that specialize `AffineGaussianGate`.\n",
     "\n",
-    "The next example uses a shear-rotation with anisotropic diagonal noise (spread differs by direction), which none of the specialized gates produce alone.\n"
+    "To exercise the general gate we need parameters that no single specialized gate produces, so the next example uses a shear-rotation with anisotropic diagonal noise, meaning the spread differs by direction.\n"
    ]
   },
   {
@@ -399,7 +399,7 @@
    "id": "5c8d7dba",
    "metadata": {},
    "source": [
-    "Now we sample the gate over a standard-normal input cloud."
+    "We now sample that gate over a standard-normal input cloud, which lets us see the deformation and check the sampled moments against the analytic ones at the same time."
    ]
   },
   {
@@ -498,7 +498,7 @@
    "id": "745f1410",
    "metadata": {},
    "source": [
-    "Each slate curve is a Mahalanobis-radius-1 ellipse. For a two-dimensional Gaussian it encloses about 39% of the probability, not the 68% associated with a one-dimensional one-standard-deviation interval. The samples follow the predicted shear-rotation and anisotropic spread."
+    "The outlined ellipse on each panel, drawn in the slate blue this gallery reserves for exact results, is a Mahalanobis-radius-1 contour of the analytic covariance. For a two-dimensional Gaussian it encloses about 39% of the probability, not the 68% associated with a one-dimensional one-standard-deviation interval. The orange samples fill it as predicted, following the shear-rotation and the anisotropic spread."
    ]
   },
   {
@@ -506,7 +506,7 @@
    "id": "626cc6d3",
    "metadata": {},
    "source": [
-    "The named constructors make common affine Gaussian transformations explicit. Each gate stores the sites it acts on; its numeric parameters live in separate `theta` arrays. A `HybridPCircuit` then composes the four gates into one layer that repeats four times."
+    "Now we build a stack from the named constructors, which make the common affine Gaussian transformations explicit. Each gate stores only the sites it acts on, and its numeric parameters live in separate `theta` arrays, so structure and values stay independent. A `HybridPCircuit` then composes the four gates into one layer that repeats four times."
    ]
   },
   {
@@ -625,7 +625,7 @@
    "id": "0679d259",
    "metadata": {},
    "source": [
-    "Each repetition reuses the same four-gate layer. The whole stack still composes to one affine Gaussian map."
+    "The schematic draws one layer, and all four repetitions reuse it unchanged, so the whole stack still composes to a single affine Gaussian map."
    ]
   },
   {
@@ -635,11 +635,11 @@
    "source": [
     "### The effect of each gate\n",
     "\n",
-    "Each named gate changes one part of the moments.\n",
+    "Each named gate touches one part of the moments, which is easiest to see one gate at a time.\n",
     "\n",
-    "`Diffuse` adds to $\\Sigma$, so it broadens the cloud along $x_0$. `Displace` adds to $\\mu$, so it shifts. `Scale` multiplies site 0, so it stretches along $x_0$. `Mix` rotates the two sites, so it correlates them.\n",
+    "`Diffuse` adds to $\\Sigma$, so it broadens the cloud along $x_0$, and `Scale` multiplies site 0, so it stretches along that same axis. `Displace` adds to $\\mu$, so it shifts the cloud without changing its shape, while `Mix` rotates the two sites and thereby correlates them.\n",
     "\n",
-    "To see those effects separately, we apply each gate to the same input cloud and check the sampled moments against each gate's analytic update; the print reports the largest mean and covariance errors. The figure then shows the moment change panel by panel."
+    "To separate those four effects we apply each gate to the same input cloud and compare the sampled moments against that gate's analytic update. The print reports the largest mean and covariance error per gate, and the cell raises past its tolerance rather than reporting a mismatch quietly."
    ]
   },
   {
@@ -805,7 +805,7 @@
    "id": "6e265033",
    "metadata": {},
    "source": [
-    "Each panel deforms the same input cloud, shown faintly with a dashed ellipse, as its moment update predicts: broaden, shift, stretch, and tilt into correlation."
+    "Every panel keeps the same input cloud underneath, faint and outlined with a dashed ellipse, so each deformation can be read against one reference: broaden, shift, stretch, and tilt into correlation."
    ]
   },
   {
@@ -815,9 +815,9 @@
    "source": [
     "## Exact moment propagation\n",
     "\n",
-    "Sampling clouds is a useful sanity check on the gates, but because a stack of affine Gaussian gates is still one affine Gaussian map, we can carry the moments forward without drawing samples.\n",
+    "Sampling clouds is a useful sanity check on the gates, but because a stack of affine Gaussian gates is still one affine Gaussian map, we can carry the moments forward without drawing samples at all.\n",
     "\n",
-    "`AffineGaussianSimulator` propagates the mean and covariance analytically through the composed map. For a Gaussian, those two moments determine the density."
+    "`AffineGaussianSimulator` propagates the mean and covariance analytically through the composed map, and for a Gaussian those two moments determine the density, so the propagated pair is the entire distribution."
    ]
   },
   {
@@ -953,7 +953,7 @@
    "id": "46fd641a",
    "metadata": {},
    "source": [
-    "The marked mean in the joint plot and the two one-dimensional marginals come from one propagated mean and covariance, with no samples underneath."
+    "Both figures come from that one propagated mean and covariance with no samples underneath, so the marked mean in the joint plot and the two one-dimensional marginals carry no Monte Carlo error to explain away."
    ]
   },
   {
@@ -963,7 +963,7 @@
    "source": [
     "## Conditioning on one site\n",
     "\n",
-    "The `Mix` gate introduced off-diagonal covariance between site 0 and site 1, so the two sites are correlated, and an observation of one site changes the distribution of the other.\n",
+    "The `Mix` gate put off-diagonal entries into the covariance between site 0 and site 1, so the two sites are correlated and an observation of one changes the distribution of the other. For a Gaussian we can write that updated distribution down exactly.\n",
     "\n",
     "Given an exact value $y_1$ for site 1, the Gaussian posterior on site 0 follows the Schur-complement identity in [Petersen and Pedersen (2012)](#ref-matrix-cookbook):\n",
     "\n",
@@ -973,7 +973,7 @@
     "\\Sigma_{0\\mid 1} = \\Sigma_{00} - \\Sigma_{01}\\Sigma_{11}^{-1}\\Sigma_{10}.\n",
     "$$\n",
     "\n",
-    "`AffineGaussianSimulator.condition` computes this exact point-conditioned posterior at $y_1 = 0.35$, the value later named `Y_OBS`. This is a closed-form conditional distribution, not a request to draw samples that land exactly on a zero-width point. The later histogram selects a finite band around `Y_OBS` only as a Monte Carlo approximation to this exact curve."
+    "`AffineGaussianSimulator.condition` evaluates that identity at $y_1 = 0.35$, the value later named `Y_OBS`, and returns the point-conditioned posterior mean and covariance for site 0."
    ]
   },
   {
@@ -1057,11 +1057,12 @@
    "source": [
     "## Monte Carlo comparison\n",
     "\n",
-    "The analytic moments are exact, so they give us a clean reference.\n",
+    "The propagated moments are exact, which makes them a clean reference for the sampler.\n",
     "\n",
-    "`HybridPCircuit.sample_multiple` draws full trajectories. By the Monte Carlo principle introduced by [Metropolis and Ulam (1949)](#ref-metropolis-ulam), empirical means and covariances approach their analytic values as the sample count grows.\n",
+    "`HybridPCircuit.sample_multiple` draws full trajectories, and empirical means and covariances approach their analytic values as the sample count grows ([Metropolis and Ulam, 1949](#ref-metropolis-ulam)). The useful question is therefore how closely it agrees at a finite sample count, which is what a tolerance scaled to that count answers.\n",
     "\n",
-    "We draw 20,000 samples and check the empirical moments against six-standard-error tolerances at this seed.\n"
+    "We draw 20,000 samples and check each empirical moment against a six-standard-error tolerance at this seed.\n",
+    "\n"
    ]
   },
   {
@@ -1260,7 +1261,7 @@
    "id": "bab07828",
    "metadata": {},
    "source": [
-    "The lower panel reports each sample-minus-exact residual divided by its six-standard-error tolerance. Every point stays inside the shaded tolerance band."
+    "The lower panel reports each sample-minus-exact residual divided by its six-standard-error tolerance, and all five residuals stay inside the shaded band, so the sampler reproduces the exact moments to within Monte Carlo error at 20,000 samples."
    ]
   },
   {
@@ -1270,9 +1271,9 @@
    "source": [
     "## Comparing the posterior to samples\n",
     "\n",
-    "The sample-cloud figure shows the prior mean and a dashed line at the exact observation $y_1 = 0.35$.\n",
+    "We now look for the same conditioning in the samples themselves. The first figure marks the prior mean and draws a dashed line at the exact observation $y_1 = 0.35$, which is the slice the posterior conditions on.\n",
     "\n",
-    "The posterior figure compares the exact point-conditioned density over site 0 with a finite-band Monte Carlo approximation. The gray histogram keeps trajectories satisfying $|x_1 - Y_{\\mathrm{OBS}}| < \\mathrm{BAND}$, so it approaches rather than equals the zero-width conditional distribution."
+    "An exact point condition has zero width, so no finite set of samples falls on that line. Instead we keep the trajectories satisfying $|x_1 - Y_{\\mathrm{OBS}}| < \\mathrm{BAND}$ and histogram them in gray, which makes that narrow band the Monte Carlo stand-in for the exact conditional density over site 0."
    ]
   },
   {
@@ -1395,7 +1396,7 @@
    "id": "015b6317",
    "metadata": {},
    "source": [
-    "The exact posterior narrows site 0. The selected histogram provides finite-band sampling evidence for that point-conditioned result."
+    "The exact posterior over site 0 is visibly narrower than the prior, and the band-selected histogram sits under it, so the samples support the narrowing that `condition` computed in closed form."
    ]
   },
   {
@@ -1405,9 +1406,9 @@
    "source": [
     "## Mixtures: leaving the Gaussian family\n",
     "\n",
-    "Pure affine Gaussian gates can only produce Gaussians.\n",
+    "Every gate so far has been affine with Gaussian noise, so every distribution so far has been Gaussian. Leaving that family takes a gate whose behavior depends on a discrete choice.\n",
     "\n",
-    "`MixtureGaussianGate` uses a **pdit** (a $d$-state discrete site) to select one of `K` Gaussian components. The gate adds the selected component's mean and Gaussian noise to the current continuous value. Starting from $x=0$, marginalizing the control gives a mixture density:\n",
+    "`MixtureGaussianGate` is that gate. It uses a **pdit** (a $d$-state discrete site) as a control to select one of `K` Gaussian components, then adds the selected component's mean and Gaussian noise to the current continuous value. Starting from $x=0$, marginalizing the control gives a mixture density:\n",
     "\n",
     "$$\n",
     "\\rho(x) = \\sum_{k} \\pi_k\\,\\mathcal{N}(x;\\, \\mu_k,\\, \\sigma_k^2),\n",
@@ -1415,9 +1416,13 @@
     "\n",
     "which is no longer Gaussian.\n",
     "\n",
-    "The notebook helper `plot_mixture_density` (from `examples/helpers/_plots_fields.py`) evaluates the exact PDF from the gate's `means` and `log_vars` together with the separate control `weights` over a grid. `MixtureGaussianGate` itself only carries `means` and `log_vars`; the component weights are a separate control distribution, which we encode in this binary pdit demonstration through `PditShift`, a gate that flips the control from 0 to 1 with probability set by its log-odds `theta`. The sampler below draws the pdit control with the declared weights, then lets `MixtureGaussianGate` draw the component-conditioned Gaussian sample.\n",
+    "The control needs a gate of its own. `PditShift` flips the pdit from 0 to 1 with a probability set by its log-odds `theta`, which is how this binary demonstration encodes the component weights.\n",
     "\n",
-    "This is the non-Gaussian primitive used by the continuous arc. The full process is developed in [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb).\n"
+    "That leaves a clean split of parameters. `MixtureGaussianGate` carries the component `means` and `log_vars`, and the control distribution carries the weights $\\pi_k$. The sampler below draws the pdit control with the declared weights, then lets `MixtureGaussianGate` draw the component-conditioned Gaussian sample.\n",
+    "\n",
+    "The notebook helper `plot_mixture_density`, from `examples/helpers/_plots_fields.py`, draws the figure and evaluates the exact PDF itself, reading the gate's `means` and `log_vars` together with the separate control `weights` over a display grid.\n",
+    "\n",
+    "This is the non-Gaussian primitive the continuous arc is built on, and the full process is developed in [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb).\n"
    ]
   },
   {
@@ -1659,7 +1664,7 @@
    "id": "85f6e6ea",
    "metadata": {},
    "source": [
-    "The figure shows a bimodal histogram matching the exact two-component mixture density."
+    "The sampled histogram is bimodal and follows the exact two-component mixture curve, so the discrete control has taken this continuous site out of the Gaussian family."
    ]
   },
   {
@@ -1669,11 +1674,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We built the pmode Gaussian gate set and checked it from a few angles.\n",
+    "We built the pmode Gaussian gate set and checked it three ways: sampled point clouds, exact moment propagation, and closed-form conditioning.\n",
     "\n",
-    "`AffineGaussianGate` is the general continuous gate. The `Displace`, `Scale`, `Mix`, and `Diffuse` gates are specialized affine Gaussian maps for common cases. Because stacks of these gates remain affine Gaussian, `AffineGaussianSimulator` can propagate moments exactly without sampling.\n",
+    "`AffineGaussianGate` is the general continuous gate, and `Displace`, `Scale`, `Mix`, and `Diffuse` are specialized affine Gaussian maps for common cases. Because stacks of these gates remain affine Gaussian, `AffineGaussianSimulator` can propagate moments exactly without sampling.\n",
     "\n",
-    "The sample-based checks with `HybridPCircuit.sample_multiple` land within their Monte Carlo tolerances. The `condition` method gives the exact point-conditioned Gaussian posterior, while a separately labeled finite-band sample selection approximates it. Finally, `MixtureGaussianGate` adds a discrete control and produces a mixture density, so the model can leave the Gaussian family.\n",
+    "The sampled moments from `HybridPCircuit.sample_multiple` agree with those exact moments inside their six-standard-error Monte Carlo tolerances at 20,000 samples. The `condition` method gives the exact point-conditioned Gaussian posterior, while the separately labeled finite-band sample selection approximates that same curve from trajectories. Finally, `MixtureGaussianGate` adds a discrete control and produces a mixture density, so the model can leave the Gaussian family.\n",
     "\n",
     "To continue, see [`11_gaussian_hierarchical_ssm.ipynb`](11_gaussian_hierarchical_ssm.ipynb) for the Kalman and Rauch-Tung-Striebel (RTS) smoother, and [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb) for the regime-switching mixture process."
    ]

--- a/examples/11_gaussian_hierarchical_ssm.ipynb
+++ b/examples/11_gaussian_hierarchical_ssm.ipynb
@@ -13,9 +13,9 @@
    "id": "1f5bb7ca",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We unroll a <a href=\"#ref-kalman-1960\">linear-Gaussian state-space model</a> into affine gates with time-homogeneous parameters, condition on all observations, and inspect an offline event score from the exact <a href=\"#ref-rts-1965\">smoothed posterior</a>. A dense NumPy recursion plus a Schur complement independently verify the prior propagation and conditioning algebra.</p>\n",
-    "</div>\n"
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>A hidden 3-dimensional drive is visible only through six noisy channels, so we unroll a <a href=\"#ref-kalman-1960\">linear-Gaussian state-space model</a> into affine gates with time-homogeneous parameters, condition on all observations, and read an offline event score that says, at each time step, whether the drive was active. Because that score is allowed to use the whole trial, it comes from the exact <a href=\"#ref-rts-1965\">smoothed posterior</a> rather than from a running estimate. A dense NumPy recursion plus a Schur complement independently verify the prior propagation and conditioning algebra.</p>\n",
+    "</div>"
    ]
   },
   {
@@ -23,22 +23,23 @@
    "id": "ea3dd444",
    "metadata": {},
    "source": [
-    "In this tutorial, we build a [linear-Gaussian state-space model](#ref-kalman-1960) in Torx and read an offline event score from its exact smoothed posterior.\n",
+    "Suppose something is going on that you cannot measure. Call it the **drive**: one hidden quantity that rises while an event of interest is under way and falls when it is not. You never see the drive itself, but you do have six noisy sensors that each respond to it in their own way. The question this tutorial answers is whether you can reconstruct, after the trial is over, the time steps during which the drive was active.\n",
     "\n",
-    "Six synthetic Gaussian observation channels are generated directly from a 3-dimensional latent state. Each latent state and observation is a **pmode**, a continuous Torx site valued in $\\mathbb{R}^N$ and tracked by its mean and covariance.\n",
+    "We answer it with a [linear-Gaussian state-space model](#ref-kalman-1960) built in Torx. We generate six synthetic Gaussian observation channels directly from a 3-dimensional latent state, condition the model on all of them, and read an **event score** off the result: one number per time step, near 1 where the model believes the drive was active and near 0 where it believes it was not. Because we generated the data ourselves we also hold the true latent trajectory, and that is what lets us check the score at the end.\n",
     "\n",
-    "This example is time-homogeneous: the same dynamics and emission parameters apply at every time step. Torx represents that assumption by explicitly unrolling the sequence into per-step gates while reusing the same transition and emission `theta` values.\n",
+    "Each latent state and observation is a **pmode**, a continuous Torx site valued in $\\mathbb{R}^N$ and tracked by its mean and covariance.\n",
     "\n",
-    "The full program has an initial gate, shared-parameter transition gates, and per-step emission gates. All are `AffineGaussianGate` instances.\n",
+    "This example is time-homogeneous, which means the same dynamics and emission parameters apply at every time step. Torx represents that assumption by explicitly unrolling the sequence into per-step gates while reusing the same transition and emission `theta` values.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates latent states using the full observation sequence, including observations from later time steps. It is an offline, acausal calculation.</p></details>\n",
+    "The full program is therefore an initial gate, shared-parameter transition gates, and per-step emission gates, all of them `AffineGaussianGate` instances.\n",
+    "\n",
+    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates latent states using the full observation sequence, including observations from later time steps, so it is an offline, acausal calculation. Filtering is the online counterpart: it estimates the state at each step from that step's observation and the earlier ones only, so it can run as data arrives. We smooth here because we are analyzing a finished trial and want the best estimate at every step rather than a causal one.</p></details>\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
     "- build one initial gate, one gate per transition, and one per emission,\n",
     "- condition on all observations to get the exact smoothed posterior, equivalent to [Kalman filtering (1960)](#ref-kalman-1960) followed by [Rauch-Tung-Striebel smoothing (1965)](#ref-rts-1965), and\n",
-    "- run a one-seed oracle-axis sanity check against a dense NumPy prior recursion and conditioning formula.\n",
-    "\n"
+    "- run a one-seed sanity check that the smoother recovered the hidden drive, using a dense NumPy prior recursion and conditioning formula as the reference."
    ]
   },
   {
@@ -48,7 +49,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "The setup cells import dependencies and define `_det_log_var`, a material helper that assigns exact zero variance to deterministic passthrough coordinates.\n",
+    "We import the dependencies and define one small helper, `_det_log_var`, which returns the log-variance of a noise-free affine channel so that deterministic passthrough coordinates get exact zero variance instead of a small positive one.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul>\n",
     "<li>Torx gates build the joint Gaussian and compute the exact smoothed posterior.</li>\n",
@@ -187,9 +188,9 @@
    "source": [
     "## The model\n",
     "\n",
-    "A 3-dimensional latent state (`latent_dim = 3`) carries the hidden drive.\n",
+    "Before we build anything we need to state exactly what generates the data, because every gate in the next section is a direct translation of one line of the equations below.\n",
     "\n",
-    "Six synthetic Gaussian observation channels (`num_channels = 6`) are generated directly by the observation equation below.\n",
+    "A 3-dimensional latent state (`latent_dim = 3`) carries the hidden drive, and the six synthetic Gaussian observation channels (`num_channels = 6`) that we actually get to see are generated directly by the observation equation below.\n",
     "\n",
     "The model is linear-Gaussian:\n",
     "\n",
@@ -201,21 +202,17 @@
     "x_t = C\\,z_t + \\eta_t.\n",
     "$$\n",
     "\n",
-    "The initial state draws from the prior $\\mathcal{N}(m_0,P_0)$. The process noise is $\\varepsilon_t \\sim \\mathcal{N}(0,Q)$, the measurement noise is $\\eta_t \\sim \\mathcal{N}(0,R)$, and $C$ is the observation map.\n",
+    "The initial state draws from the prior $\\mathcal{N}(m_0,P_0)$, the process noise is $\\varepsilon_t \\sim \\mathcal{N}(0,Q)$, the measurement noise is $\\eta_t \\sim \\mathcal{N}(0,R)$, and $C$ is the observation map.\n",
     "\n",
-    "The transition sub-product uses the same transition parameters at every adjacent pair:\n",
+    "Nothing on either right-hand side depends on $t$, so a single set of parameters describes the whole sequence. The transition sub-product makes that reuse explicit by using the same transition parameters at every adjacent pair:\n",
     "\n",
     "$$\n",
     "G_{\\mathrm{trans}}(\\theta)=\\underbrace{\\prod_{t=1}^{T-1}}_{\\vphantom{\\big|}\\text{$T-1$ transitions}} \\underbrace{K_\\theta^{(t-1,\\,t)}}_{\\vphantom{\\big|}\\text{same theta reused}} .\n",
     "$$\n",
     "\n",
-    "Each factor $K_\\theta^{(t-1,\\,t)}$ is the transition kernel from latent site $t-1$ to latent site $t$, and every factor reuses the same `theta`.\n",
+    "Each factor $K_\\theta^{(t-1,\\,t)}$ is the transition kernel from latent site $t-1$ to latent site $t$, and every transition gate reuses the same fixed `theta` values while the built circuit stays explicitly unrolled into one gate per transition and one gate per emission.\n",
     "\n",
-    "This sharing is inference-time reuse of the same fixed `theta` values: the built circuit is explicitly unrolled into one gate per transition and one gate per emission, and each gate aliases the same `theta` dictionary. There is no compact scan primitive and no trainable parameter tying involved. Under a normal JAX optimizer the repeated gates would receive separate gradients, so training would require an explicit gate-to-theta reduction. The initial gate carries the prior $\\mathcal{N}(m_0,P_0)$, and the emission gates carry the observation map $C$ and measurement noise $R$.\n",
-    "\n",
-    "One length-$T$ sequence is therefore one initial gate, $T-1$ transition gates that reuse the same transition `theta`, and $T$ emission gates that reuse the same emission `theta`.\n",
-    "\n",
-    "The exact-inference construction below uses `log_var = -inf` on deterministic passthrough coordinates. That is exact for conditioning, but not differentiable through those coordinates. Clamp to a large finite-negative value before training with gradients.\n"
+    "The initial gate carries the prior $\\mathcal{N}(m_0,P_0)$, and the emission gates carry the observation map $C$ and the measurement noise $R$. One length-$T$ sequence is therefore one initial gate, $T-1$ transition gates that reuse the same transition `theta`, and $T$ emission gates that reuse the same emission `theta`."
    ]
   },
   {
@@ -223,7 +220,7 @@
    "id": "38eecac9",
    "metadata": {},
    "source": [
-    "The next cell sets the dimensions that define the latent and observation sites, plus the fixed `intent_axis` used later to score the drive."
+    "First we fix the size of the problem: how many time steps there are, how wide the latent state is, and how many channels observe it. The same cell fixes `intent_axis`, the direction in latent space along which we read the drive as a single number, because both the hidden labels and the score later project onto it."
    ]
   },
   {
@@ -254,7 +251,7 @@
    "id": "76bcadb9",
    "metadata": {},
    "source": [
-    "The transition matrix `A` specifies the latent dynamics from one time step to the next."
+    "The transition matrix `A` specifies the latent dynamics from one time step to the next, which makes it the only part of the model that carries information forward in time."
    ]
   },
   {
@@ -285,7 +282,7 @@
    "id": "48381ab5",
    "metadata": {},
    "source": [
-    "The observation matrix `C` maps the latent state into six continuous channels."
+    "The observation matrix `C` maps the latent state into six continuous channels, one row per channel. Every row mixes all three latent coordinates, so no single channel is a clean view of the drive."
    ]
   },
   {
@@ -319,7 +316,7 @@
    "id": "61ca9e21",
    "metadata": {},
    "source": [
-    "The prior mean `m0` and the diagonal covariance parameters set the initial uncertainty (`P0_diag`), process noise (`Q_diag`), and measurement noise (`R_diag`)."
+    "What remains are the scales that decide how hard the recovery problem is. The prior mean `m0` and the diagonal covariance parameters set the initial uncertainty (`P0_diag`), the process noise that perturbs the latent state at every step (`Q_diag`), and the measurement noise added to each channel (`R_diag`)."
    ]
   },
   {
@@ -347,7 +344,7 @@
    "id": "6c057e7a",
    "metadata": {},
    "source": [
-    "`simulate_lgssm` draws one latent trajectory and six Gaussian observation channels with plain NumPy."
+    "With every parameter fixed we can generate a trial. `simulate_lgssm` draws one latent trajectory and six Gaussian observation channels with plain NumPy, following the two model equations line for line."
    ]
   },
   {
@@ -382,7 +379,7 @@
    "id": "a972e19b",
    "metadata": {},
    "source": [
-    "A synthetic Gaussian trial supplies `observations` for conditioning and hidden `true_event` labels for the one-seed sanity check."
+    "Running it once gives us both halves of the experiment: a synthetic Gaussian trial whose `observations` we condition on, and the hidden `true_event` labels that we set aside for the one-seed sanity check at the end."
    ]
   },
   {
@@ -427,7 +424,7 @@
    "id": "6a41a5a7",
    "metadata": {},
    "source": [
-    "A shape check catches simulation mistakes before the circuit uses the data."
+    "A shape check catches simulation mistakes here, while the arrays are still readable, instead of later as a dimension error inside the circuit."
    ]
   },
   {
@@ -453,7 +450,7 @@
    "id": "363e1c34",
    "metadata": {},
    "source": [
-    "The printed `true_event_rate` gives the `majority_baseline_acc` used later for the detector comparison."
+    "The printed `true_event_rate` also fixes `majority_baseline_acc`, the accuracy you would reach by always guessing the more common class. That is the bar the score has to clear in the detector comparison later, since beating it is the minimum evidence that the posterior carries real information about the drive."
    ]
   },
   {
@@ -463,15 +460,15 @@
    "source": [
     "## Building the circuit\n",
     "\n",
-    "Each time index has one latent pmode and one observation pmode.\n",
+    "Now we turn those equations into gates. Each time index has one latent pmode and one observation pmode, and every gate writes one new site while copying the site it read.\n",
     "\n",
-    "The transition gates implement the kernel $K_\\theta^{(t-1,\\,t)}$ above; the initial and emission gates carry the prior and the observation model:\n",
+    "The transition gates implement the kernel $K_\\theta^{(t-1,\\,t)}$ above, and the initial and emission gates carry the prior and the observation model:\n",
     "\n",
     "- Initial gate ($t=0$): encodes the prior $z_0 \\sim \\mathcal{N}(m_0, P_0)$ as a single-site `AffineGaussianGate`.\n",
     "- Transition gate ($t=1\\ldots T-1$): uses a block matrix that copies $z_{t-1}$ and writes $z_t = A z_{t-1}$, with process noise $Q$ on the new site.\n",
     "- Emission gate ($t=0\\ldots T-1$): uses a block matrix that copies $z_t$ and writes $x_t = C z_t$, with measurement noise $R$ on the observation site.\n",
     "\n",
-    "Passthrough coordinates use `log_var = -inf` via the visible `_det_log_var` helper above, so they are deterministic copies. The block structure carries the model, and the gate list repeats it across time by aliasing the same fixed `theta`."
+    "Passthrough coordinates take `log_var = -inf` via the visible `_det_log_var` helper above, which is what makes them exact deterministic copies. The block structure carries the model, and the gate list repeats it across time by aliasing the same fixed `theta`."
    ]
   },
   {
@@ -479,7 +476,7 @@
    "id": "53f05081",
    "metadata": {},
    "source": [
-    "The matrices `transition_matrix` and `emission_matrix` make the deterministic passthrough coordinates explicit."
+    "Both gate types work the same way, so we build their matrices together. The matrices `transition_matrix` and `emission_matrix` make the deterministic passthrough coordinates explicit, which is what lets a single affine gate both copy a site and write the next one beside it."
    ]
   },
   {
@@ -518,7 +515,7 @@
    "id": "540b3fe0",
    "metadata": {},
    "source": [
-    "The initial gate `initial_gate` writes the Gaussian prior onto the first latent site."
+    "The first gate has nothing to read from, so `initial_gate` simply writes the Gaussian prior onto the first latent site."
    ]
   },
   {
@@ -551,7 +548,11 @@
    "id": "8297b190",
    "metadata": {},
    "source": [
-    "The transition gates in `transition_gates` unroll adjacent time steps while reusing the same transition parameter dictionary.\n"
+    "Next come the transitions. The transition gates in `transition_gates` unroll adjacent time steps, and each one aliases the same transition parameter dictionary rather than owning a copy of it.\n",
+    "\n",
+    "<div class=\"note\"><span class=\"note-t\">Before you train</span>\n",
+    "<p>That sharing is inference-time reuse of the same fixed <code>theta</code> values, not trainable parameter tying, and no compact scan primitive is involved. Under a normal JAX optimizer the repeated gates would receive separate gradients, so training would require an explicit gate-to-theta reduction. The passthrough coordinates are the second obstacle: <code>log_var = -inf</code> is exact for conditioning but not differentiable through those coordinates, so clamp it to a large finite-negative value before training with gradients.</p>\n",
+    "</div>"
    ]
   },
   {
@@ -593,7 +594,7 @@
    "id": "77c487f6",
    "metadata": {},
    "source": [
-    "The emission gates in `emission_gates` attach one observed pmode to each latent time step."
+    "Emissions follow the same pattern in the other direction, so the emission gates in `emission_gates` attach one observed pmode to each latent time step."
    ]
   },
   {
@@ -635,7 +636,7 @@
    "id": "955ef561",
    "metadata": {},
    "source": [
-    "`HybridPCircuit` combines the gate groups into the full unrolled circuit, with one `theta` per gate collected in a matching list."
+    "`HybridPCircuit` combines the gate groups into the full unrolled circuit. The parameters stay outside it, one `theta` per gate collected in a matching list, which is why `thetas` has to be exactly as long as `circuit.gates`."
    ]
   },
   {
@@ -675,7 +676,7 @@
    "id": "4ae51e75",
    "metadata": {},
    "source": [
-    "A dimension check confirms the latent and observed site layout in `circuit`."
+    "A site layout this repetitive is easy to get wrong by one, so a dimension check confirms the latent and observed site layout in `circuit` before anything reads from it."
    ]
   },
   {
@@ -700,15 +701,9 @@
    "id": "2e4212ad",
    "metadata": {},
    "source": [
-    "The printed count confirms that one initial gate, 31 transition gates, and 32 emission gates represent the model."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "d0188fa1",
-   "metadata": {},
-   "source": [
-    "One time slice contains a transition followed by an emission. The directed schematic labels the parameters, written coordinates, and passthrough wires."
+    "The printed count confirms that one initial gate, 31 transition gates, and 32 emission gates represent the model.\n",
+    "\n",
+    "One time slice contains a transition followed by an emission, and because the other 31 slices repeat it exactly, we draw that slice once as a directed schematic."
    ]
   },
   {
@@ -755,7 +750,7 @@
    "id": "438f1941",
    "metadata": {},
    "source": [
-    "The slice writes $z_t$ with transition parameters $A,Q$, then writes $x_t$ with emission parameters $C,R$ while passing the source coordinates through."
+    "Reading the schematic left to right, the slice writes $z_t$ with the transition parameters $A,Q$, then writes $x_t$ with the emission parameters $C,R$, while the labeled passthrough wires carry the source coordinates through untouched."
    ]
   },
   {
@@ -765,17 +760,11 @@
    "source": [
     "## Exact posterior\n",
     "\n",
-    "For a linear-Gaussian model, conditioning the joint Gaussian on the full observation sequence gives the same smoothed posterior as [Kalman filtering (1960)](#ref-kalman-1960) followed by the backward pass of [Rauch, Tung, and Striebel (1965)](#ref-rts-1965).\n",
+    "We can now ask the model what the latent drive was, given everything we observed. For a linear-Gaussian model that answer involves no approximation: conditioning the joint Gaussian on the full observation sequence gives the same smoothed posterior as the classical two-pass recursion, which runs [Kalman filtering (1960)](#ref-kalman-1960) forward through the data to get a causal estimate at each step, then makes the backward pass of [Rauch, Tung, and Striebel (1965)](#ref-rts-1965) to revise each of those estimates using the observations that arrived after it.\n",
     "\n",
-    "`AffineGaussianSimulator.condition` conditions on all 32 observations at once. The result is exact for this model, offline, and acausal because each latent estimate can use later observations."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "46c4e686",
-   "metadata": {},
-   "source": [
-    "We compile the circuit for `AffineGaussianSimulator`, then condition on the observed pmodes in `observed` and query the latent pmodes in `latent_sites`."
+    "`AffineGaussianSimulator.condition` reaches the same result in one step, conditioning on all 32 observations at once. The result is exact for this model, offline, and acausal because each latent estimate can use later observations.\n",
+    "\n",
+    "So we compile the circuit for `AffineGaussianSimulator`, then condition on the observed pmodes in `observed` and query the latent pmodes in `latent_sites`."
    ]
   },
   {
@@ -832,7 +821,7 @@
    "id": "66cc2dbb",
    "metadata": {},
    "source": [
-    "A dense NumPy baseline independently propagates the LGSSM moments from `(A, C, Q, R, m0, P0)` and then applies the Schur-complement conditioning formula. Torx must match both the dense prior and dense posterior to within the relative and absolute tolerances asserted below.\n"
+    "Exact is a strong claim, so we test it against code that shares nothing with the gates. A dense NumPy baseline independently propagates the LGSSM moments from `(A, C, Q, R, m0, P0)` and then applies the Schur-complement conditioning formula, which gives us a separate reference for the prior and for the posterior. Torx must match both the dense prior and dense posterior to within the relative and absolute tolerances asserted below."
    ]
   },
   {
@@ -907,7 +896,7 @@
    "id": "f97a69a1",
    "metadata": {},
    "source": [
-    "First, propagate the Torx prior through every site and check it against the dense joint moments."
+    "First, propagate the Torx prior through every site and check it against the dense joint moments. Testing the prior on its own isolates the propagation algebra, so a failure here cannot be blamed on the conditioning step."
    ]
   },
   {
@@ -939,7 +928,7 @@
    "id": "df87d55c",
    "metadata": {},
    "source": [
-    "Then condition the dense joint on the observations. The Schur complement gives the reference posterior mean and covariance for the Torx result to match."
+    "Then condition the dense joint on the same observations. The Schur complement gives the reference posterior mean and covariance for the Torx result to match, and the assertion below confirms that it does, to a relative tolerance of `1e-5`."
    ]
   },
   {
@@ -1013,7 +1002,7 @@
    "id": "bd666dcb",
    "metadata": {},
    "source": [
-    "A structural check bins the smoothed covariance into per-timestep blocks. Most of the mass should sit on the diagonal, with the nearest-neighbor lag dominating the off-diagonal terms."
+    "The posterior links every pair of time steps, but for dynamics this local the link should weaken as the gap grows. To see whether it does, a structural check bins the smoothed covariance into per-timestep blocks and tests two expectations: most of the mass should sit on the diagonal, and among the off-diagonal terms the nearest-neighbor lag should dominate. The printed mean block norms for lags 0 to 4 are the evidence."
    ]
   },
   {
@@ -1066,7 +1055,7 @@
    "id": "27bfa39a",
    "metadata": {},
    "source": [
-    "The next cell computes the model log-evidence from the dense reference: the log-probability of the observed data under the model."
+    "A single number summarizes how well the model explains this trial at all. The next cell computes the model log-evidence from the dense reference: the log-probability of the observed data under the model, with the latent states marginalized away."
    ]
   },
   {
@@ -1115,7 +1104,7 @@
    "id": "2e14be81",
    "metadata": {},
    "source": [
-    "The printed `log_evidence` scores this observed trial under the dense reference model. Compare candidate models only on the same observations and with the same likelihood conventions."
+    "The printed `log_evidence` scores this observed trial under the dense reference model. It only means something in comparison, so compare candidate models only on the same observations and with the same likelihood conventions."
    ]
   },
   {
@@ -1125,19 +1114,13 @@
    "source": [
     "## Offline event-score sanity check\n",
     "\n",
-    "Projecting `posterior_mean` onto `intent_axis` gives a scalar latent drive. Each step's per-site covariance marginal gives the variance of that projection.\n",
+    "One question is left: did the smoother actually recover the hidden drive? To answer it we project `posterior_mean` onto `intent_axis`, which collapses each 3-dimensional smoothed state into the scalar latent drive we care about. Projecting each step's per-site covariance marginal along the same direction gives the variance of that projection, so every point comes with an uncertainty.\n",
     "\n",
-    "`intent_axis` is fixed in advance and also defines the hidden labels. The result is therefore a one-seed oracle-axis latent-recovery sanity check, not a decoder benchmark.\n",
+    "Two facts limit what a good result here would prove. `intent_axis` is fixed in advance and is also the axis that defines the hidden labels, so the score and the labels are read along the very same direction, which is the friendliest arrangement possible. On top of that we run a single seed. Together they make this a check that the circuit and its conditioning recover a latent signal, rather than a measurement of how a detector would behave on data it had not been handed the answer to.\n",
     "\n",
-    "The binary prediction uses the median of the complete smoothed trajectory. Both the threshold and smoothed posterior use future time bins, making this a retrospective full-trial analysis."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a92e4cf2",
-   "metadata": {},
-   "source": [
-    "The posterior drive `posterior_drive` and its standard deviation `posterior_drive_std` come from the smoothed latent moments."
+    "The binary prediction uses the median of the complete smoothed trajectory as its threshold. Both that threshold and the smoothed posterior use future time bins, which makes this a retrospective full-trial analysis rather than anything you could run online.\n",
+    "\n",
+    "The smoothed latent moments give us the posterior drive `posterior_drive` and its standard deviation `posterior_drive_std`."
    ]
   },
   {
@@ -1170,7 +1153,7 @@
    "id": "9e0c9cab",
    "metadata": {},
    "source": [
-    "The logistic transform is an uncalibrated display score centered on the full-trial median. Its 0.5 decision is identical to `posterior_drive > detection_threshold`."
+    "The logistic transform is an uncalibrated display score centered on the full-trial median, so read it as an ordering rather than as a probability. Its 0.5 decision is identical to `posterior_drive > detection_threshold`."
    ]
   },
   {
@@ -1198,7 +1181,7 @@
    "id": "b5d67a1e",
    "metadata": {},
    "source": [
-    "For this one seeded oracle-axis check, accuracy, [AUC](https://doi.org/10.1016/j.patrec.2005.10.010), precision, recall, and confusion counts summarize latent-drive recovery. Their scope is this synthetic trial only."
+    "For this one seeded check on the oracle axis, we summarize latent-drive recovery with accuracy, [AUC](https://doi.org/10.1016/j.patrec.2005.10.010) (the chance that a randomly chosen active step scores above a randomly chosen inactive one), precision, recall, and confusion counts. Their scope is this synthetic trial only."
    ]
   },
   {
@@ -1318,7 +1301,7 @@
    "id": "e1b93b0e",
    "metadata": {},
    "source": [
-    "These metrics describe one seeded synthetic trajectory on the same oracle axis used to define the labels. They are a circuit sanity check, not evidence of general detector performance.\n"
+    "All of these numbers describe one seeded synthetic trajectory scored along the same oracle axis that defined its labels, so they confirm that the circuit recovers the drive rather than showing what a detector would do in general."
    ]
   },
   {
@@ -1326,7 +1309,7 @@
    "id": "c51c5b1f",
    "metadata": {},
    "source": [
-    "The first plot shows the six synthetic Gaussian observation channels, with gray bands on time steps where the true drive is positive."
+    "It helps to see what the model has to work with before looking at what it recovered. The first plot shows the six synthetic Gaussian observation channels, with gray bands on time steps where the true drive is positive."
    ]
   },
   {
@@ -1373,7 +1356,7 @@
    "id": "6c1a03b5",
    "metadata": {},
    "source": [
-    "The gray bands identify the active event steps used only for evaluation."
+    "Because each channel is a different row of `C`, the same drive appears with a different sign and amplitude in every trace, which is why recovery needs all six of them. The gray bands identify the active event steps used only for evaluation."
    ]
   },
   {
@@ -1381,7 +1364,7 @@
    "id": "0aa899e4",
    "metadata": {},
    "source": [
-    "The next plot compares `true_drive` with the offline Torx-smoothed `posterior_drive`, both projected onto `intent_axis`. It also shows the $\\pm 2\\sigma$ marginal band and the dashed full-trial median threshold.\n",
+    "Now we put the recovered drive next to the truth. The next plot compares `true_drive` with the offline Torx-smoothed `posterior_drive`, both projected onto `intent_axis`. It also shows the $\\pm 2\\sigma$ marginal band and the dashed full-trial median threshold.\n",
     "\n",
     "The smoother and threshold use the complete 32-step trial."
    ]
@@ -1435,7 +1418,7 @@
    "id": "e82ffe59",
    "metadata": {},
    "source": [
-    "The posterior mean tracks the latent drive in this seeded trial. The marginal uncertainty widens near the boundaries, where fewer observations surround a latent state."
+    "The posterior mean tracks the latent drive in this seeded trial, and the marginal uncertainty widens near the boundaries, where fewer observations surround a latent state."
    ]
   },
   {
@@ -1443,7 +1426,7 @@
    "id": "9a9a5014",
    "metadata": {},
    "source": [
-    "The covariance plot shows the Frobenius norm of each $3 \\times 3$ timestep block. Diagonal cells describe same-step uncertainty, the nearest-neighbor band is the strongest off-diagonal coupling, and longer-lag block norms are smaller in the check above.\n"
+    "The last structural question is how far across time the posterior ties states together. The covariance plot shows the Frobenius norm of each $3 \\times 3$ timestep block, so diagonal cells describe same-step uncertainty and any bright off-diagonal band means the smoother has linked states that far apart."
    ]
   },
   {
@@ -1490,7 +1473,7 @@
    "id": "fe5b660d",
    "metadata": {},
    "source": [
-    "The block-norm covariance remains concentrated near the diagonal, as expected for local time-homogeneous dynamics."
+    "The block-norm covariance remains concentrated near the diagonal, with the nearest-neighbor band the strongest off-diagonal coupling and longer-lag block norms smaller, matching the lag means printed in the check above. That is what local time-homogeneous dynamics should produce."
    ]
   },
   {
@@ -1498,7 +1481,7 @@
    "id": "ac78226f",
    "metadata": {},
    "source": [
-    "The final plot shows the uncalibrated offline score and the resulting binary event bars for this one-seed oracle-axis sanity check."
+    "Finally we look at the score itself. The last plot shows the uncalibrated offline score and the resulting binary event bars for this one-seed oracle-axis sanity check."
    ]
   },
   {
@@ -1546,7 +1529,7 @@
    "id": "76509771",
    "metadata": {},
    "source": [
-    "The predicted bars align with most active intervals in this seeded oracle-axis check."
+    "The predicted bars align with most active intervals, at the accuracy printed above for this seeded oracle-axis check."
    ]
   },
   {
@@ -1556,15 +1539,15 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We built a time-homogeneous linear-Gaussian state-space model in Torx and inspected an offline score from its exact smoothed posterior.\n",
+    "We started with a drive we could not measure and six noisy channels that could, and we finished with one score per time step saying when that drive was active. Getting there took a time-homogeneous linear-Gaussian state-space model built in Torx and an offline score read from its exact smoothed posterior.\n",
     "\n",
     "- The model is represented as 64 `AffineGaussianGate` instances, one initial gate plus one gate per transition and emission.\n",
-    "- Transition and emission gates alias fixed `theta` dictionaries at inference time while the circuit remains explicitly unrolled.\n",
+    "- Transition and emission gates alias fixed `theta` dictionaries at inference time while the circuit remains explicitly unrolled, which keeps the sharing free to build but explicit to train.\n",
     "- `AffineGaussianSimulator.condition` returns the exact offline, acausal smoothed posterior and matches the dense NumPy reference to a relative tolerance of `1e-5`.\n",
-    "- The median-threshold metrics are a one-seed oracle-axis sanity check, and the logistic output is an uncalibrated score.\n",
-    "- Exact `-inf` passthrough log-variances are appropriate here but must be clamped before gradient training.\n",
+    "- The median-threshold metrics are a one-seed oracle-axis sanity check, because the axis that scores the drive is the axis that defined the labels, and the logistic output is an uncalibrated score.\n",
+    "- Exact `-inf` passthrough log-variances are what make the conditioning exact here, but they must be clamped before gradient training.\n",
     "\n",
-    "This tutorial applies the affine-Gaussian density layer of [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb) to a time series. To continue, work through [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb).\n"
+    "This tutorial applies the affine-Gaussian density layer of [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb) to a time series. To continue, work through [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb)."
    ]
   },
   {

--- a/examples/11_gaussian_hierarchical_ssm.ipynb
+++ b/examples/11_gaussian_hierarchical_ssm.ipynb
@@ -23,9 +23,9 @@
    "id": "ea3dd444",
    "metadata": {},
    "source": [
-    "Suppose something is going on that you cannot measure. Call it the **drive**: one hidden quantity that rises while an event of interest is under way and falls when it is not. You never see the drive itself, but you do have six noisy sensors that each respond to it in their own way. The question this tutorial answers is whether you can reconstruct, after the trial is over, the time steps during which the drive was active.\n",
+    "Suppose something is going on that you can't measure. Call it the **drive**: one hidden quantity that rises while an event of interest is under way and falls when it isn't. You never see the drive itself, but you do have six noisy sensors that each respond to it in their own way. The question this tutorial answers is whether you can reconstruct, after the trial is over, the time steps during which the drive was active.\n",
     "\n",
-    "We answer it with a [linear-Gaussian state-space model](#ref-kalman-1960) built in Torx. We generate six synthetic Gaussian observation channels directly from a 3-dimensional latent state, condition the model on all of them, and read an **event score** off the result: one number per time step, near 1 where the model believes the drive was active and near 0 where it believes it was not. Because we generated the data ourselves we also hold the true latent trajectory, and that is what lets us check the score at the end.\n",
+    "We answer it with a [linear-Gaussian state-space model](#ref-kalman-1960) built in Torx. We generate six synthetic Gaussian observation channels directly from a 3-dimensional latent state, condition the model on all of them, and read an **event score** off the result: one number per time step, near 1 where the model believes the drive was active and near 0 where it believes it wasn't. Because we generated the data ourselves we also hold the true latent trajectory, and that's what lets us check the score at the end.\n",
     "\n",
     "Each latent state and observation is a **pmode**, a continuous Torx site valued in $\\mathbb{R}^N$ and tracked by its mean and covariance.\n",
     "\n",
@@ -33,7 +33,7 @@
     "\n",
     "The full program is therefore an initial gate, shared-parameter transition gates, and per-step emission gates, all of them `AffineGaussianGate` instances.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates latent states using the full observation sequence, including observations from later time steps, so it is an offline, acausal calculation. Filtering is the online counterpart: it estimates the state at each step from that step's observation and the earlier ones only, so it can run as data arrives. We smooth here because we are analyzing a finished trial and want the best estimate at every step rather than a causal one.</p></details>\n",
+    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates latent states using the full observation sequence, including observations from later time steps, so it's an offline, acausal calculation. Filtering is the online counterpart: it estimates the state at each step from that step's observation and the earlier ones only, so it can run as data arrives. We smooth here because we're analyzing a finished trial and want the best estimate at every step rather than a causal one.</p></details>\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -450,7 +450,7 @@
    "id": "363e1c34",
    "metadata": {},
    "source": [
-    "The printed `true_event_rate` also fixes `majority_baseline_acc`, the accuracy you would reach by always guessing the more common class. That is the bar the score has to clear in the detector comparison later, since beating it is the minimum evidence that the posterior carries real information about the drive."
+    "The printed `true_event_rate` also fixes `majority_baseline_acc`, the accuracy you would reach by always guessing the more common class. That's the bar the score has to clear in the detector comparison later, since beating it is the minimum evidence that the posterior carries real information about the drive."
    ]
   },
   {
@@ -896,7 +896,7 @@
    "id": "f97a69a1",
    "metadata": {},
    "source": [
-    "First, propagate the Torx prior through every site and check it against the dense joint moments. Testing the prior on its own isolates the propagation algebra, so a failure here cannot be blamed on the conditioning step."
+    "First, propagate the Torx prior through every site and check it against the dense joint moments. Testing the prior on its own isolates the propagation algebra, so a failure here can't be blamed on the conditioning step."
    ]
   },
   {
@@ -1116,7 +1116,7 @@
     "\n",
     "One question is left: did the smoother actually recover the hidden drive? To answer it we project `posterior_mean` onto `intent_axis`, which collapses each 3-dimensional smoothed state into the scalar latent drive we care about. Projecting each step's per-site covariance marginal along the same direction gives the variance of that projection, so every point comes with an uncertainty.\n",
     "\n",
-    "Two facts limit what a good result here would prove. `intent_axis` is fixed in advance and is also the axis that defines the hidden labels, so the score and the labels are read along the very same direction, which is the friendliest arrangement possible. On top of that we run a single seed. Together they make this a check that the circuit and its conditioning recover a latent signal, rather than a measurement of how a detector would behave on data it had not been handed the answer to.\n",
+    "Two facts limit what a good result here would prove. `intent_axis` is fixed in advance and is also the axis that defines the hidden labels, so the score and the labels are read along the very same direction, which is the friendliest arrangement possible, and on top of that we run a single seed. Together those two limits make this a check that the circuit and its conditioning recover a latent signal, rather than a measurement of how a detector would behave on data it had not been handed the answer to.\n",
     "\n",
     "The binary prediction uses the median of the complete smoothed trajectory as its threshold. Both that threshold and the smoothed posterior use future time bins, which makes this a retrospective full-trial analysis rather than anything you could run online.\n",
     "\n",
@@ -1153,7 +1153,7 @@
    "id": "9e0c9cab",
    "metadata": {},
    "source": [
-    "The logistic transform is an uncalibrated display score centered on the full-trial median, so read it as an ordering rather than as a probability. Its 0.5 decision is identical to `posterior_drive > detection_threshold`."
+    "The logistic transform is an uncalibrated display score centered on the full-trial median, so read it as an ordering rather than as a probability, keeping in mind that its 0.5 decision boundary is exactly `posterior_drive > detection_threshold`."
    ]
   },
   {
@@ -1181,7 +1181,7 @@
    "id": "b5d67a1e",
    "metadata": {},
    "source": [
-    "For this one seeded check on the oracle axis, we summarize latent-drive recovery with accuracy, [AUC](https://doi.org/10.1016/j.patrec.2005.10.010) (the chance that a randomly chosen active step scores above a randomly chosen inactive one), precision, recall, and confusion counts. Their scope is this synthetic trial only."
+    "For this one seeded check on the oracle axis, we summarize latent-drive recovery with accuracy, [AUC](https://doi.org/10.1016/j.patrec.2005.10.010) (the chance that a randomly chosen active step scores above a randomly chosen inactive one), precision, recall, and confusion counts, all of which describe this one synthetic trial and nothing beyond it."
    ]
   },
   {
@@ -1473,7 +1473,7 @@
    "id": "fe5b660d",
    "metadata": {},
    "source": [
-    "The block-norm covariance remains concentrated near the diagonal, with the nearest-neighbor band the strongest off-diagonal coupling and longer-lag block norms smaller, matching the lag means printed in the check above. That is what local time-homogeneous dynamics should produce."
+    "The block-norm covariance remains concentrated near the diagonal, with the nearest-neighbor band the strongest off-diagonal coupling and longer-lag block norms smaller, matching the lag means printed in the check above. That's what local time-homogeneous dynamics should produce."
    ]
   },
   {

--- a/examples/12_langevin_graph_ising.ipynb
+++ b/examples/12_langevin_graph_ising.ipynb
@@ -13,7 +13,7 @@
    "id": "1cab76ff",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
     "<p>We sample the continuous Boltzmann law of a soft-spin graph Ising energy with a custom <a href=\"#ref-parisi-1981\">overdamped-Langevin</a> <code>LangevinGate</code> driven through <code>HybridPCircuit.sample</code> inside a JAX scan. We validate the <a href=\"#ref-roberts-tweedie-1996\">Metropolis-adjusted (MALA)</a> chain against exact quadrature and compare it with the <a href=\"#ref-roberts-tweedie-1996\">unadjusted (ULA)</a> chain.</p>\n",
     "</div>"
    ]
@@ -29,7 +29,7 @@
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Langevin sampler vocabulary</summary><p>A pmode is a Torx continuous-valued site, and ULA takes every Langevin proposal while MALA applies a Metropolis accept/reject correction. A stationary law is a distribution unchanged by another update, and quadrature here means numerical integration on a grid.</p></details>\n",
     "\n",
-    "In this tutorial, we sample that Boltzmann law with `LangevinGate`, custom notebook code built on Torx's `AbstractContinuousGate` interface and defined in the helper module `examples/helpers/_langevin.py`, shown below. Its `sample` method takes one gradient-drift step on the soft-spin energy. We repeat `HybridPCircuit.sample` with `jax.lax.scan` in two modes, unadjusted (ULA) and Metropolis-adjusted (MALA). The gate section below spells out the difference.\n",
+    "In this tutorial, we sample that Boltzmann law with `LangevinGate`. The gate is our own notebook code rather than a Torx API class. It implements Torx's `AbstractContinuousGate` interface, which is all a circuit needs in order to run it, and it lives in the helper module `examples/helpers/_langevin.py`. We show its source below. Its `sample` method takes one gradient-drift step on the soft-spin energy, and we repeat `HybridPCircuit.sample` with `jax.lax.scan` in two modes, unadjusted (ULA) and Metropolis-adjusted (MALA). The gate section below spells out the difference.\n",
     "\n",
     "Because the drift $\\nabla V$ is nonlinear, this gate has no closed-form affine-Gaussian channel, so we cannot read off exact Gaussian moments the way a linear gate allows. Instead we validate the sampler where the target is tractable, a one-dimensional instance of the same energy whose Boltzmann density we obtain by fine-grid quadrature, and then deploy that same gate on the full graph.\n",
     "\n",
@@ -151,17 +151,15 @@
    "source": [
     "## The graph and soft-spin Ising energy\n",
     "\n",
-    "The target is a 10-node graph: a cycle plus three cross-chords.\n",
+    "Before we can sample anything we need the energy the gate will descend, and that energy is fixed by the geometry we choose. The target is a 10-node graph: a cycle plus three cross-chords, which give the ring a few nonlocal couplings.\n",
     "\n",
-    "That geometry fixes the soft-spin Ising energy. Each node carries a soft spin $s_i = \\tanh(x_i)$, $A_{\\mathrm{adj}}$ is the adjacency matrix, and\n",
+    "Each node carries a soft spin $s_i = \\tanh(x_i)$, $A_{\\mathrm{adj}}$ is the adjacency matrix, and\n",
     "\n",
     "$$V(x) = \\underbrace{-\\frac{\\beta}{2}\\, s^\\top A_{\\mathrm{adj}}\\, s}_{\\vphantom{\\big|}\\text{bond energy}} \\;-\\; h^\\top s \\;+\\; \\underbrace{\\frac{\\lambda_q}{4}\\sum_i (x_i^2 - 1)^2}_{\\vphantom{\\big|}\\text{spin well}}, \\qquad s_i = \\tanh(x_i).$$\n",
     "\n",
     "The bond term rewards aligned neighbors, the field term $-h^\\top s$ tilts the pattern, and the quartic well softly confines each coordinate near $x_i = \\pm 1$.\n",
     "\n",
-    "This $V$ is the potential the gate descends, and its Boltzmann law $\\pi(x)\\propto e^{-V(x)/T}$ is the distribution we sample.\n",
-    "\n",
-    "We now build the `graph` and `field` that define the system."
+    "This $V$ is the potential the gate descends, so its Boltzmann law $\\pi(x)\\propto e^{-V(x)/T}$ is the distribution we sample. The cell below builds the `graph` and `field` that define it."
    ]
   },
   {
@@ -223,7 +221,7 @@
    "source": [
     "## The Langevin gate\n",
     "\n",
-    "`LangevinGate` is custom notebook code rather than a Torx API class. It implements the `AbstractContinuousGate` interface and ships with the notebooks; at run time the circuit passes each gate's `theta` to `sample` as `params`. The following is excerpted from `examples/helpers/_langevin.py`:\n",
+    "Here is the gate itself. Because `LangevinGate` ships with the notebooks rather than with the Torx API, satisfying the `AbstractContinuousGate` interface is the only contract it has to meet: at run time the circuit passes each gate's `theta` to `sample` as `params`, and everything that happens inside `sample` is ours to write. The following is excerpted from `examples/helpers/_langevin.py`:\n",
     "\n",
     "```python\n",
     "class LangevinGate(AbstractContinuousGate[dict[str, Array], tuple[int, ...]]):\n",
@@ -347,7 +345,7 @@
    "id": "cc04ff4a",
    "metadata": {},
    "source": [
-    "`LangevinGate` itself carries the structural pieces (its sites, dims, and the ULA/MALA switch) and reads every physical coefficient from `theta`. The helper below builds a one-step Torx circuit in either mode, repeats it with `jax.lax.scan`, and batches independent chains with `jax.vmap`."
+    "`LangevinGate` itself carries the structural pieces (its sites, dims, and the ULA/MALA switch) and reads every physical coefficient from `theta`, so one helper can run either mode without touching the gate's logic. The helper below builds a one-step Torx circuit in either mode, repeats it with `jax.lax.scan`, and batches independent chains with `jax.vmap`."
    ]
   },
   {
@@ -395,7 +393,7 @@
    "id": "0b2584aa",
    "metadata": {},
    "source": [
-    "One step is a single custom gate acting on the whole vector pmode $x\\in\\mathbb{R}^{10}$. The compact bus below represents all ten coupled coordinates, and the scan executes this one-step Torx circuit `reps` times."
+    "The schematic below shows how little the circuit does per step. One step is a single custom gate acting on the whole vector pmode $x\\in\\mathbb{R}^{10}$, so the compact bus stands for all ten coupled coordinates, and the scan executes this one-step Torx circuit `reps` times."
    ]
   },
   {
@@ -448,7 +446,7 @@
     "\n",
     "Because $\\nabla V$ is nonlinear, the gate has no affine-Gaussian channel and no closed-form Gaussian moments to check against. We validate the sampler where the target is tractable instead: a single soft spin in the same quartic double-well with a field bias (the couplings switched off), whose Boltzmann density $\\pi(x)\\propto e^{-V(x)/T}$ we obtain by fine-grid quadrature.\n",
     "\n",
-    "This exercises the same `sample` code path as the graph run below (gradient drift plus, for MALA, the Metropolis accept/reject); only the energy coefficients differ. Matching the 1-D reference therefore validates the proposal-and-acceptance machinery against an exact target; the deployed 10-D chain, which has no tractable reference, is checked separately by long-run-MALA parity below.\n",
+    "This exercises the same `sample` code path as the graph run below (gradient drift plus, for MALA, the Metropolis accept/reject), and only the energy coefficients differ. Matching the 1-D reference therefore validates the proposal-and-acceptance machinery against an exact target. The deployed 10-D chain has no tractable reference of its own, so we check it separately against a long MALA run further down.\n",
     "\n",
     "To isolate the step-size bias from mixing, we hold the total simulated time $T_{\\mathrm{sim}} = \\texttt{reps}\\times\\varepsilon$ fixed across the sweep, so every chain integrates the same amount of dynamics and only the discretization changes."
    ]
@@ -519,7 +517,7 @@
    "id": "fc26ca4b",
    "metadata": {},
    "source": [
-    "We sweep the step size for both ULA and MALA, sampling `N_1D` independent chains at each $\\varepsilon$ and scoring each empirical marginal against the exact reference with the `ks_distance` helper, a one-sample Kolmogorov-Smirnov statistic."
+    "We sweep the step size for both ULA and MALA, sampling `N_1D` independent chains at each $\\varepsilon$ and scoring each empirical marginal against the exact reference with the `ks_distance` helper, a one-sample Kolmogorov-Smirnov statistic that reports the largest gap between the sampled and exact cumulative distributions, so smaller means closer."
    ]
   },
   {
@@ -603,7 +601,7 @@
    "id": "3022e939",
    "metadata": {},
    "source": [
-    "The MALA histogram sits on top of the exact Boltzmann density: with the accept/reject step, the chain samples $\\pi(x)\\propto e^{-V(x)/T}$ to within Monte Carlo noise."
+    "The first panel asks the most basic question: does the Metropolis-adjusted chain reach the right target at all? It does. The MALA histogram sits on top of the exact Boltzmann density, which tells us that with the accept/reject step the chain samples $\\pi(x)\\propto e^{-V(x)/T}$ to within Monte Carlo noise."
    ]
   },
   {
@@ -649,7 +647,7 @@
    "id": "e6c3e19e",
    "metadata": {},
    "source": [
-    "At a coarse step the unadjusted chain (ULA) underweights the main mode and overfills the trough relative to the exact density, while MALA, which runs the identical proposal plus accept/reject, stays on the target. That accept/reject step is what removes the bias."
+    "The next panel shows what the accept/reject step buys us. At a coarse step the unadjusted chain (ULA) underweights the main mode and overfills the trough relative to the exact density, while MALA, which runs the identical proposal plus accept/reject, stays on the target. That accept/reject step is what removes the bias."
    ]
   },
   {
@@ -786,7 +784,7 @@
    "id": "6a767600",
    "metadata": {},
    "source": [
-    "Is `DEPLOY_REPS` steps enough? With no tractable reference in ten dimensions, we compare per-site mean soft spins $\\langle\\tanh x_i\\rangle$ against a much longer MALA run. Site-specific Monte Carlo error bars and standardized residuals make this a finite-sample convergence sanity check, not proof of stationarity."
+    "Are `DEPLOY_REPS` steps enough? With no tractable reference in ten dimensions, we compare per-site mean soft spins $\\langle\\tanh x_i\\rangle$ against a much longer MALA run. Site-specific Monte Carlo error bars and standardized residuals, meaning each site's difference divided by its own standard error, make this a finite-sample convergence sanity check rather than proof of stationarity."
    ]
   },
   {
@@ -882,7 +880,7 @@
    "id": "384c41b1",
    "metadata": {},
    "source": [
-    "The labeled, site-specific error bars show where deployed and long-run estimates differ. The printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ identifies the worst standardized residual."
+    "The labeled, site-specific error bars show where the deployed and long-run estimates differ, and the printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ names the worst standardized residual, which is the one site to look at if any of them has not settled."
    ]
   },
   {
@@ -892,11 +890,9 @@
    "source": [
     "## Terminal field and magnetization\n",
     "\n",
-    "We summarize the terminal samples as a soft-spin field and a magnetization distribution.\n",
+    "With the chain deployed, the question becomes what pattern it settled into, so we summarize the terminal samples two ways: as a soft-spin field on the graph and as a magnetization distribution across paths.\n",
     "\n",
-    "The graph view shows the mean soft spin $\\tanh(x_i)$ over `NUM_SAMPLES` samples on the graph. A diverging colormap fits here because magnetization is signed.\n",
-    "\n",
-    "We compute these summaries from the terminal states."
+    "The graph view shows the mean soft spin $\\tanh(x_i)$ over `NUM_SAMPLES` samples on the graph, drawn with a diverging colormap because magnetization is signed and the sign is what we want to read at a glance. The cell below computes both summaries from the terminal states."
    ]
   },
   {
@@ -923,7 +919,7 @@
    "id": "4397d33c",
    "metadata": {},
    "source": [
-    "Each terminal-field node is labeled with its graph-site ID on the first line and its mean soft spin on the second."
+    "To make a color traceable back to a site, each terminal-field node is labeled with its graph-site ID on the first line and its mean soft spin on the second."
    ]
   },
   {
@@ -967,7 +963,7 @@
    "id": "b4e560e1",
    "metadata": {},
    "source": [
-    "The magnetization histogram shows the per-path magnetization $m = \\frac{1}{n}\\sum_i \\tanh(x_i)$ with the sample mean marked."
+    "The field above averages over paths, which hides how much the paths disagree, so we also look at the spread. The magnetization histogram shows the per-path magnetization $m = \\frac{1}{n}\\sum_i \\tanh(x_i)$ with the sample mean marked."
    ]
   },
   {
@@ -1014,7 +1010,7 @@
    "id": "6028d177",
    "metadata": {},
    "source": [
-    "For these parameters, the sampled per-path magnetization is broad and its empirical mean is near zero (-0.001). The zero-sum external field does not by itself force zero net magnetization. The graph colors report the observed site-specific response."
+    "For these parameters the sampled per-path magnetization is broad, and its empirical mean comes out near zero (-0.001). It would be easy to read that as a symmetry result, but the zero-sum external field does not by itself force zero net magnetization, so a near-zero mean here is something we observed rather than something the setup guarantees. The graph colors report the observed site-specific response behind that average."
    ]
   },
   {
@@ -1024,9 +1020,9 @@
    "source": [
     "## Energy relaxation diagnostic\n",
     "\n",
-    "A single MALA path scores its own energy $V(x_t)$ as it evolves. Starting from $x = 0$ every term except the quartic well vanishes, so $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. The trace shows relaxation from that initial state, but 500 steps are not used to claim stationarity.\n",
+    "Every figure so far has looked at where the chains ended up. Here we instead watch one MALA path while it runs, recording its own energy $V(x_t)$ at each step. Starting from $x = 0$ every term except the quartic well vanishes, so we know the starting height exactly: $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. The trace shows relaxation from that initial state, but we do not use 500 steps to claim stationarity.\n",
     "\n",
-    "This diagnostic calls the custom `LangevinGate` directly rather than through the terminal-state circuit so it can record every intermediate state. A compiled scan records $V(x_t)$ and the acceptance rate."
+    "We call the custom `LangevinGate` directly here rather than going through the terminal-state circuit, because only the direct call lets us record every intermediate state. One compiled scan collects $V(x_t)$ and the acceptance rate."
    ]
   },
   {
@@ -1129,7 +1125,7 @@
    "id": "1122bb83",
    "metadata": {},
    "source": [
-    "The trace drops below its initial energy while continuing to drift late in the run. The dashed line is only the last-100-step mean, a compact relaxation diagnostic rather than an equilibrium estimate."
+    "The trace drops below its initial energy while continuing to drift late in the run, which is why the dashed line is only the last-100-step mean, a compact relaxation diagnostic rather than an equilibrium estimate."
    ]
   },
   {
@@ -1139,7 +1135,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "We close with checks that the MALA acceptance rate is healthy and that the recorded path relaxes below its initial energy. The terminal magnetization remains an empirical summary, not a symmetry assertion."
+    "We close with the checks the notebook actually asserts: the MALA acceptance rate has to stay above 0.5, and the recorded path has to relax below its initial energy. Neither one touches the terminal magnetization, which remains an empirical summary rather than a symmetry assertion."
    ]
   },
   {
@@ -1222,7 +1218,7 @@
     "\n",
     "We sampled the continuous Boltzmann law of a soft-spin graph Ising energy with a custom `LangevinGate`.\n",
     "\n",
-    "The gate takes one gradient-drift step on $V$, with the gradient computed by `jax.grad` inside `sample`. A JAX scan repeats that Torx `HybridPCircuit.sample` transition, and `jax.vmap` batches independent chains in one JIT-compiled pass. On a tractable 1-D instance, the Metropolis-adjusted chain matched the exact quadrature density, and the step-size sweep quantified the ULA bias it removes. On the full graph, site-specific errors compare deployed and long-run means, while the single-path energy trace is reported only as a relaxation diagnostic.\n",
+    "The gate takes one gradient-drift step on $V$, with the gradient computed by `jax.grad` inside `sample`. A JAX scan repeats that Torx `HybridPCircuit.sample` transition, and `jax.vmap` batches independent chains in one JIT-compiled pass. On a tractable 1-D instance, the Metropolis-adjusted chain matched the exact quadrature density, and the step-size sweep quantified the ULA bias it removes. On the full graph we compared the deployed per-site means against a much longer run with site-specific error bars, and we report the single-path energy trace only as a relaxation diagnostic.\n",
     "\n",
     "Because the drift is nonlinear, the gate forfeits the closed-form affine-Gaussian moment simulator, so the tractable reference and finite-sample diagnostics expose distinct parts of the computation.\n",
     "\n",

--- a/examples/12_langevin_graph_ising.ipynb
+++ b/examples/12_langevin_graph_ising.ipynb
@@ -29,9 +29,9 @@
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Langevin sampler vocabulary</summary><p>A pmode is a Torx continuous-valued site, and ULA takes every Langevin proposal while MALA applies a Metropolis accept/reject correction. A stationary law is a distribution unchanged by another update, and quadrature here means numerical integration on a grid.</p></details>\n",
     "\n",
-    "In this tutorial, we sample that Boltzmann law with `LangevinGate`. The gate is our own notebook code rather than a Torx API class. It implements Torx's `AbstractContinuousGate` interface, which is all a circuit needs in order to run it, and it lives in the helper module `examples/helpers/_langevin.py`. We show its source below. Its `sample` method takes one gradient-drift step on the soft-spin energy, and we repeat `HybridPCircuit.sample` with `jax.lax.scan` in two modes, unadjusted (ULA) and Metropolis-adjusted (MALA). The gate section below spells out the difference.\n",
+    "In this tutorial, we sample that Boltzmann law with `LangevinGate`. The gate is our own notebook code rather than a Torx API class. It implements Torx's `AbstractContinuousGate` interface, which is all a circuit needs in order to run it, and it lives in the helper module `examples/helpers/_langevin.py`, whose source we show below. Its `sample` method takes one gradient-drift step on the soft-spin energy, and we repeat `HybridPCircuit.sample` with `jax.lax.scan` in two modes, unadjusted (ULA) and Metropolis-adjusted (MALA), a difference the gate section below spells out in full.\n",
     "\n",
-    "Because the drift $\\nabla V$ is nonlinear, this gate has no closed-form affine-Gaussian channel, so we cannot read off exact Gaussian moments the way a linear gate allows. Instead we validate the sampler where the target is tractable, a one-dimensional instance of the same energy whose Boltzmann density we obtain by fine-grid quadrature, and then deploy that same gate on the full graph.\n",
+    "Because the drift $\\nabla V$ is nonlinear, this gate has no closed-form affine-Gaussian channel, so we can't read off exact Gaussian moments the way a linear gate allows. Instead we validate the sampler where the target is tractable, a one-dimensional instance of the same energy whose Boltzmann density we obtain by fine-grid quadrature, and then deploy that same gate on the full graph.\n",
     "\n",
     "The main steps are:\n",
     "\n",
@@ -221,7 +221,7 @@
    "source": [
     "## The Langevin gate\n",
     "\n",
-    "Here is the gate itself. Because `LangevinGate` ships with the notebooks rather than with the Torx API, satisfying the `AbstractContinuousGate` interface is the only contract it has to meet: at run time the circuit passes each gate's `theta` to `sample` as `params`, and everything that happens inside `sample` is ours to write. The following is excerpted from `examples/helpers/_langevin.py`:\n",
+    "Here's the gate itself. Because `LangevinGate` ships with the notebooks rather than with the Torx API, satisfying the `AbstractContinuousGate` interface is the only contract it has to meet: at run time the circuit passes each gate's `theta` to `sample` as `params`, and everything that happens inside `sample` is ours to write. The following is excerpted from `examples/helpers/_langevin.py`:\n",
     "\n",
     "```python\n",
     "class LangevinGate(AbstractContinuousGate[dict[str, Array], tuple[int, ...]]):\n",
@@ -880,7 +880,7 @@
    "id": "384c41b1",
    "metadata": {},
    "source": [
-    "The labeled, site-specific error bars show where the deployed and long-run estimates differ, and the printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ names the worst standardized residual, which is the one site to look at if any of them has not settled."
+    "The labeled, site-specific error bars show where the deployed and long-run estimates differ, and the printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ names the worst standardized residual, which is the one site to look at if any of them hasn't settled."
    ]
   },
   {
@@ -1010,7 +1010,7 @@
    "id": "6028d177",
    "metadata": {},
    "source": [
-    "For these parameters the sampled per-path magnetization is broad, and its empirical mean comes out near zero (-0.001). It would be easy to read that as a symmetry result, but the zero-sum external field does not by itself force zero net magnetization, so a near-zero mean here is something we observed rather than something the setup guarantees. The graph colors report the observed site-specific response behind that average."
+    "For these parameters the sampled per-path magnetization is broad, and its empirical mean comes out near zero (-0.001). It would be easy to read that as a symmetry result, but the zero-sum external field doesn't by itself force zero net magnetization, so a near-zero mean here is something we observed rather than something the setup guarantees. The graph colors report the observed site-specific response behind that average."
    ]
   },
   {
@@ -1020,7 +1020,7 @@
    "source": [
     "## Energy relaxation diagnostic\n",
     "\n",
-    "Every figure so far has looked at where the chains ended up. Here we instead watch one MALA path while it runs, recording its own energy $V(x_t)$ at each step. Starting from $x = 0$ every term except the quartic well vanishes, so we know the starting height exactly: $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. The trace shows relaxation from that initial state, but we do not use 500 steps to claim stationarity.\n",
+    "Every figure so far has looked at where the chains ended up. Here we instead watch one MALA path while it runs, recording its own energy $V(x_t)$ at each step. Starting from $x = 0$ every term except the quartic well vanishes, so we know the starting height exactly: $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. The trace shows relaxation from that initial state, but we don't use 500 steps to claim stationarity.\n",
     "\n",
     "We call the custom `LangevinGate` directly here rather than going through the terminal-state circuit, because only the direct call lets us record every intermediate state. One compiled scan collects $V(x_t)$ and the acceptance rate."
    ]
@@ -1135,7 +1135,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "We close with the checks the notebook actually asserts: the MALA acceptance rate has to stay above 0.5, and the recorded path has to relax below its initial energy. Neither one touches the terminal magnetization, which remains an empirical summary rather than a symmetry assertion."
+    "We close with the checks the notebook actually asserts: the MALA acceptance rate has to stay above 0.5, and the recorded path has to relax below its initial energy, which leaves the terminal magnetization outside the assertions entirely and keeps it an empirical summary rather than a symmetry claim."
    ]
   },
   {

--- a/examples/13_regime_switching_diffusion.ipynb
+++ b/examples/13_regime_switching_diffusion.ipynb
@@ -27,7 +27,7 @@
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Torx sites and time stepping</summary><p>A pdit is a Torx discrete-valued site, while a pmode is a continuous-valued site. A generator gives the infinitesimal rule, and an <a href=\"#ref-kloeden-platen-1992\">Euler step</a> with a <a href=\"#ref-trotter-1959\">Lie-Trotter split</a> approximates it by applying small regime and position updates in sequence.</p></details>\n",
     "\n",
-    "The regime follows a discrete Markov chain, and when it switches the next position increment comes from a different Gaussian law, so the model needs exactly two moving parts: something to advance the regime and something to draw a regime-dependent increment. We assemble those from `PditCycle` and `MixtureGaussianGate`. Torx also ships a binary-firing `torx.psc.JumpDiffusionGate`, but that gate puts jumps in $X$ itself, which is a different model, so we do not use it here.\n",
+    "The regime follows a discrete Markov chain, and when it switches the next position increment comes from a different Gaussian law, so the model needs exactly two moving parts: something to advance the regime and something to draw a regime-dependent increment. We assemble those from `PditCycle` and `MixtureGaussianGate`. Torx also ships a binary-firing `torx.psc.JumpDiffusionGate`, but that gate puts jumps in $X$ itself, which is a different model, so we don't use it here.\n",
     "\n",
     "This pattern appears in regime-switching finance, neural spike trains, and other systems where a continuous signal changes its noise level because an unobserved state has changed. Conditioned on the current regime a Gaussian gate gives a Gaussian step, while marginalizing the regime generally gives a non-Gaussian mixture.\n",
     "\n",
@@ -47,7 +47,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "The setup cells import Torx, JAX, SciPy, and the plotting helpers, then apply the shared notebook style. Nothing about the process itself appears until the next section.\n",
+    "The setup cells import Torx, JAX, SciPy, and the plotting helpers, then apply the shared notebook style, so the process itself doesn't enter until the next section.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: <code>PditCycle</code>, <code>MixtureGaussianGate</code>, <code>HybridPCircuit</code>, and <code>HybridSampleSimulator</code> execute each sampled step.</li><li>Notebook code: <code>scan</code> advances time and <code>vmap</code> batches paths.</li><li>Helpers: <code>examples/helpers/_affine_gaussian.py</code> supplies reference densities, while <code>examples/helpers/_notebook_paths.py</code>, <code>examples/helpers/_notebook_style.py</code>, <code>examples/helpers/_plots_fields.py</code>, and <code>examples/helpers/_plots_schematics.py</code> handle paths, style, and figures.</li></ul></details>"
    ]
@@ -203,7 +203,7 @@
     "\n",
     "Letting a discrete state pick the increment changes the transition kernel: the increment is Gaussian once we condition on a regime, but marginalizing over an unobserved regime turns it into a mixture of Gaussians.\n",
     "\n",
-    "That leaves the question of how to interleave the two updates. The generator, the operator describing how the distribution changes over an instant, splits into a regime part and a position part, $A = A_S + A_X$, and the two pieces do not commute, so the order of the approximation matters.\n",
+    "That leaves the question of how to interleave the two updates. The generator, the operator describing how the distribution changes over an instant, splits into a regime part and a position part, $A = A_S + A_X$, and the two pieces don't commute, so the order of the approximation matters.\n",
     "\n",
     "One Trotter step applies them in sequence: switch the regime first, then take the position step under the new regime. This is the [Lie-Trotter split](#ref-trotter-1959), whose local one-step error is $O(\\Delta t^2)$, giving first-order $O(\\Delta t)$ global error over the full interval.\n",
     "\n",
@@ -647,7 +647,7 @@
     "\n",
     "That mixture is the right target only if our sampling scheme really does draw regimes with the stationary weights, and it does. The pooled sample below starts equally often from each regime, and because this `PditCycle` chain is doubly stochastic (rows and columns each sum to 1), a uniform start stays uniform after one step, so pooling per-regime samples reproduces the stationary marginal.\n",
     "\n",
-    "The mixture is also where the discrete site earns its place. Compositions of affine Gaussian gates preserve Gaussianity, so it is the act of selecting among unequal Gaussian components with a discrete regime that generally produces a non-Gaussian law.\n",
+    "The mixture is also where the discrete site earns its place. Compositions of affine Gaussian gates preserve Gaussianity, so it's the act of selecting among unequal Gaussian components with a discrete regime that generally produces a non-Gaussian law.\n",
     "\n",
     "As a check, we sample the one-step increments $\\Delta x$ from each starting regime and compare them with the analytic densities."
    ]
@@ -895,7 +895,7 @@
    "id": "bba6f9ab",
    "metadata": {},
    "source": [
-    "Each histogram follows its analytic curve, which is the observation that matters here. Regimes 0 and 2 give narrow conditional Gaussians while regime 1 gives a wide one, and because the stationary marginal blends all three, it is wider than the sharpest conditional."
+    "Each histogram follows its analytic curve, which is the observation that matters here. Regimes 0 and 2 give narrow conditional Gaussians while regime 1 gives a wide one, and because the stationary marginal blends all three, it's wider than the sharpest conditional."
    ]
   },
   {
@@ -1116,7 +1116,7 @@
    "source": [
     "## Sample paths\n",
     "\n",
-    "With one step matching its law, we can look at what 120 of them produce. Six representative paths are shown separately so crossings do not hide regime switches. Each panel is labeled by path index, and each segment is colored by the active regime. Slate is regime 0 with positive drift, orange is regime 1 with zero drift, and copper is regime 2 with negative drift."
+    "With one step matching its law, we can look at what 120 of them produce. Six representative paths are shown separately so crossings don't hide regime switches. Each panel is labeled by path index, and each segment is colored by the active regime. Slate is regime 0 with positive drift, orange is regime 1 with zero drift, and copper is regime 2 with negative drift."
    ]
   },
   {
@@ -1418,7 +1418,7 @@
    "id": "b6106695",
    "metadata": {},
    "source": [
-    "The empirical terminal mean is checked only against the exact reference for the discretized Torx chain, because that is the chain the sampler is asked to reproduce. The half-step and matrix-exponential values printed beside it separately show the scale of continuous-time discretization error, so the gap between them is a property of the timestep rather than a defect in the sampler."
+    "The empirical terminal mean is checked only against the exact reference for the discretized Torx chain, because that's the chain the sampler is asked to reproduce. The half-step and matrix-exponential values printed beside it separately show the scale of continuous-time discretization error, so the gap between them is a property of the timestep rather than a defect in the sampler."
    ]
   },
   {

--- a/examples/13_regime_switching_diffusion.ipynb
+++ b/examples/13_regime_switching_diffusion.ipynb
@@ -13,8 +13,8 @@
    "id": "a30cbde9",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We control Gaussian position increments with a discrete (pdit) regime cycle to build a regime-switching diffusion sampler in which the only jumps are the latent regime switches. We check the regime-conditioned laws, the stationary occupancy, and the terminal mean against analytic references.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We let a discrete regime cycle on a pdit, Torx's d-state site, choose which Gaussian law generates the next position increment, which gives a regime-switching diffusion sampler whose only jumps are the latent regime switches. Because every piece of one step has a closed form, we can hold the sampler to analytic references for the regime-conditioned laws, the stationary occupancy, and the terminal mean.</p>\n",
     "</div>"
    ]
   },
@@ -27,7 +27,7 @@
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Torx sites and time stepping</summary><p>A pdit is a Torx discrete-valued site, while a pmode is a continuous-valued site. A generator gives the infinitesimal rule, and an <a href=\"#ref-kloeden-platen-1992\">Euler step</a> with a <a href=\"#ref-trotter-1959\">Lie-Trotter split</a> approximates it by applying small regime and position updates in sequence.</p></details>\n",
     "\n",
-    "The regime follows a discrete Markov chain. When it switches, the next position increment comes from a different Gaussian law. We assemble the two parts from `PditCycle` and `MixtureGaussianGate`. The binary-firing `torx.psc.JumpDiffusionGate` is a separate jump model, which we do not use here.\n",
+    "The regime follows a discrete Markov chain, and when it switches the next position increment comes from a different Gaussian law, so the model needs exactly two moving parts: something to advance the regime and something to draw a regime-dependent increment. We assemble those from `PditCycle` and `MixtureGaussianGate`. Torx also ships a binary-firing `torx.psc.JumpDiffusionGate`, but that gate puts jumps in $X$ itself, which is a different model, so we do not use it here.\n",
     "\n",
     "This pattern appears in regime-switching finance, neural spike trains, and other systems where a continuous signal changes its noise level because an unobserved state has changed. Conditioned on the current regime a Gaussian gate gives a Gaussian step, while marginalizing the regime generally gives a non-Gaussian mixture.\n",
     "\n",
@@ -47,7 +47,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "The setup cells wire imports and styling.\n",
+    "The setup cells import Torx, JAX, SciPy, and the plotting helpers, then apply the shared notebook style. Nothing about the process itself appears until the next section.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: <code>PditCycle</code>, <code>MixtureGaussianGate</code>, <code>HybridPCircuit</code>, and <code>HybridSampleSimulator</code> execute each sampled step.</li><li>Notebook code: <code>scan</code> advances time and <code>vmap</code> batches paths.</li><li>Helpers: <code>examples/helpers/_affine_gaussian.py</code> supplies reference densities, while <code>examples/helpers/_notebook_paths.py</code>, <code>examples/helpers/_notebook_style.py</code>, <code>examples/helpers/_plots_fields.py</code>, and <code>examples/helpers/_plots_schematics.py</code> handle paths, style, and figures.</li></ul></details>"
    ]
@@ -189,7 +189,9 @@
    "source": [
     "## The process and its gates\n",
     "\n",
-    "The target is a regime-switching stochastic differential equation (SDE): a position $X_t$ whose drift and volatility are both set by a latent regime $S_t$. That regime is a continuous-time Markov chain, and `PditCycle` realizes its $O(\\Delta t)$ [Euler discretization](#ref-kloeden-platen-1992) with switch probabilities linear in $\\Delta t$.\n",
+    "We start from the process we want to sample, because both Torx gates can be read straight off it.\n",
+    "\n",
+    "The target is a regime-switching stochastic differential equation (SDE): a position $X_t$ whose drift and volatility are both set by a latent regime $S_t$, which is itself a continuous-time Markov chain.\n",
     "\n",
     "$$\n",
     "dX_t = \\underbrace{\\mu_{S_t}\\,dt}_{\\vphantom{\\big|}\\text{drift}} + \\underbrace{\\sigma_{S_t}\\,dW_t}_{\\vphantom{\\big|}\\text{diffusion}}.\n",
@@ -197,29 +199,31 @@
     "\n",
     "Here $W_t$ is a standard Wiener (Brownian) process, and the current regime selects $(\\mu, \\sigma)$ for the continuous increment.\n",
     "\n",
-    "This discrete control changes the transition kernel: the increment is Gaussian once we condition on a regime, and marginalizing over an unobserved regime turns it into a mixture of Gaussians.\n",
+    "To simulate this on a grid of step $\\Delta t$ we need a discrete stand-in for that regime chain, and `PditCycle` is exactly its $O(\\Delta t)$ [Euler discretization](#ref-kloeden-platen-1992), with switch probabilities linear in $\\Delta t$.\n",
     "\n",
-    "The generator, the operator describing how the distribution changes over an instant, splits into a regime part and a position part, $A = A_S + A_X$. The two pieces do not commute, so the order of the approximation matters.\n",
+    "Letting a discrete state pick the increment changes the transition kernel: the increment is Gaussian once we condition on a regime, but marginalizing over an unobserved regime turns it into a mixture of Gaussians.\n",
     "\n",
-    "One Trotter step applies them in sequence: switch the regime first, then take the position step under the new regime. This is the [Lie-Trotter split](#ref-trotter-1959): its local one-step error is $O(\\Delta t^2)$, giving first-order $O(\\Delta t)$ global error over the full interval.\n",
+    "That leaves the question of how to interleave the two updates. The generator, the operator describing how the distribution changes over an instant, splits into a regime part and a position part, $A = A_S + A_X$, and the two pieces do not commute, so the order of the approximation matters.\n",
+    "\n",
+    "One Trotter step applies them in sequence: switch the regime first, then take the position step under the new regime. This is the [Lie-Trotter split](#ref-trotter-1959), whose local one-step error is $O(\\Delta t^2)$, giving first-order $O(\\Delta t)$ global error over the full interval.\n",
     "\n",
     "$$\n",
     "T_{\\text{Trotter}}(\\Delta t) = \\underbrace{T_{\\text{MoG}}(\\Delta t)}_{\\vphantom{\\big|}\\text{position step}}\\, \\underbrace{T_{\\text{PditCycle}}(\\Delta t)}_{\\vphantom{\\big|}\\text{regime switch}}.\n",
     "$$\n",
     "\n",
-    "The `PditCycle` gate advances the regime on a cyclic 3-state chain. At each step of size $\\Delta t$ it:\n",
+    "Reading that product right to left, `PditCycle` runs first and advances the regime on a cyclic 3-state chain. At each step of size $\\Delta t$ it:\n",
     "\n",
     "- moves forward with probability $p_+ = \\lambda_+\\Delta t$,\n",
     "- moves backward with probability $p_- = \\lambda_-\\Delta t$, and\n",
     "- stays put with probability $p_0 = 1 - p_+ - p_-$.\n",
     "\n",
-    "The `MixtureGaussianGate` gate then applies the regime-conditioned increment:\n",
+    "`MixtureGaussianGate` then applies the increment belonging to whichever regime the chain just switched into:\n",
     "\n",
     "$$\n",
     "X' = X + \\mu_k\\,\\Delta t + \\sigma_k\\sqrt{\\Delta t}\\,\\mathcal{N}(0,1)\\quad\\text{when } S = k .\n",
     "$$\n",
     "\n",
-    "We use $K=3$ regimes with $\\mu = (1.0,\\,0.0,\\,-0.8)$, $\\sigma = (0.3,\\,1.0,\\,0.5)$, and rates $\\lambda_+ = 0.5$ and $\\lambda_- = 0.3$.\n"
+    "Throughout we use $K=3$ regimes with $\\mu = (1.0,\\,0.0,\\,-0.8)$, $\\sigma = (0.3,\\,1.0,\\,0.5)$, and rates $\\lambda_+ = 0.5$ and $\\lambda_- = 0.3$."
    ]
   },
   {
@@ -291,7 +295,7 @@
    "id": "4ab97cc8",
    "metadata": {},
    "source": [
-    "Both gates use log-space parameters. `PditCycle` takes the log odds of moving forward or backward relative to staying, and `MixtureGaussianGate` takes per-regime means and log variances."
+    "Both gates read their parameters in log space, so the next cell converts the rates and volatilities chosen above into that form. `PditCycle` takes the log odds of moving forward or backward relative to staying, and `MixtureGaussianGate` takes per-regime means and log variances."
    ]
   },
   {
@@ -361,9 +365,9 @@
    "source": [
     "## The regime chain\n",
     "\n",
-    "Solid edges show the forward cycle at rate $\\lambda_+$, tinted by their source regime. Dashed edges show the backward cycle at rate $\\lambda_-$ in a single neutral color. The self-loops for the stay probability $p_0$ are omitted so the drawing focuses on transitions between regimes.\n",
+    "The regime dynamics are easier to trust once drawn, so we sketch the cycle before sampling from it. Solid edges show the forward cycle at rate $\\lambda_+$, tinted by their source regime, while dashed edges show the backward cycle at rate $\\lambda_-$ in a single neutral color. The self-loops for the stay probability $p_0$ are left out so the drawing focuses on transitions between regimes.\n",
     "\n",
-    "Because the chain is rotationally symmetric, its stationary distribution, the long-run fraction of time spent in each regime, is uniform $(1/3, 1/3, 1/3)$ for any split between the forward and backward rates. The occupancy check at the end confirms this empirically."
+    "The drawing also settles a target we test at the end. Because the chain is rotationally symmetric, its stationary distribution, the long-run fraction of time spent in each regime, is uniform $(1/3, 1/3, 1/3)$ for any split between the forward and backward rates. The occupancy check at the end confirms this empirically."
    ]
   },
   {
@@ -414,7 +418,7 @@
    "id": "c4220bc0",
    "metadata": {},
    "source": [
-    "Every switch is a single forward or backward step around the ring. For $K=3$ both non-self states are nearest neighbors, so one step can reach either. On larger rings this would permit only nearest-neighbor moves."
+    "The point to take from the drawing is that every switch moves one place around the ring, forward or backward. For $K=3$ both non-self states are nearest neighbors, so one step can reach either of them. On larger rings the same gate would permit only nearest-neighbor moves."
    ]
   },
   {
@@ -424,7 +428,7 @@
    "source": [
     "## Building the one-step circuit\n",
     "\n",
-    "We use the Trotter split $T_{\\text{Trotter}} = T_{\\text{MoG}}\\,T_{\\text{PditCycle}}$ to update the regime wire $|S)$ first. The Gaussian gate then samples the position increment on the wire $|X)$, conditioned on the new regime."
+    "With both gates parameterized, we compose them into the single step the sampler will repeat. The Trotter split $T_{\\text{Trotter}} = T_{\\text{MoG}}\\,T_{\\text{PditCycle}}$ puts the regime first, so `PditCycle` updates the regime wire, written $|S)$ in the schematic because a wire here carries a probability distribution over states rather than one fixed value. The Gaussian gate then samples the position increment on the wire $|X)$, conditioned on the new regime."
    ]
   },
   {
@@ -501,7 +505,7 @@
    "id": "bf5b400e",
    "metadata": {},
    "source": [
-    "The regime wire $|S)$ is updated before it conditions the Gaussian increment on $|X)$, so each step samples the position under the freshly switched regime."
+    "The schematic shows the ordering that matters: the regime wire $|S)$ is updated before it conditions the Gaussian increment on $|X)$, so each step samples the position under the freshly switched regime."
    ]
   },
   {
@@ -511,7 +515,7 @@
    "source": [
     "## Scanning the trajectories\n",
     "\n",
-    "The circuit's `sample` method runs one path at a time."
+    "The circuit's `sample` method advances one path by one step, so the time loop and the batching over paths are ours to supply."
    ]
   },
   {
@@ -537,7 +541,7 @@
    "id": "00b74241",
    "metadata": {},
    "source": [
-    "The `scan` function carries the discrete and continuous state through each circuit step. The `vmap` transform then batches the 20,000 trajectory keys into one compiled computation."
+    "The `scan` function carries the discrete and continuous state through each circuit step, which is what turns one step into a path of 120 steps of size $\\Delta t = T/120$ over the interval $T = 10$. The `vmap` transform then batches the 20,000 trajectory keys into one compiled computation, so every path runs in a single call."
    ]
   },
   {
@@ -637,15 +641,15 @@
    "source": [
     "## The one-step transition density\n",
     "\n",
-    "One application of `PditCycle` followed by `MixtureGaussianGate` produces a Gaussian mixture.\n",
+    "A 120-step path is only as trustworthy as one step, so we check a single step first, where the answer is known exactly.\n",
     "\n",
-    "Conditioning on the new regime $k$ gives the Gaussian increment $\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$. Marginalizing over regimes (averaging across all possible regimes) with the stationary weights $\\pi = (1/3, 1/3, 1/3)$ gives $\\Delta x \\sim \\sum_k \\pi_k\\,\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$.\n",
+    "One application of `PditCycle` followed by `MixtureGaussianGate` produces a Gaussian mixture. Conditioning on the new regime $k$ gives the Gaussian increment $\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$, while marginalizing over regimes (averaging across all possible regimes) with the stationary weights $\\pi = (1/3, 1/3, 1/3)$ gives $\\Delta x \\sim \\sum_k \\pi_k\\,\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$.\n",
     "\n",
-    "The pooled sample below starts equally often from each regime. Because this `PditCycle` chain is doubly stochastic (rows and columns each sum to 1), that uniform start remains uniform after one step, so pooling per-regime samples reproduces the stationary marginal.\n",
+    "That mixture is the right target only if our sampling scheme really does draw regimes with the stationary weights, and it does. The pooled sample below starts equally often from each regime, and because this `PditCycle` chain is doubly stochastic (rows and columns each sum to 1), a uniform start stays uniform after one step, so pooling per-regime samples reproduces the stationary marginal.\n",
     "\n",
-    "Compositions of affine Gaussian gates preserve Gaussianity. Selecting among unequal Gaussian components with a discrete regime generally produces a non-Gaussian mixture.\n",
+    "The mixture is also where the discrete site earns its place. Compositions of affine Gaussian gates preserve Gaussianity, so it is the act of selecting among unequal Gaussian components with a discrete regime that generally produces a non-Gaussian law.\n",
     "\n",
-    "As a check, we sample the one-step increments $\\Delta x$ from each starting regime and compare them with the analytic densities.\n"
+    "As a check, we sample the one-step increments $\\Delta x$ from each starting regime and compare them with the analytic densities."
    ]
   },
   {
@@ -781,7 +785,7 @@
    "id": "68bcc63c",
    "metadata": {},
    "source": [
-    "We evaluate the analytic conditional and mixture densities on a shared grid with the `mixture_density` helper, then overlay them on the sampled histograms."
+    "We evaluate the analytic conditional and mixture densities on a shared grid with the `mixture_density` helper, then overlay them on the sampled histograms so any mismatch is visible without fitting anything."
    ]
   },
   {
@@ -891,7 +895,7 @@
    "id": "bba6f9ab",
    "metadata": {},
    "source": [
-    "Regimes 0 and 2 give narrow conditional Gaussians, while regime 1 gives a wide one. The stationary marginal blends all three, so it is wider than the sharpest conditional.\n"
+    "Each histogram follows its analytic curve, which is the observation that matters here. Regimes 0 and 2 give narrow conditional Gaussians while regime 1 gives a wide one, and because the stationary marginal blends all three, it is wider than the sharpest conditional."
    ]
   },
   {
@@ -901,13 +905,13 @@
    "source": [
     "### Sample-law checks\n",
     "\n",
-    "The exact target law lets us check the full distribution.\n",
+    "Curves that overlap by eye can still disagree in the tails, so we put numbers on the comparison against the exact target law.\n",
     "\n",
     "Each regime-conditional increment is $\\mathcal{N}(\\mu_k\\Delta t,\\sigma_k^2\\Delta t)$, and the stationary marginal is the mixture $\\sum_k \\pi_k\\,\\mathcal{N}(\\mu_k\\Delta t,\\sigma_k^2\\Delta t)$.\n",
     "\n",
     "The Kolmogorov-Smirnov (KS) statistic measures the largest gap between the empirical and true cumulative distribution function (CDF), where 0 is perfect.\n",
     "\n",
-    "The checks below report KS D per regime and for the stationary marginal, then verify the sample means and variances against the analytic moments.\n"
+    "We report KS D per regime and for the stationary marginal, which compares the full distributions, and then verify the sample means and variances against the analytic moments, which pins the first two moments down at Monte Carlo tolerance."
    ]
   },
   {
@@ -1112,7 +1116,7 @@
    "source": [
     "## Sample paths\n",
     "\n",
-    "Six representative paths are shown separately so crossings do not hide regime switches. Each panel is labeled by path index, and each segment is colored by the active regime. Slate is regime 0 with positive drift, orange is regime 1 with zero drift, and copper is regime 2 with negative drift."
+    "With one step matching its law, we can look at what 120 of them produce. Six representative paths are shown separately so crossings do not hide regime switches. Each panel is labeled by path index, and each segment is colored by the active regime. Slate is regime 0 with positive drift, orange is regime 1 with zero drift, and copper is regime 2 with negative drift."
    ]
   },
   {
@@ -1159,7 +1163,7 @@
    "id": "94af75f1",
    "metadata": {},
    "source": [
-    "Slate regimes set a positive expected direction, copper regimes set a negative expected direction, and orange regimes have the widest typical spread. Gaussian noise can still reverse any realized increment."
+    "The colors track the local behavior of each path: slate regimes set a positive expected direction, copper regimes set a negative expected direction, and orange regimes have the widest typical spread. Gaussian noise can still reverse any realized increment."
    ]
   },
   {
@@ -1169,7 +1173,7 @@
    "source": [
     "## Regime occupancy\n",
     "\n",
-    "At each timestep, `occupancy[k]` is the fraction of paths in regime $k$. Separate lines expose every regime against the same $1/3$ stationary reference, and shaded bands show $\\pm 2$ Monte Carlo standard errors across independent paths."
+    "Every path starts in regime 0, so the chain has to forget that start before the population can match the uniform stationary law derived above. The occupancy traces let us watch it happen. At each timestep, `occupancy[k]` is the fraction of paths in regime $k$, and separate lines expose every regime against the same $1/3$ stationary reference. The shaded bands show $\\pm 2$ Monte Carlo standard errors, the standard error being the spread of the estimate itself across independent paths, which shrinks like $1/\\sqrt{N}$ in the number of paths."
    ]
   },
   {
@@ -1248,7 +1252,7 @@
    "id": "2bf9c4e0",
    "metadata": {},
    "source": [
-    "Regime 0 falls from 1 while regimes 1 and 2 rise. The three directly comparable lines approach the shared $1/3$ reference as the chain forgets its start."
+    "Regime 0 falls from 1 while regimes 1 and 2 rise, and the three directly comparable lines approach the shared $1/3$ reference as the chain forgets its start."
    ]
   },
   {
@@ -1258,7 +1262,11 @@
    "source": [
     "## Verification\n",
     "\n",
-    "The back-half occupancy checks mixing toward the uniform stationary distribution. The terminal mean is compared with an independently assembled transition matrix for the same discretized Torx chain, then with a half-timestep propagation and the exact continuous-time Markov-chain mean."
+    "Two questions are left. Has the regime chain settled, and is the sampled terminal mean correct?\n",
+    "\n",
+    "For the first, we read the back half of the occupancy traces, the steps past $T/2$, which should sit near the uniform stationary distribution once the chain has mixed.\n",
+    "\n",
+    "For the second, we compare the sampled terminal mean against three references, each answering a different question. A transition matrix we assemble by hand from the same stated one-step probabilities gives the exact answer for the discretized Torx chain we actually run, so it isolates sampling error. A half-timestep propagation and the exact continuous-time Markov-chain mean then show how much of the remaining gap comes from the timestep itself rather than from sampling."
    ]
   },
   {
@@ -1309,7 +1317,9 @@
    "id": "727bf75c",
    "metadata": {},
    "source": [
-    "We assemble the stay, forward, and backward matrices directly from the stated probabilities. This gives an exact terminal-mean reference for the discretized Torx chain, while half-step refinement and a matrix-exponential continuous-time reference expose timestep error without reusing Torx's matrix as the reference."
+    "A check only convinces if its reference is built without the code under test. So we assemble the stay, forward, and backward matrices by hand from the probabilities stated above, and confirm that `PditCycle` reports the same matrix before that matrix is used for anything.\n",
+    "\n",
+    "Propagating the hand-built matrix over the full run gives an exact terminal-mean reference for the discretized Torx chain, which is the number the sampler is held to. Repeating the propagation at half the timestep shows how much of that reference depends on $\\Delta t$. A matrix exponential of the continuous-time generator gives the $\\Delta t \\to 0$ answer, so the two together expose timestep error without reusing Torx's matrix as the reference."
    ]
   },
   {
@@ -1408,7 +1418,7 @@
    "id": "b6106695",
    "metadata": {},
    "source": [
-    "The empirical terminal mean is checked only against the exact reference for the discretized Torx chain. The half-step and matrix-exponential values separately show the scale of continuous-time discretization error."
+    "The empirical terminal mean is checked only against the exact reference for the discretized Torx chain, because that is the chain the sampler is asked to reproduce. The half-step and matrix-exponential values printed beside it separately show the scale of continuous-time discretization error, so the gap between them is a property of the timestep rather than a defect in the sampler."
    ]
   },
   {
@@ -1468,7 +1478,7 @@
     "\n",
     "`PditCycle` advances the 3-state regime chain with first-order transition probabilities, and `MixtureGaussianGate` draws the regime-conditioned position increment. `HybridPCircuit` composes the gates into one Euler step, and a jit-compiled `scan` and `vmap` around `circuit.sample` run 20,000 paths over 120 steps.\n",
     "\n",
-    "The one-step samples match their conditional and stationary-mixture laws. The back-half occupancy approaches the uniform stationary distribution. The terminal mean comparison validates the discretized Torx chain, while the independent half-step and exact continuous-time references expose rather than hide timestep error.\n",
+    "Three checks support that construction. The one-step samples match their conditional and stationary-mixture laws, with the largest KS D at 0.0101 against a sampling tolerance of 0.0354. The back-half occupancy comes within 0.0014 of the uniform stationary distribution. The sampled terminal mean of $+1.4295$ reproduces the exact discretized-chain reference of $+1.4052$ to about one standard error of 0.024, while the independent half-step reference at $+1.4441$ and the exact continuous-time value at $+1.4830$ expose rather than hide the timestep error.\n",
     "\n",
     "See also:\n",
     "- [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb), affine Gaussian gates and exact moment propagation.\n",

--- a/examples/14_gaussian_bernoulli_clustering.ipynb
+++ b/examples/14_gaussian_bernoulli_clustering.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We write Gaussian-categorical clustering as a joint mixture energy. NumPy draws labels, Torx draws the conditional Gaussian samples, JAX computes label probabilities, and the later handwritten JAX Gibbs loop does not execute a Torx gate. Hard assignments exceed 99%, and Gibbs occupancy approaches the mixture weights.</p>\n",
+    "<p>We learn to read a Gaussian mixture as a Boltzmann machine: one joint energy over a continuous visible vector and a categorical hidden unit. Fixing the visible vector turns that energy into a softmax over cluster labels, the responsibilities, and fixing the label turns it into a Gaussian, so those two conditionals are the whole model. We use the softmax to recover the clusters, where hard assignments exceed 99%, and then alternate the two conditionals in a Gibbs chain whose occupancy relaxes to the mixture weights.</p>\n",
     "</div>"
    ]
   },
@@ -23,9 +23,9 @@
    "id": "930b6ce7",
    "metadata": {},
    "source": [
-    "In this tutorial, we write a Gaussian mixture as one energy function and run it as a **Boltzmann machine** [(Ackley et al. 1985)](#ref-ackley-1985). One categorical hidden unit chooses the cluster, and a Gaussian visible vector describes points drawn from that cluster.\n",
+    "In this tutorial, we write a Gaussian mixture as one energy function and run it as a **Boltzmann machine** [(Ackley et al. 1985)](#ref-ackley-1985). One categorical hidden unit chooses the cluster, and a Gaussian visible vector describes points drawn from that cluster, so the whole model is a single energy with two kinds of variable inside it.\n",
     "\n",
-    "In Torx, the model uses the [continuous `pmode` and categorical `pdit`](01_introduction_to_parametrised_stochastic_circuits.ipynb) data primitives. The `pmode` carries the visible vector $v$, and the $K$-state `pdit` carries the one-hot hidden state $h$. We treat them as one Boltzmann kernel $p(v,h)\\propto e^{-E(v,h)}$ on paper. The notebook does not build a single joint Torx energy object.\n",
+    "In Torx, the model uses the [continuous `pmode` and categorical `pdit`](01_introduction_to_parametrised_stochastic_circuits.ipynb) data primitives. The `pmode` carries the visible vector $v$, and the $K$-state `pdit` carries the one-hot hidden state $h$. We derive the joint Boltzmann kernel $p(v,h)\\propto e^{-E(v,h)}$ on paper and then execute it through its two conditionals, which is why the code carries the parameters $(\\mu_k,\\Sigma_k,\\pi_k)$ rather than a single joint Torx energy object.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: pmode and pdit</summary><p>A <code>pmode</code> is continuous-valued, while a <code>pdit</code> stores one of $K$ discrete states. The categorical state $k$ corresponds to the one-hot vector $e_k$ in the derivation.</p></details>\n",
     "\n",
@@ -35,9 +35,9 @@
     "\n",
     "1. write the mixture as one joint energy $E(v,h)$ and derive the cluster probabilities,\n",
     "2. draw labels with NumPy and conditional Gaussian samples with Torx, and\n",
-    "3. recover the clusters in JAX, then run a handwritten JAX block Gibbs loop.\n",
+    "3. recover the clusters in JAX, then run a handwritten JAX block Gibbs loop, which redraws one whole block of variables from its conditional while the other block is held fixed.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>NumPy draws mixture labels, counts, and the final shuffle.</li><li>Torx <code>HybridSampleSimulator</code> and <code>MixtureGaussianGate</code> draw $v\\mid h=k$.</li><li>JAX computes Gaussian-mixture responsibilities.</li><li>Notebook JAX code implements Gibbs directly and does not execute <code>MixtureGaussianGate</code>.</li></ul></details>\n",
+    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>NumPy draws mixture labels, counts, and the final shuffle.</li><li>Torx <code>HybridSampleSimulator</code> and <code>MixtureGaussianGate</code> draw $v\\mid h=k$.</li><li>JAX computes the Gaussian-mixture responsibilities and the hard assignments taken from them.</li><li>Notebook JAX code implements both Gibbs conditionals directly from the analytic formulas.</li></ul></details>\n",
     "\n",
     "This tutorial assumes familiarity with Gaussian mixtures and basic Boltzmann machines. The code uses JAX, NumPy, Matplotlib, and Torx.\n"
    ]
@@ -49,7 +49,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "First we import the numerical, plotting, and Torx dependencies used throughout the tutorial. Path and style setup live in `examples/helpers/_notebook_paths.py` and `examples/helpers/_notebook_style.py`. The analytic density helper is `examples/helpers/_affine_gaussian.py`, and figure encodings live in `examples/helpers/_plots_fields.py`, `examples/helpers/_plots_sampling.py`, and `examples/helpers/_plots_schematics.py`.\n"
+    "First we import the numerical, plotting, and Torx dependencies used throughout the tutorial. Path and style setup live in `examples/helpers/_notebook_paths.py` and `examples/helpers/_notebook_style.py`. The analytic density helper is `examples/helpers/_affine_gaussian.py`, and figure encodings live in `examples/helpers/_plots_fields.py`, `examples/helpers/_plots_sampling.py`, and `examples/helpers/_plots_schematics.py`, which keeps the modelling cells below short.\n"
    ]
   },
   {
@@ -145,13 +145,13 @@
    "source": [
     "## One energy for a visible vector and a one-hot hidden\n",
     "\n",
-    "The model is a joint energy over one continuous visible vector and one categorical hidden state. For diagonal component variances, the Gaussian-mixture energy used by the code is\n",
+    "Our aim in this section is to see that a Gaussian mixture is already a Boltzmann machine, because one energy over a continuous visible vector and one categorical hidden state generates both the cluster probabilities and the per-cluster Gaussians we use later. For diagonal component variances, the Gaussian-mixture energy used by the code is\n",
     "\n",
     "$$\n",
     "E(v,h)=\\sum_k h_k\\left[\\frac{1}{2}\\sum_i\\frac{(v_i-\\mu_{ki})^2}{\\sigma_{ki}^2}+\\frac{1}{2}\\sum_i\\log\\sigma_{ki}^2-\\log\\pi_k\\right],\\qquad p(v,h)\\propto e^{-E(v,h)}.\n",
     "$$\n",
     "\n",
-    "The $k$-independent Gaussian normalizer is omitted. The hidden state is one-hot by construction:\n",
+    "The $k$-independent Gaussian normalizer is omitted, since it cancels in every comparison across clusters that follows. The hidden state is one-hot by construction:\n",
     "\n",
     "$$\n",
     "\\sum_k h_k=1,\\qquad h_k\\in\\{0,1\\},\n",
@@ -159,7 +159,7 @@
     "\n",
     "so $h$ is one of the $K$ basis states $e_k$.\n",
     "\n",
-    "For shared $\\sigma_i$ this energy also has the linear-coupling form\n",
+    "Written that way the energy still looks specific to mixtures, so we rewrite it once to show that it is an ordinary Boltzmann machine with linear couplings between the visible and hidden units. For shared $\\sigma_i$ the same energy is\n",
     "\n",
     "$$\n",
     "E(v,h)=\\sum_i\\frac{(v_i-a_i)^2}{2\\sigma_i^2}-\\sum_k c_k h_k-\\sum_{i,k}\\frac{v_i}{\\sigma_i}W_{ik}h_k+\\text{constant},\n",
@@ -172,11 +172,11 @@
     "c_k=\\log\\pi_k-a^\\top\\operatorname{diag}(\\sigma)^{-1}W_{:k}-\\frac{1}{2}\\lVert W_{:k}\\rVert^2,\n",
     "$$\n",
     "\n",
-    "up to one $k$-independent additive constant. The bias $c_k$ alone is not the log mixture weight because completing the square contributes the other two terms.\n",
+    "up to one $k$-independent additive constant. The bias $c_k$ alone is not the log mixture weight, because completing the square contributes the other two terms. The code never needs $W$, since it works with $(\\mu_k,\\Sigma_k,\\pi_k)$ throughout, but this equivalence is what licenses calling the model a Boltzmann machine at all.\n",
     "\n",
-    "This tutorial uses the structural route: the $K$ cluster choices are represented by one `pdit`. The closing section compares this exact categorical constraint with an energetic winner-take-all penalty over binary units.\n",
+    "There are two ways to hold $h$ to a one-hot state. Structurally, a single $K$-state `pdit` represents the $K$ cluster choices and nothing else. Energetically, a penalty over $K$ binary units makes the one-hot configurations the ground states. This tutorial takes the structural route, and the closing section builds the energetic one so we can compare the exact categorical constraint against a winner-take-all penalty at finite strength.\n",
     "\n",
-    "Holding $v$ fixed gives a softmax across the one-hot states. Holding $h=e_k$ fixed gives the Gaussian for component $k$.\n",
+    "Holding $v$ fixed gives a softmax across the one-hot states, and holding $h=e_k$ fixed gives the Gaussian for component $k$. Those two readings are the next two sections.\n",
     "\n",
     "We use three well-separated cluster means, shared variance, and unequal mixture weights.\n"
    ]
@@ -250,7 +250,7 @@
    "id": "fdd518e8",
    "metadata": {},
    "source": [
-    "The factor graph shows the two conditional readings of the same Gaussian-categorical energy. Fixing $v$ gives cluster probabilities, and fixing $h=e_k$ gives the Gaussian for cluster $k$.\n"
+    "Before specializing either conditional, we look at the factor graph of this energy, because it shows that inference and generation are two readings of one object rather than two separate models.\n"
    ]
   },
   {
@@ -296,7 +296,7 @@
    "id": "e3a21297",
    "metadata": {},
    "source": [
-    "The diagram shows inference and generation as two directions through the same factor."
+    "Both directions run through the same factor: fixing $v$ gives the cluster probabilities, and fixing $h=e_k$ gives the Gaussian for cluster $k$."
    ]
   },
   {
@@ -306,18 +306,18 @@
    "source": [
     "## The softmax emerges\n",
     "\n",
-    "Holding $v$ fixed leaves one component score per hidden state:\n",
+    "Taking the first reading, holding $v$ fixed leaves one component score per hidden state, which makes the categorical conditional a softmax:\n",
     "\n",
     "$$\n",
     "p(h=e_k\\mid v)=\\operatorname{softmax}_k(\\theta(v)),\\qquad\n",
     "\\theta_k(v)=\\log\\pi_k-\\frac{1}{2}\\sum_i\\frac{(v_i-\\mu_{ki})^2}{\\sigma_{ki}^2}-\\frac{1}{2}\\sum_i\\log\\sigma_{ki}^2.\n",
     "$$\n",
     "\n",
-    "This is exactly the expression implemented by `cluster_logits`. With shared covariance and the linear-coupling parameterization above, the same score is $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
+    "The recovery section further down implements exactly this expression, in a function we will meet there called `cluster_logits`. With shared covariance and the linear-coupling parameterization above, the same score is $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: responsibility</summary><p>A Gaussian-mixture responsibility is the posterior probability $p(h=e_k\\mid v)$ that component $k$ generated a point, as in the mixture-model treatment of <a href=\"#ref-dempster-1977\">Dempster et al. 1977</a>.</p></details>\n",
     "\n",
-    "A single bias `pbit` gives a sigmoid, and a one-hot `pdit` gives a softmax. The continuous conditional is supplied by `MixtureGaussianGate` in the next section.\n"
+    "The shape of the conditional comes from the hidden unit alone: a single bias `pbit` gives a sigmoid, while the one-hot `pdit` used here gives a softmax. The matching continuous conditional is supplied by `MixtureGaussianGate` in the next section.\n"
    ]
   },
   {
@@ -327,15 +327,15 @@
    "source": [
     "## The Gaussian conditional and the gate\n",
     "\n",
-    "Fixing $h=e_k$ leaves the energy quadratic in $v$:\n",
+    "The second reading fixes $h=e_k$, which leaves the energy quadratic in $v$ and therefore Gaussian:\n",
     "\n",
     "$$\n",
     "p(v\\mid h=e_k)=\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k),\\qquad p(v)=\\sum_k \\pi_k\\,\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k).\n",
     "$$\n",
     "\n",
-    "The code works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, the same parameters used by the energy and `cluster_logits`. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects these parameters to the linear-coupling form above.\n",
+    "The code works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, the same parameters used by the energy and `cluster_logits`, so the two conditionals cannot drift apart. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects these parameters to the linear-coupling form above.\n",
     "\n",
-    "`MixtureGaussianGate` realizes only $p(v\\mid h=e_k)$. A single `pdit` stores the cluster index $k\\in\\{0,1,2\\}$ directly.\n",
+    "This Gaussian conditional is the piece Torx executes: `MixtureGaussianGate` realizes $p(v\\mid h=e_k)$ and nothing else, with a single `pdit` storing the cluster index $k\\in\\{0,1,2\\}$ directly.\n",
     "\n",
     "Next, we construct `gate` and wrap it in a `HybridPCircuit` named `gen`. The circuit infers and preserves the gate's discrete control wire, so the seeded cluster label passes through unchanged."
    ]
@@ -367,7 +367,7 @@
    "id": "2e20f1e1",
    "metadata": {},
    "source": [
-    "The circuit diagram shows the Gaussian mixture as one hybrid gate."
+    "We draw the circuit to see how little structure this model needs."
    ]
   },
   {
@@ -413,7 +413,7 @@
    "id": "7b4e5c14",
    "metadata": {},
    "source": [
-    "The categorical input passes through the near-no-op registration gate, then selects the continuous Gaussian output.\n"
+    "The whole Gaussian mixture is one hybrid gate: the categorical input passes through the near-no-op registration gate, then selects which Gaussian the continuous output comes from.\n"
    ]
   },
   {
@@ -423,7 +423,7 @@
    "source": [
     "### Generating the clusters\n",
     "\n",
-    "NumPy draws the component counts from $\\pi$ and later shuffles the labeled blocks. For each NumPy label $k$, Torx seeds the discrete state and `MixtureGaussianGate` draws $v\\sim\\mathcal{N}(\\mu_k,\\Sigma_k)$.\n",
+    "To have something to cluster, we generate a labeled data set whose ground truth we know, splitting the work between two libraries. NumPy draws the component counts from $\\pi$ and later shuffles the labeled blocks, and for each NumPy label $k$, Torx seeds the discrete state so that `MixtureGaussianGate` draws $v\\sim\\mathcal{N}(\\mu_k,\\Sigma_k)$.\n",
     "\n",
     "A multinomial split sets the number of conditional samples requested from each cluster.\n"
    ]
@@ -523,7 +523,7 @@
    "id": "f93e225d",
    "metadata": {},
    "source": [
-    "We compute the sampled per-cluster moments as a numerical check on the generated clusters."
+    "Before looking at any figure, we compute the sampled per-cluster moments, because they are the cheapest way to confirm that each block of Torx draws really came from the component we seeded."
    ]
   },
   {
@@ -571,7 +571,7 @@
    "id": "ac10a4c0",
    "metadata": {},
    "source": [
-    "The scatter plot compares NumPy labels and Torx conditional samples with analytic one-sigma contours. The black circle around each cluster is the $1\\sigma$ contour of $\\mathcal{N}(\\mu_k,\\Sigma_k)$, and the $+$ marks the mean $\\mu_k$.\n"
+    "The scatter plot puts the NumPy labels and the Torx conditional samples in one frame with the analytic one-sigma contours, so we can see whether the drawn points sit where the components say they should. The black circle around each cluster is the $1\\sigma$ contour of $\\mathcal{N}(\\mu_k,\\Sigma_k)$, and the $+$ marks the mean $\\mu_k$.\n"
    ]
   },
   {
@@ -620,17 +620,15 @@
    "source": [
     "## Recovering clusters with the softmax\n",
     "\n",
+    "Now we run the energy the other way and ask which cluster each sampled point came from, which is the softmax conditional evaluated at the data:\n",
+    "\n",
     "$$\n",
     "p(h=e_k\\mid v)=\\frac{\\exp[-E_k(v)]}{\\sum_{k'}\\exp[-E_{k'}(v)]}=\\operatorname{softmax}_k(\\theta(v)),\\qquad \\theta_k(v)=\\log \\pi_k-\\frac{1}{2}(v-\\mu_k)^\\top\\Sigma_k^{-1}(v-\\mu_k)-\\frac{1}{2}\\log\\det\\Sigma_k.\n",
     "$$\n",
     "\n",
-    "This is the Gaussian-mixture responsibility from the opening energy. The logits are the negated component energies with shared constants removed, so each row is the one-hot Boltzmann conditional.\n",
+    "This is the Gaussian-mixture responsibility from the opening energy, because the logits are the negated component energies with shared constants removed, so each row is the one-hot Boltzmann conditional.\n",
     "\n",
-    "The log-determinant is required when covariances differ. With the shared diagonal covariance used here, it cancels in the softmax.\n",
-    "\n",
-    "The assignment figure overlays hard $\\arg\\max_k p(k\\mid v)$ labels on the soft responsibility field. Its legend shows how the component colors blend to encode $p(k\\mid v)$.\n",
-    "\n",
-    "The clusters are well separated, so every point is recovered with near-certain responsibility. The field blends between colors only in the empty regions between clusters.\n",
+    "The log-determinant is required when covariances differ, and with the shared diagonal covariance used here it cancels in the softmax.\n",
     "\n",
     "The `cluster_logits` function below builds these logits from the component energies.\n"
    ]
@@ -693,7 +691,7 @@
    "id": "e3a1af0c",
    "metadata": {},
    "source": [
-    "We use `posterior_probs` to turn the component energies into hard assignments and a soft-boundary score."
+    "`posterior_probs` softmaxes those logits into responsibilities, from which we take the hard label $\\arg\\max_k p(k\\mid v)$ and the fraction of points whose top responsibility falls below 0.92, a soft-boundary score counting how many points are genuinely ambiguous. We then plot the hard labels on top of the soft responsibility field."
    ]
   },
   {
@@ -778,7 +776,7 @@
    "id": "6efeed89",
    "metadata": {},
    "source": [
-    "The assignment figure shows near-certain assignments on every point, with the responsibility field blending only in the empty regions between clusters.\n"
+    "The assignment figure overlays the hard $\\arg\\max_k p(k\\mid v)$ labels on the soft responsibility field, whose component colors blend to encode $p(k\\mid v)$. Every point is recovered with a near-certain responsibility, at a printed hard reassignment accuracy of 1.000 and a soft boundary fraction of 0.000, and the field blends between colors only in the empty regions between clusters, where no data live.\n"
    ]
   },
   {
@@ -786,7 +784,7 @@
    "id": "1ae915ab",
    "metadata": {},
    "source": [
-    "Next we check one visible coordinate against the exact mixture density. The density comes from `mixture_density`, a notebook helper in `examples/helpers/_affine_gaussian.py` that evaluates the analytic Gaussian mixture on a grid."
+    "One more check on the generated data closes this section. We compare the histogram of a single visible coordinate against the exact mixture density for that coordinate, which tests the marginal rather than the per-cluster blocks. The density comes from `mixture_density`, a notebook helper in `examples/helpers/_affine_gaussian.py` that evaluates the analytic Gaussian mixture on a grid."
    ]
   },
   {
@@ -861,7 +859,7 @@
    "id": "480984cb",
    "metadata": {},
    "source": [
-    "The histogram follows the analytic mixture density for the selected coordinate."
+    "For the selected coordinate, the sampled histogram follows the analytic mixture density, so the marginal of the generated data reproduces the mixture we specified."
    ]
   },
   {
@@ -871,17 +869,17 @@
    "source": [
     "## Block Gibbs on the joint Boltzmann machine\n",
     "\n",
+    "With both conditionals in hand we can stop conditioning on fixed data and sample the joint law itself, by alternating them:\n",
+    "\n",
     "$$\n",
     "h\\sim p(h\\mid v)=\\operatorname{softmax}(\\theta(v)),\\qquad v\\sim p(v\\mid h=e_k)=\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k).\n",
     "$$\n",
     "\n",
-    "The notebook implements both Gibbs updates directly in JAX from the same conditional formulas. This handwritten loop does not call `MixtureGaussianGate`, a Torx circuit, or a Torx simulator. One sweep redraws each visible point from its current component, then redraws its label from the analytic responsibility vector.\n",
+    "We implement both updates directly in JAX from these same formulas, so the Gibbs mechanics stay visible line by line, which means Torx's role in this notebook ends with the conditional Gaussian draws above. One sweep redraws each visible point from its current component, then redraws its label from the analytic responsibility vector.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: Gibbs sweep</summary><p>A <a href=\"https://doi.org/10.1093/biomet/81.3.541\">block Gibbs sweep</a> redraws each variable block from its conditional distribution while holding the other block fixed.</p></details>\n",
+    "<details class=\"tx-disclosure\"><summary>Term: Gibbs sweep</summary><p>A <a href=\"#ref-geman-1984\">block Gibbs sweep (Geman and Geman 1984)</a> redraws each variable block from its conditional distribution while holding the other block fixed.</p></details>\n",
     "\n",
-    "Mixing speed depends on cluster overlap. The well-separated mixture above would leave chains almost frozen, so this convergence study uses closer means and a larger shared variance. Every chain starts in cluster 0, and the per-sweep population occupancy relaxes toward $\\pi$.\n",
-    "\n",
-    "The curves need not land exactly on the dashed targets because a finite population of chains has sampling noise.\n"
+    "Mixing speed depends on cluster overlap, and the well-separated mixture above would leave chains almost frozen in whichever cluster they started, so this convergence study uses closer means and a larger shared variance. Every chain starts in cluster 0, which is as far off-stationary as the population can be, and the per-sweep population occupancy then relaxes toward $\\pi$. The curves need not sit exactly on the dashed targets, because a finite population of chains carries sampling noise of its own.\n"
    ]
   },
   {
@@ -1039,7 +1037,7 @@
    "id": "c2cbc03d",
    "metadata": {},
    "source": [
-    "We run 30 Gibbs sweeps over 6,000 chains and record the occupancy at each sweep."
+    "We run 30 Gibbs sweeps over 6,000 chains and record the occupancy at each sweep, which gives us the whole relaxation curve rather than only its endpoint."
    ]
   },
   {
@@ -1125,7 +1123,7 @@
    "id": "3eac0ee6",
    "metadata": {},
    "source": [
-    "The handwritten JAX chain's back-half occupancy lands on $\\pi$ within finite-population sampling noise.\n"
+    "The occupancy leaves its seeded $(1, 0, 0)$ start within a few sweeps and then flattens out. Pooling the back half of the sweeps, after that transient, gives $(0.403, 0.350, 0.246)$ against the target weights $\\pi=(0.400, 0.350, 0.250)$, so the handwritten JAX chain reproduces the mixture weights to within 0.004 per component, the size of the finite-population sampling noise here.\n"
    ]
   },
   {
@@ -1135,7 +1133,7 @@
    "source": [
     "## The one-hot constraint as a winner-take-all energy\n",
     "\n",
-    "Recall from the opening energy section that the one-hot constraint can be written as the penalty energy over binary units $z\\in\\{0,1\\}^K$:\n",
+    "We close by building the energetic alternative named at the start, so the structural choice this notebook made can be compared against it at a definite penalty strength. Recall from the opening energy section that the one-hot constraint can be written as the penalty energy over binary units $z\\in\\{0,1\\}^K$:\n",
     "\n",
     "$$\n",
     "E_{\\mathrm{WTA}}(z) = \\lambda\\Big(\\sum_k z_k - 1\\Big)^2,\n",
@@ -1143,9 +1141,9 @@
     "\n",
     "whose ground states are exactly the one-hot vectors $e_k$. Up to the constant $\\lambda$, the penalty expands into a bias term $-\\lambda\\sum_k z_k$ plus an all-pairs repulsion $2\\lambda\\sum_{k<k'} z_k z_{k'}$, a winner-take-all Potts-type coupling.\n",
     "\n",
-    "Its Boltzmann distribution $p(z)\\propto e^{-E_{\\mathrm{WTA}}(z)}$ concentrates on those one-hot states. By symmetry it assigns the one-hot states equal probability. At finite $\\lambda$ it still leaks mass onto non-one-hot configurations (the sweep below makes this leakage visible), so it equals the structural $K$-state `pdit` only in the $\\lambda\\to\\infty$ limit, or once restricted to the one-hot subset. Increasing $\\lambda$ sharpens the concentration toward that uniform categorical.\n",
+    "Its Boltzmann distribution $p(z)\\propto e^{-E_{\\mathrm{WTA}}(z)}$ therefore concentrates on those one-hot states, and by symmetry it assigns them equal probability. At finite $\\lambda$ it still leaks mass onto non-one-hot configurations, which the sweep below makes visible, so it equals the structural $K$-state `pdit` only in the $\\lambda\\to\\infty$ limit, or once restricted to the one-hot subset. Increasing $\\lambda$ sharpens the concentration toward that uniform categorical.\n",
     "\n",
-    "Here we enumerate all $2^K$ binary configurations and compute the exact finite Boltzmann distribution of the energy directly. On hardware, the same penalty can be realized with pairwise couplings, but the equilibrium object below is the energy distribution itself."
+    "Here we enumerate all $2^K$ binary configurations and compute the exact finite Boltzmann distribution of the energy directly, so no sampling error enters the comparison. On hardware, the same penalty can be realized with pairwise couplings, but the equilibrium object below is the energy distribution itself."
    ]
   },
   {
@@ -1175,7 +1173,7 @@
    "id": "62e0465e",
    "metadata": {},
    "source": [
-    "The normalized Boltzmann probability of each configuration follows directly from its penalty energy.\n"
+    "With only $2^K$ configurations to sum over, the normalized Boltzmann probability of each one follows directly from its penalty energy.\n"
    ]
   },
   {
@@ -1204,7 +1202,7 @@
    "id": "3c036a9e",
    "metadata": {},
    "source": [
-    "The exact probabilities show how much mass the penalty places on one-hot states."
+    "We evaluate that distribution at $\\lambda=4$ and total the mass sitting on one-hot states, which is the number that says how closely the penalty imitates a `pdit`."
    ]
   },
   {
@@ -1295,7 +1293,7 @@
    "id": "7eff7bb8",
    "metadata": {},
    "source": [
-    "The winner-take-all figure shows equal probability across one-hot states and increasing one-hot mass as the penalty grows."
+    "At $\\lambda=4$ the three one-hot states share the mass equally at 0.325387 each, for a one-hot total of 0.976161, and the sweep over $\\lambda$ shows that total rising as the penalty grows. The remaining 0.024 sits on configurations that a $K$-state `pdit` cannot represent at all, which is the price of the energetic route at finite $\\lambda$."
    ]
   },
   {
@@ -1305,7 +1303,17 @@
    "source": [
     "## Verification\n",
     "\n",
-    "We check the numerical claims behind the figures: component moments, mixture weights, posterior normalization, hard recovery, marginal moments, Gibbs occupancy, and the winner-take-all distribution."
+    "The figures above are readings, so we finish by asserting the numbers behind them.\n",
+    "\n",
+    "First the generated data against the parameters we asked for. Each cluster's sampled mean matches $\\mu_k$ within 0.06 and its sampled variance matches $\\sigma_k^2$ within 12% relative, and the realized label proportions match $\\pi$ within 0.025, so the NumPy-and-Torx generation path is faithful to the model it claims to sample.\n",
+    "\n",
+    "Then the inference path. Every responsibility row sums to one within $10^{-6}$, and the softmax of our Boltzmann logits matches responsibilities assembled independently from per-component Gaussian densities within $10^{-4}$, which is the claim that the energy view and the textbook mixture view are the same computation. Hard reassignment accuracy is asserted above 0.99, confirming that clusters this well separated are recoverable from the responsibilities alone.\n",
+    "\n",
+    "Next, the pooled sample mean and variance of the visible data match the analytic mixture moments within 0.08 and 5% relative, so the full marginal is right as well as the per-cluster blocks checked earlier.\n",
+    "\n",
+    "For the Gibbs chain we assert both ends. The seeded start really is off-stationary, with over 95% of chains in cluster 0, and the back-half occupancy is within 0.04 of $\\pi$ in every component, which together make the trace a relaxation rather than a chain that began at its target.\n",
+    "\n",
+    "Finally, the winner-take-all distribution puts over 95% of its mass on one-hot states, spreads that mass equally across them to within $10^{-9}$, and increases monotonically in $\\lambda$, matching the three claims made for it above."
    ]
   },
   {
@@ -1453,12 +1461,9 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "This tutorial wrote a Gaussian-categorical mixture as one Boltzmann machine.\n",
+    "This tutorial wrote a Gaussian-categorical mixture as one Boltzmann machine, then ran that single energy from both sides.\n",
     "\n",
-    "- The analytic joint energy uses the same $(\\mu_k,\\Sigma_k,\\pi_k)$ parameterization as the executed JAX logits.\n",
-    "- NumPy drew labels and shuffled blocks, while Torx `MixtureGaussianGate` drew only the conditional Gaussian samples.\n",
-    "- JAX computed responsibilities and hard assignments.\n",
-    "- A separate handwritten JAX Gibbs loop alternated the two conditional formulas without executing a Torx gate.\n",
+    "The analytic joint energy uses the same $(\\mu_k,\\Sigma_k,\\pi_k)$ parameterization as the executed JAX logits, which is what lets the derivation on paper and the running code check each other. Generation split across two libraries: NumPy drew the labels and shuffled the blocks, while Torx `MixtureGaussianGate` drew the conditional Gaussian samples and nothing else. Recovery was pure JAX, computing the responsibilities and the hard assignments taken from them. The closing block Gibbs section then alternated the two conditional formulas in a separate handwritten JAX loop, which kept every step of a sweep on the page.\n",
     "\n",
     "See also:\n",
     "- [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb), pure Gaussian gates and closed-form Gaussian conditioning.\n",
@@ -1473,7 +1478,8 @@
     "## References\n",
     "\n",
     "1. <span id=\"ref-ackley-1985\"></span>Ackley, D.H., Hinton, G.E., Sejnowski, T.J. 1985. [*A learning algorithm for Boltzmann machines*](https://www.cs.toronto.edu/~hinton/absps/cogscibm.pdf). Cognitive Science 9(1), 147-169. Foundational Boltzmann-machine definition and equilibrium treatment.\n",
-    "2. <span id=\"ref-dempster-1977\"></span>Dempster, A.P., Laird, N.M., Rubin, D.B. 1977. [*Maximum likelihood from incomplete data via the EM algorithm*](https://doi.org/10.1111/j.2517-6161.1977.tb01600.x). Journal of the Royal Statistical Society B 39(1), 1-38.\n"
+    "2. <span id=\"ref-dempster-1977\"></span>Dempster, A.P., Laird, N.M., Rubin, D.B. 1977. [*Maximum likelihood from incomplete data via the EM algorithm*](https://doi.org/10.1111/j.2517-6161.1977.tb01600.x). Journal of the Royal Statistical Society B 39(1), 1-38. Introduces the responsibility, the posterior over mixture components used throughout this notebook.\n",
+    "3. <span id=\"ref-geman-1984\"></span>Geman, S., Geman, D. 1984. [*Stochastic relaxation, Gibbs distributions, and the Bayesian restoration of images*](https://doi.org/10.1109/TPAMI.1984.4767596). IEEE Transactions on Pattern Analysis and Machine Intelligence 6(6), 721-741. Introduces Gibbs sampling as stochastic relaxation toward a Boltzmann distribution, the block sweep run above.\n"
    ]
   }
  ],

--- a/examples/14_gaussian_bernoulli_clustering.ipynb
+++ b/examples/14_gaussian_bernoulli_clustering.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "so $h$ is one of the $K$ basis states $e_k$.\n",
     "\n",
-    "Written that way the energy still looks specific to mixtures, so we rewrite it once to show that it is an ordinary Boltzmann machine with linear couplings between the visible and hidden units. For shared $\\sigma_i$ the same energy is\n",
+    "Written that way the energy still looks specific to mixtures, so we rewrite it once to show that it's an ordinary Boltzmann machine with linear couplings between the visible and hidden units. For shared $\\sigma_i$ the same energy is\n",
     "\n",
     "$$\n",
     "E(v,h)=\\sum_i\\frac{(v_i-a_i)^2}{2\\sigma_i^2}-\\sum_k c_k h_k-\\sum_{i,k}\\frac{v_i}{\\sigma_i}W_{ik}h_k+\\text{constant},\n",
@@ -172,7 +172,7 @@
     "c_k=\\log\\pi_k-a^\\top\\operatorname{diag}(\\sigma)^{-1}W_{:k}-\\frac{1}{2}\\lVert W_{:k}\\rVert^2,\n",
     "$$\n",
     "\n",
-    "up to one $k$-independent additive constant. The bias $c_k$ alone is not the log mixture weight, because completing the square contributes the other two terms. The code never needs $W$, since it works with $(\\mu_k,\\Sigma_k,\\pi_k)$ throughout, but this equivalence is what licenses calling the model a Boltzmann machine at all.\n",
+    "up to one $k$-independent additive constant. The bias $c_k$ alone isn't the log mixture weight, because completing the square contributes the other two terms. The code never needs $W$, since it works with $(\\mu_k,\\Sigma_k,\\pi_k)$ throughout, but this equivalence is what licenses calling the model a Boltzmann machine at all.\n",
     "\n",
     "There are two ways to hold $h$ to a one-hot state. Structurally, a single $K$-state `pdit` represents the $K$ cluster choices and nothing else. Energetically, a penalty over $K$ binary units makes the one-hot configurations the ground states. This tutorial takes the structural route, and the closing section builds the energetic one so we can compare the exact categorical constraint against a winner-take-all penalty at finite strength.\n",
     "\n",
@@ -313,7 +313,7 @@
     "\\theta_k(v)=\\log\\pi_k-\\frac{1}{2}\\sum_i\\frac{(v_i-\\mu_{ki})^2}{\\sigma_{ki}^2}-\\frac{1}{2}\\sum_i\\log\\sigma_{ki}^2.\n",
     "$$\n",
     "\n",
-    "The recovery section further down implements exactly this expression, in a function we will meet there called `cluster_logits`. With shared covariance and the linear-coupling parameterization above, the same score is $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
+    "The recovery section further down implements exactly this expression, in a function we'll meet there called `cluster_logits`. With shared covariance and the linear-coupling parameterization above, the same score is $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: responsibility</summary><p>A Gaussian-mixture responsibility is the posterior probability $p(h=e_k\\mid v)$ that component $k$ generated a point, as in the mixture-model treatment of <a href=\"#ref-dempster-1977\">Dempster et al. 1977</a>.</p></details>\n",
     "\n",
@@ -333,7 +333,7 @@
     "p(v\\mid h=e_k)=\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k),\\qquad p(v)=\\sum_k \\pi_k\\,\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k).\n",
     "$$\n",
     "\n",
-    "The code works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, the same parameters used by the energy and `cluster_logits`, so the two conditionals cannot drift apart. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects these parameters to the linear-coupling form above.\n",
+    "The code works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, the same parameters used by the energy and `cluster_logits`, so the two conditionals can't drift apart. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects these parameters to the linear-coupling form above.\n",
     "\n",
     "This Gaussian conditional is the piece Torx executes: `MixtureGaussianGate` realizes $p(v\\mid h=e_k)$ and nothing else, with a single `pdit` storing the cluster index $k\\in\\{0,1,2\\}$ directly.\n",
     "\n",
@@ -1293,7 +1293,7 @@
    "id": "7eff7bb8",
    "metadata": {},
    "source": [
-    "At $\\lambda=4$ the three one-hot states share the mass equally at 0.325387 each, for a one-hot total of 0.976161, and the sweep over $\\lambda$ shows that total rising as the penalty grows. The remaining 0.024 sits on configurations that a $K$-state `pdit` cannot represent at all, which is the price of the energetic route at finite $\\lambda$."
+    "At $\\lambda=4$ the three one-hot states share the mass equally at 0.325387 each, for a one-hot total of 0.976161, and the sweep over $\\lambda$ shows that total rising as the penalty grows. The remaining 0.024 sits on configurations that a $K$-state `pdit` can't represent at all, which is the price of the energetic route at finite $\\lambda$."
    ]
   },
   {

--- a/examples/15_intro_to_factors.ipynb
+++ b/examples/15_intro_to_factors.ipynb
@@ -13,8 +13,8 @@
    "id": "9967b62e",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>The notebook defines four tutorial factors and composes them with Torx's factor bases, sampler, directed graph, and composite factors. Same-key checks compare Torx <code>TiledFactor</code> and <code>ChainFactor</code> with manual JAX equivalents.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We define four tutorial factors, sample each one on its own, then compose them with Torx's factor bases, sampler, directed graph, and composite factors, so a single sampling interface carries from one probabilistic bit up to a whole graph. Because Torx <code>TiledFactor</code> and <code>ChainFactor</code> are meant to be bookkeeping around a factor and nothing more, we rerun them with the same random keys as manual JAX equivalents and require the draws to agree exactly.</p>\n",
     "</div>\n"
    ]
   },
@@ -23,22 +23,15 @@
    "id": "40ce5e41",
    "metadata": {},
    "source": [
-    "In this tutorial, we build with Torx factors from a single **probabilistic bit** (pbit), wire two factors into a Torx directed factor graph, and connect that software hierarchy to the parametrised stochastic circuit (PSC) view used elsewhere in the gallery.\n",
+    "In this tutorial we start from the smallest object Torx can sample, a single **probabilistic bit** (pbit), and build upward from there. We give that pbit a factor of its own, wire two factors into a Torx directed factor graph, and then connect the resulting software hierarchy to the parametrised stochastic circuit (PSC) view used elsewhere in the gallery.\n",
     "\n",
-    "A Torx **factor** reads named inputs, reads parameters stored outside the object, and returns one stochastic output. The notebook defines `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor` for teaching. These are not Torx library primitives.\n",
+    "A **factor** is one conditional distribution packaged as an object. It reads named inputs, reads parameters that live outside the object and arrive with each call, and returns one stochastic output. Keeping the parameters outside is what makes a factor reusable, because the object itself carries no numbers to get stale. Four factors carry the teaching here: `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor` are defined in this notebook and are not Torx library primitives, while the base classes, sampler, graph, and composites that combine them all come from Torx.\n",
     "\n",
-    "| Label used below | Owner |\n",
-    "|---|---|\n",
-    "| Torx primitive | `AbstractReferenceFactor`, `AbstractMatrixFactor`, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, `ChainFactor` |\n",
-    "| Tutorial factor | the four notebook-defined classes and their probability formulas |\n",
-    "| Notebook JAX | batching, compilation, estimates, and checks |\n",
-    "| Plot helper | presentation only |\n",
-    "\n",
-    "This tutorial mirrors [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) from the factor side. It also connects the same composition ideas to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n",
+    "A **directed factor graph** is a set of such factors with the output of one wired into the input of another, arranged without cycles so that every node can be sampled in a single pass from parents to children. Torx gates are factors as well, through their base classes, so the difference between a gate and a bare factor is not the probability model but how much has already been decided about placement. A PSC fixes their placement into circuit wiring, while a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Torx DFG and conventional factor graph</summary><p>A Torx directed factor graph is a DAG of conditional samplers, while the <a href=\"#ref-kschischang-2001\">conventional factor graph</a> of Kschischang et al. is a bipartite graph of variable and factor nodes. A PSC subclasses Torx <code>AbstractDFG</code> as a circuit-shaped implementation, but it is not a subclass of the concrete Torx <code>DFG</code> class.</p></details>\n",
     "\n",
-    "Torx gates are factors through their base classes. A PSC fixes their placement into circuit wiring, while a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n"
+    "This tutorial mirrors [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) from the factor side, so the two are worth reading together for both views of the same idea. It also connects the same composition ideas to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n"
    ]
   },
   {
@@ -48,9 +41,9 @@
    "source": [
     "## Setup\n",
     "\n",
-    "We set up helper paths, imports, styling, and figure export. `jax.ShapeDtypeStruct` records a port's shape and dtype without allocating data; `BIT` describes one integer pbit, and `DRIVE` one scalar floating-point input.\n",
+    "Before any factor exists we need paths, imports, styling, figure export, and a way to describe a port without allocating an array for it. `jax.ShapeDtypeStruct` records a port's shape and dtype without allocating data, so we use it to declare the only two port types this notebook needs: `BIT` describes one integer pbit, and `DRIVE` one scalar floating-point input.\n",
     "\n",
-    "The `examples/helpers` modules used here handle paths, style, and plots only.\n"
+    "The `examples/helpers` modules used here handle paths, style, and plots only, which means none of the probability model is hidden inside them.\n"
    ]
   },
   {
@@ -188,9 +181,9 @@
    "source": [
     "## A tutorial factor as a sampler\n",
     "\n",
-    "The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor`. It has no input ports, so it is a distribution over one pbit. The parameter dictionary lives outside the object and is passed into each `sample` call.\n",
+    "We meet the contract first in its simplest form, on a factor that takes no inputs at all, so nothing about wiring gets in the way. The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor`. It has no input ports, so it is a distribution over one pbit.\n",
     "\n",
-    "Its custom `sample` method draws 1 with probability $\\sigma(b)$ through Torx `JaxPRNGSampler`.\n"
+    "Two details of the contract are visible right away. The parameter dictionary lives outside the object and is passed into each `sample` call, and the custom `sample` method draws 1 with probability $\\sigma(b)$ through Torx `JaxPRNGSampler`.\n"
    ]
   },
   {
@@ -262,7 +255,7 @@
    "id": "4fa9de59",
    "metadata": {},
    "source": [
-    "The sampled frequency lands on the sigmoid target, so the factor draws its declared distribution."
+    "Averaged over 20,000 independent keys, the sampled frequency of 1 comes out at 0.601 against a target $\\sigma(b)$ of 0.599, which confirms that the factor draws the distribution it declares and does so well inside the tolerance of 0.02 we assert at the end."
    ]
   },
   {
@@ -272,13 +265,13 @@
    "source": [
     "## A tutorial factor with inputs\n",
     "\n",
-    "The notebook-defined `ConditionalBit` uses the same Torx base contract with one named input port. Its custom formula is\n",
+    "A factor with no inputs cannot be wired into anything, so the next step is one that reads a value from elsewhere. The notebook-defined `ConditionalBit` uses the same Torx base contract with one named input port. Its custom formula is\n",
     "\n",
     "$$\n",
     "P(\\text{out}=1 \\mid x)=\\sigma(wx+b).\n",
     "$$\n",
     "\n",
-    "The sweep below checks that samples drawn through Torx `JaxPRNGSampler` track that sigmoid curve.\n"
+    "To see whether the object really implements that formula, we sweep the drive across 21 values, draw 8,000 samples at each one through Torx `JaxPRNGSampler`, and compare the sampled means with the sigmoid curve. What matters in the figure is agreement across the whole sweep rather than only near the midpoint, since that is what shows the input port feeding the bias with the declared weight.\n"
    ]
   },
   {
@@ -414,11 +407,20 @@
    "source": [
     "## Wiring tutorial factors into a Torx directed factor graph\n",
     "\n",
-    "Torx `Site` places a factor in a graph. It names the parents, routes parent outputs to input ports, and selects a parameter slice with `param_key`. Torx `DFG` walks these sites in topological order, parents first, then children [(Pearl 1988)](#ref-pearl-1988).\n",
+    "Two factors become a graph only once something decides which output feeds which input, and that decision is exactly what a Torx `Site` records. A `Site` places a factor in a graph: it names the parents, routes parent outputs to input ports, and selects a parameter slice with `param_key`. Torx `DFG` then walks these sites in topological order, parents first, then children [(Pearl 1988)](#ref-pearl-1988), which is all the ordering a directed factor graph needs to be sampled in one pass.\n",
     "\n",
-    "Here the concrete Torx graph contains two notebook-defined factors. `coin` draws first, and `out` receives the coin bit through the notebook function `to_drive`. The graph itself keeps the Torx `sample(key, inputs, params)` contract.\n",
+    "Several actors are on stage from here on, so the tables and figures below use these labels:\n",
     "\n",
-    "A concrete path through the fixed tutorial parameters is:\n",
+    "| Label used below | Owner |\n",
+    "|---|---|\n",
+    "| Torx primitive | `AbstractReferenceFactor`, `AbstractMatrixFactor`, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, `ChainFactor` |\n",
+    "| Tutorial factor | the four notebook-defined classes and their probability formulas |\n",
+    "| Notebook JAX | batching, compilation, estimates, and checks |\n",
+    "| Plot helper | presentation only |\n",
+    "\n",
+    "Here the concrete Torx graph contains two notebook-defined factors. `coin` draws first, and `out` receives the coin bit through the notebook function `to_drive`, which casts the integer bit into the float that the `drive` port declares. The graph itself keeps the Torx `sample(key, inputs, params)` contract, so we call the two-node graph exactly the way we called the single factor.\n",
+    "\n",
+    "Tracing one concrete path through the fixed tutorial parameters shows what each actor contributes:\n",
     "\n",
     "| Step | Value | Owner |\n",
     "|---|---:|---|\n",
@@ -427,7 +429,7 @@
     "| `ConditionalBit` score | $2(1)-1=1$ | tutorial formula |\n",
     "| child probability | $P(\\mathrm{out}=1)=\\sigma(1)=0.731$ | tutorial factor called by Torx DFG |\n",
     "\n",
-    "The anatomy below shows the shared factor contract: inputs and external parameters enter, and one sample leaves.\n"
+    "The anatomy below shows the shared factor contract that makes such wiring possible at all: inputs and external parameters enter, and one sample leaves.\n"
    ]
   },
   {
@@ -578,7 +580,7 @@
    "id": "717fb307",
    "metadata": {},
    "source": [
-    "The sampled graph mean lands on the hand-marginalized value. This verifies that the Torx `DFG` composes the two tutorial factors correctly.\n"
+    "Across 60,000 graph draws the sampled mean of `out` is 0.549, while marginalizing the hidden coin by hand gives 0.546, so the Torx `DFG` reproduces the distribution that the two tutorial factors define jointly. That is the evidence that its routing and its parents-first ordering are both correct. The schematic below shows the two-node graph we just sampled.\n"
    ]
   },
   {
@@ -627,11 +629,11 @@
    "source": [
     "## Exact probabilities as an opt-in capability\n",
     "\n",
-    "The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`. It provides both the common sampling contract and the optional `get_log_probability_matrix` capability.\n",
+    "Sampling is the one thing every factor must do, but some factors can also report their distribution in closed form, and Torx lets them advertise that instead of demanding it of everyone. The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`. It provides both the common sampling contract and the optional `get_log_probability_matrix` capability.\n",
     "\n",
-    "A matrix factor uses rows for input configurations and columns for output configurations. `input_states` and `output_states` fix that ordering. This factor has no inputs, so its matrix has one row for the empty input configuration and three columns ordered as `x = 0, 1, 2`. Each matrix entry is a normalized log probability, and exponentiating the row gives probabilities that sum to one.\n",
+    "A matrix factor uses rows for input configurations and columns for output configurations, and `input_states` and `output_states` fix that ordering. This factor has no inputs, so its matrix has one row for the empty input configuration and three columns ordered as `x = 0, 1, 2`. Each matrix entry is a normalized log probability, which means exponentiating the row gives probabilities that sum to one.\n",
     "\n",
-    "Samples return a dictionary keyed by output name, so the draws are read with `[\"x\"]`.\n"
+    "One wrinkle when reading the draws: samples return a dictionary keyed by output name, so we read them with `[\"x\"]`.\n"
    ]
   },
   {
@@ -716,7 +718,7 @@
    "id": "8c44d3da",
    "metadata": {},
    "source": [
-    "The sampled frequencies land on the exact row, so the opt-in probability table and the sampling contract describe the same distribution. The bar chart below plots the two side by side."
+    "The frequencies from 50,000 draws reproduce the exact row of 0.269, 0.598, and 0.133 to within the tolerance of 0.02 asserted at the end, so the opt-in probability table and the sampling contract describe one distribution rather than two that merely resemble each other. The bar chart below plots the two side by side, one pair of bars per state."
    ]
   },
   {
@@ -765,7 +767,7 @@
    "source": [
     "## Torx composites around a tutorial transition\n",
     "\n",
-    "The notebook-defined `FlipFactor` supplies the transition formula. Torx `TiledFactor` runs eight weight-tied copies in parallel, and Torx `ChainFactor` repeats five weight-tied steps while feeding each output back to the `state` port.\n"
+    "Two needs come up constantly in practice: running many copies of one factor at once, and running one factor repeatedly on its own output. Torx covers both with composites, and we build them around a transition of our own. The notebook-defined `FlipFactor` supplies the transition formula, Torx `TiledFactor` runs eight weight-tied copies in parallel, and Torx `ChainFactor` repeats five weight-tied steps while feeding each output back to the `state` port. Weight-tied means every copy or step reads one shared parameter slice instead of holding a slice of its own.\n"
    ]
   },
   {
@@ -847,7 +849,7 @@
    "id": "d29c9d57",
    "metadata": {},
    "source": [
-    "Both composites run: the tile returns eight parallel draws and the chain returns the state after five fed-back steps, each through the same `sample` contract as the single factor."
+    "Tying the weights is what these two composites are really demonstrating. Both reuse the single `FlipFactor` unchanged and hand it one parameter slice, so the tile's eight parallel draws share that same slice, and the chain threads the state through the same tied transition five times before returning the state after the fifth fed-back step. Neither composite alters the `sample` contract, so we call both of them exactly the way we call the single factor."
    ]
   },
   {
@@ -857,9 +859,9 @@
    "source": [
     "## One sampling interface at every level\n",
     "\n",
-    "All five objects keep the same basic shape: read inputs and parameters, then return a sample. A Torx `DFG` arranges `Site` factors in a DAG and samples them in topological order; a PSC specializes `AbstractDFG` by fixing factors into circuit wiring. Composite factors wrap or repeat another factor without changing its `sample` interface.\n",
+    "Nothing about the calling convention changed as we moved up in scale, and that is the design point worth carrying away. All five objects keep the same basic shape: read inputs and parameters, then return a sample. A Torx `DFG` arranges `Site` factors in a DAG and samples them in topological order, whereas a PSC specializes `AbstractDFG` by fixing factors into circuit wiring instead. Composite factors sit at the same level as a plain factor, because they wrap or repeat another factor without changing its `sample` interface.\n",
     "\n",
-    "[Notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) uses the PSC side, while [notebook 16](16_gibbs_sampling_factor_graph.ipynb) uses factor composition.\n"
+    "That shared interface is why the two entry points into Torx look different yet compose alike: [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) uses the PSC side, while [notebook 16](16_gibbs_sampling_factor_graph.ipynb) uses factor composition.\n"
    ]
   },
   {
@@ -869,7 +871,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "Finally, we assert the estimates computed above against their exact values, and add deterministic same-key checks for the composite factors: `TiledFactor` must equal a manual `vmap` over split keys, and `ChainFactor` must equal a manual loop that feeds each step's output back with the same split keys. We also compare a one-step chain against the bare factor."
+    "Finally, we turn each estimate above into a check that would fail if the composition were wrong. We assert the estimates computed above against their exact values, and we hold the composite factors to a stricter standard, because a composite that only reorganizes calls should not change a single draw. So we add deterministic same-key checks, meaning we feed the composite and a hand-written equivalent the identical random keys and require identical results: `TiledFactor` must equal a manual `vmap` over split keys, and `ChainFactor` must equal a manual loop that feeds each step's output back with the same split keys. We also compare a one-step chain against the bare factor."
    ]
   },
   {
@@ -1010,7 +1012,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We composed notebook-defined tutorial factors with Torx library primitives.\n",
+    "We composed notebook-defined tutorial factors with Torx library primitives, and the division of labour is the thing to carry forward.\n",
     "\n",
     "- The custom classes contain the tutorial probability formulas.\n",
     "- Torx supplies the factor contracts, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, and `ChainFactor`.\n",

--- a/examples/15_intro_to_factors.ipynb
+++ b/examples/15_intro_to_factors.ipynb
@@ -25,11 +25,11 @@
    "source": [
     "In this tutorial we start from the smallest object Torx can sample, a single **probabilistic bit** (pbit), and build upward from there. We give that pbit a factor of its own, wire two factors into a Torx directed factor graph, and then connect the resulting software hierarchy to the parametrised stochastic circuit (PSC) view used elsewhere in the gallery.\n",
     "\n",
-    "A **factor** is one conditional distribution packaged as an object. It reads named inputs, reads parameters that live outside the object and arrive with each call, and returns one stochastic output. Keeping the parameters outside is what makes a factor reusable, because the object itself carries no numbers to get stale. Four factors carry the teaching here: `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor` are defined in this notebook and are not Torx library primitives, while the base classes, sampler, graph, and composites that combine them all come from Torx.\n",
+    "A **factor** is one conditional distribution packaged as an object. It reads named inputs, reads parameters that live outside the object and arrive with each call, and returns one stochastic output. Keeping the parameters outside is what makes a factor reusable, because the object itself carries no numbers to get stale. Four factors carry the teaching here: `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor` are defined in this notebook and aren't Torx library primitives, while the base classes, sampler, graph, and composites that combine them all come from Torx.\n",
     "\n",
-    "A **directed factor graph** is a set of such factors with the output of one wired into the input of another, arranged without cycles so that every node can be sampled in a single pass from parents to children. Torx gates are factors as well, through their base classes, so the difference between a gate and a bare factor is not the probability model but how much has already been decided about placement. A PSC fixes their placement into circuit wiring, while a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n",
+    "A **directed factor graph** is a set of such factors with the output of one wired into the input of another, arranged without cycles so that every node can be sampled in a single pass from parents to children. Torx gates are factors as well, through their base classes, so the difference between a gate and a bare factor isn't the probability model but how much has already been decided about placement. A PSC fixes their placement into circuit wiring, while a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: Torx DFG and conventional factor graph</summary><p>A Torx directed factor graph is a DAG of conditional samplers, while the <a href=\"#ref-kschischang-2001\">conventional factor graph</a> of Kschischang et al. is a bipartite graph of variable and factor nodes. A PSC subclasses Torx <code>AbstractDFG</code> as a circuit-shaped implementation, but it is not a subclass of the concrete Torx <code>DFG</code> class.</p></details>\n",
+    "<details class=\"tx-disclosure\"><summary>Term: Torx DFG and conventional factor graph</summary><p>A Torx directed factor graph is a DAG of conditional samplers, while the <a href=\"#ref-kschischang-2001\">conventional factor graph</a> of Kschischang et al. is a bipartite graph of variable and factor nodes. A PSC subclasses Torx <code>AbstractDFG</code> as a circuit-shaped implementation, but it isn't a subclass of the concrete Torx <code>DFG</code> class.</p></details>\n",
     "\n",
     "This tutorial mirrors [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) from the factor side, so the two are worth reading together for both views of the same idea. It also connects the same composition ideas to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n"
    ]
@@ -181,7 +181,7 @@
    "source": [
     "## A tutorial factor as a sampler\n",
     "\n",
-    "We meet the contract first in its simplest form, on a factor that takes no inputs at all, so nothing about wiring gets in the way. The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor`. It has no input ports, so it is a distribution over one pbit.\n",
+    "We meet the contract first in its simplest form, on a factor that takes no inputs at all, so nothing about wiring gets in the way. The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor` and declares no input ports at all, which makes it a plain distribution over a single pbit.\n",
     "\n",
     "Two details of the contract are visible right away. The parameter dictionary lives outside the object and is passed into each `sample` call, and the custom `sample` method draws 1 with probability $\\sigma(b)$ through Torx `JaxPRNGSampler`.\n"
    ]
@@ -265,13 +265,13 @@
    "source": [
     "## A tutorial factor with inputs\n",
     "\n",
-    "A factor with no inputs cannot be wired into anything, so the next step is one that reads a value from elsewhere. The notebook-defined `ConditionalBit` uses the same Torx base contract with one named input port. Its custom formula is\n",
+    "A factor with no inputs can't be wired into anything, so the next step is one that reads a value from elsewhere. The notebook-defined `ConditionalBit` uses the same Torx base contract with one named input port. Its custom formula is\n",
     "\n",
     "$$\n",
     "P(\\text{out}=1 \\mid x)=\\sigma(wx+b).\n",
     "$$\n",
     "\n",
-    "To see whether the object really implements that formula, we sweep the drive across 21 values, draw 8,000 samples at each one through Torx `JaxPRNGSampler`, and compare the sampled means with the sigmoid curve. What matters in the figure is agreement across the whole sweep rather than only near the midpoint, since that is what shows the input port feeding the bias with the declared weight.\n"
+    "To see whether the object really implements that formula, we sweep the drive across 21 values, draw 8,000 samples at each one through Torx `JaxPRNGSampler`, and compare the sampled means with the sigmoid curve. What matters in the figure is agreement across the whole sweep rather than only near the midpoint, since that's what shows the input port feeding the bias with the declared weight.\n"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "id": "717fb307",
    "metadata": {},
    "source": [
-    "Across 60,000 graph draws the sampled mean of `out` is 0.549, while marginalizing the hidden coin by hand gives 0.546, so the Torx `DFG` reproduces the distribution that the two tutorial factors define jointly. That is the evidence that its routing and its parents-first ordering are both correct. The schematic below shows the two-node graph we just sampled.\n"
+    "Across 60,000 graph draws the sampled mean of `out` is 0.549, while marginalizing the hidden coin by hand gives 0.546, so the Torx `DFG` reproduces the distribution that the two tutorial factors define jointly. That's the evidence that its routing and its parents-first ordering are both correct. The schematic below shows the two-node graph we just sampled.\n"
    ]
   },
   {
@@ -629,7 +629,7 @@
    "source": [
     "## Exact probabilities as an opt-in capability\n",
     "\n",
-    "Sampling is the one thing every factor must do, but some factors can also report their distribution in closed form, and Torx lets them advertise that instead of demanding it of everyone. The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`. It provides both the common sampling contract and the optional `get_log_probability_matrix` capability.\n",
+    "Sampling is the one thing every factor must do, but some factors can also report their distribution in closed form, and Torx lets them advertise that instead of demanding it of everyone. The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`, so it carries the common sampling contract alongside the optional `get_log_probability_matrix` capability.\n",
     "\n",
     "A matrix factor uses rows for input configurations and columns for output configurations, and `input_states` and `output_states` fix that ordering. This factor has no inputs, so its matrix has one row for the empty input configuration and three columns ordered as `x = 0, 1, 2`. Each matrix entry is a normalized log probability, which means exponentiating the row gives probabilities that sum to one.\n",
     "\n",
@@ -859,7 +859,7 @@
    "source": [
     "## One sampling interface at every level\n",
     "\n",
-    "Nothing about the calling convention changed as we moved up in scale, and that is the design point worth carrying away. All five objects keep the same basic shape: read inputs and parameters, then return a sample. A Torx `DFG` arranges `Site` factors in a DAG and samples them in topological order, whereas a PSC specializes `AbstractDFG` by fixing factors into circuit wiring instead. Composite factors sit at the same level as a plain factor, because they wrap or repeat another factor without changing its `sample` interface.\n",
+    "Nothing about the calling convention changed as we moved up in scale, and that's the design point worth carrying away. All five objects keep the same basic shape: read inputs and parameters, then return a sample. A Torx `DFG` arranges `Site` factors in a DAG and samples them in topological order, whereas a PSC specializes `AbstractDFG` by fixing factors into circuit wiring instead. Composite factors sit at the same level as a plain factor, because they wrap or repeat another factor without changing its `sample` interface.\n",
     "\n",
     "That shared interface is why the two entry points into Torx look different yet compose alike: [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) uses the PSC side, while [notebook 16](16_gibbs_sampling_factor_graph.ipynb) uses factor composition.\n"
    ]
@@ -1017,7 +1017,7 @@
     "- The custom classes contain the tutorial probability formulas.\n",
     "- Torx supplies the factor contracts, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, and `ChainFactor`.\n",
     "- A Torx DFG is a directed sampler DAG, distinct from the conventional bipartite definition of a factor graph.\n",
-    "- A PSC subclasses `AbstractDFG` as a circuit-shaped implementation and is not a subclass of concrete `DFG`.\n",
+    "- A PSC subclasses `AbstractDFG` as a circuit-shaped implementation and isn't a subclass of concrete `DFG`.\n",
     "\n",
     "For the circuit-shaped view, go back to [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb). For the larger Ising model, continue to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n",
     "\n",

--- a/examples/16_gibbs_sampling_factor_graph.ipynb
+++ b/examples/16_gibbs_sampling_factor_graph.ipynb
@@ -13,8 +13,8 @@
    "id": "3392d6cf",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
-    "<p>We build a 4×4 Ising Gibbs sampler from a one-spin factor, checkerboard tiling, and a repeated directed factor graph. We check zero-field sampling, temperature sweeps, and field-conditioned pattern completion against exact enumeration.</p>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
+    "<p>We build a 4×4 Ising Gibbs sampler from a one-spin factor, checkerboard tiling, and a repeated directed factor graph. Because a 4×4 lattice has only 65,536 states, we can check zero-field sampling, temperature sweeps, and field-conditioned pattern completion against exact enumeration rather than against another approximation.</p>\n",
     "</div>"
    ]
   },
@@ -33,19 +33,19 @@
    "id": "cd10da2f",
    "metadata": {},
    "source": [
-    "A **factor** in Torx is a directed conditional $P(\\text{output} \\mid \\text{inputs})$. A custom factor supplies its input and output specs along with `sample` and `init_params`. The one-spin factor here also implements an exact `log_probability`, which is an analytic reference for that one-spin conditional only.\n",
+    "A **factor** in Torx is a directed conditional $P(\\text{output} \\mid \\text{inputs})$. A custom factor supplies its input and output specs along with `sample` and `init_params`. The one-spin factor here also implements an exact `log_probability`, which gives us an analytic reference for that one-spin conditional only.\n",
     "\n",
-    "A parametrised stochastic circuit (PSC) is an ordered list of stochastic gates applied to an initial state. This tutorial uses no PSC, compiled circuit, or simulator. We work directly with hand-written factors.\n",
+    "A parametrised stochastic circuit (PSC) is an ordered list of stochastic gates applied to an initial state. This tutorial builds nothing of that kind: no PSC, no compiled circuit, and no simulator. Everything below is hand-written factors wired into a graph, which keeps the mechanics visible.\n",
     "\n",
-    "[Gibbs sampling](#ref-geman1984) updates one variable at a time from its conditional, and it is not the main use case Torx is built for. For a dedicated Gibbs sampling library, use [thrml](https://github.com/extropic-ai/thrml). Gibbs sampling is useful here because it touches the full `DFG` workflow: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference.\n",
+    "[Gibbs sampling](#ref-geman1984) updates one variable at a time from its conditional, and it is not the main use case Torx is built for. For a dedicated Gibbs sampling library, use [thrml](https://github.com/extropic-ai/thrml). We use it here anyway because a Gibbs sampler happens to exercise the whole `DFG` workflow in one example: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference to check the result against.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Gibbs and chromatic Gibbs sampling</summary><p>Gibbs sampling resamples variables from their conditional target distributions. In <a href=\"#ref-gonzalez2011\">chromatic Gibbs sampling</a>, same-color spins have no edges between them, so they are conditionally independent given the other color and can update together before the colors swap.</p></details>\n",
     "\n",
-    "The coloring idea comes from [notebook 06](06_ising_sampling_contrastive_divergence.ipynb), where the lattice is colored so non-adjacent spins update together. Notebook 06 runs that idea on an 8-spin ring with `PNOT` gates. Here we write the same chromatic-Gibbs conditional as hand-built factors on a $4\\times4$ torus. The two notebooks share the conditional update and the coloring strategy but use different graphs and Ising distributions.\n",
+    "The coloring idea comes from [notebook 06](06_ising_sampling_contrastive_divergence.ipynb), where the lattice is colored so non-adjacent spins update together. Notebook 06 runs that idea on an 8-spin ring with `PNOT` gates, while here we write the same chromatic-Gibbs conditional as hand-built factors on a $4\\times4$ torus. The two notebooks share the conditional update and the coloring strategy but use different graphs and Ising distributions.\n",
     "\n",
-    "The graph receives the per-site `field` as an input rather than a baked-in weight. With a zero field the model is the symmetric Ising magnet. With a finite field on selected sites, the same graph performs field-conditioned pattern completion.\n",
+    "One design choice matters for everything that follows: the graph receives the per-site `field` as an input rather than as a baked-in weight. With a zero field the model is the symmetric Ising magnet, and with a finite field on selected sites the very same graph performs field-conditioned pattern completion, with no rewiring in between.\n",
     "\n",
-    "The grid is a $4\\times4$ torus, small enough that all $2^{16} = 65{,}536$ configurations fit in memory. The exact distribution is available by brute force for any fixed field, and every check compares against it.\n",
+    "The grid is a $4\\times4$ torus, which is small enough that all $2^{16} = 65{,}536$ configurations fit in memory. That is the whole reason we can be strict here: the exact distribution is available by brute force for any fixed field, so every check below compares against it rather than against another sampler.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul>\n",
     "<li>Torx runs the stochastic factor, tiling, directed factor graph, and weight-tied chain.</li>\n",
@@ -57,12 +57,12 @@
     "The main steps are:\n",
     "\n",
     "1. set up the $4\\times4$ Boltzmann machine and draw its `DFG`,\n",
-    "2. write the one-spin update as a custom factor, probe that its draw lands on $\\sigma(2\\gamma)$, and read back its exact `log_probability`,\n",
+    "2. write the one-spin update as a custom factor and check its draws against the conditional it reports analytically,\n",
     "3. tile the update into two color blocks and wire them into an explicit `DFG` for one Gibbs sweep,\n",
     "4. repeat that sweep as a weight-tied chain, build the exact distribution by brute-force enumeration, and check the sampler against it,\n",
     "5. sweep the temperature and watch the magnet order as it cools,\n",
-    "6. match the sampler spin by spin and connection by connection against it, and\n",
-    "7. drive the graph with a finite field for field-conditioned pattern completion."
+    "6. drive the model with a site-varying field and compare the sampler against that same exact distribution spin by spin and connection by connection, and\n",
+    "7. drive the graph with a strong finite field for field-conditioned pattern completion."
    ]
   },
   {
@@ -72,7 +72,7 @@
    "source": [
     "## Setup\n",
     "\n",
-    "The setup cells configure the local helper path, then fix the plotting style and seed."
+    "The setup cells put the local helper directory on the path, then fix the plotting style and the seed so every figure and draw below reproduces."
    ]
   },
   {
@@ -221,9 +221,9 @@
     "\n",
     "The model is a $4\\times4$ grid of spins with periodic boundaries, so every spin has exactly four neighbors. This is the finite Ising model used as a Boltzmann machine by [Ackley, Hinton, and Sejnowski (1985)](#ref-ackley1985).\n",
     "\n",
-    "The grid holds 16 spins and 32 connections. The state is stored as spins $s \\in \\{-1, +1\\}$. Internally, each update draws a Bernoulli **pbit** in $\\{0, 1\\}$ and maps it to the stored spin via $s = 2\\,\\text{pbit} - 1$. The neighbor lists, connection list, and checkerboard coloring come from `examples/helpers/_plots_schematics.py`.\n",
+    "The grid holds 16 spins and 32 connections, and the state is stored as spins $s \\in \\{-1, +1\\}$. Internally each update draws a Bernoulli **pbit** in $\\{0, 1\\}$ and maps it to the stored spin via $s = 2\\,\\text{pbit} - 1$, so the two representations describe the same variable in different coordinates. The neighbor lists, connection list, and checkerboard coloring come from `examples/helpers/_plots_schematics.py`.\n",
     "\n",
-    "Neighboring spins prefer to agree, and a per-site field $b_i$ biases each spin.\n",
+    "The energy says what the model prefers. Neighboring spins prefer to agree, and a per-site field $b_i$ biases each spin.\n",
     "\n",
     "$$\n",
     "H(s) = -J\\,\\sum_{(i,j)\\in E} s_i\\, s_j \\;-\\; \\sum_i b_i\\, s_i,\n",
@@ -232,7 +232,7 @@
     "\n",
     "Lower energy means higher probability, and $\\beta$ is the inverse temperature.\n",
     "\n",
-    "With $b = 0$ the model is the symmetric Ising magnet. A finite nonzero $b_i$ biases spin $i$ but does not hold it fixed."
+    "With $b = 0$ the model is the symmetric Ising magnet. A finite nonzero $b_i$ biases spin $i$ but does not hold it fixed, which is what makes the pattern completion at the end of the notebook a sampling problem rather than a clamping trick."
    ]
   },
   {
@@ -279,11 +279,9 @@
    "id": "8dd44216",
    "metadata": {},
    "source": [
-    "Here is the $4\\times4$ lattice the `DFG` will sweep.\n",
+    "The figure below is the lattice the `DFG` will sweep, drawn so that the update order is visible.\n",
     "\n",
-    "The 16 spins split into two color blocks. The solid links are the neighbor dependencies inside the grid, and the dashed stubs are the periodic wrap-around connections that close the lattice into a torus. A spin reads its four neighbors, all of which lie in the other block.\n",
-    "\n",
-    "The two colors are the two checkerboard update groups. Color `A` reads the incoming state, and color `B` reads the updated color `A`."
+    "The 16 spins split into two color blocks. Solid links are the neighbor dependencies inside the grid, and the dashed stubs are the periodic wrap-around connections that close the lattice into a torus. The two colors are the two checkerboard update groups, and every spin reads four neighbors that all lie in the other block, which is what makes a whole block safe to update at once. Color `A` reads the incoming state, and color `B` then reads the freshly updated color `A`."
    ]
   },
   {
@@ -332,13 +330,13 @@
    "source": [
     "## The per-spin update as a factor\n",
     "\n",
-    "The smallest piece of the model is a single spin update: given a spin's four neighbors and its local `drive`, draw its new value.\n",
+    "The smallest piece of the model is a single spin update: given a spin's four neighbors and its local `drive`, draw its new value. Get that one conditional right and the rest of the notebook is wiring.\n",
     "\n",
     "That update is one factor: a directed conditional that implements `sample` and `init_params` alongside its specs.\n",
     "\n",
     "The update draws a Bernoulli pbit in $\\{0, 1\\}$ with probability $\\sigma(2\\gamma_i)$, then maps it to the stored spin $s_i = 2\\,\\text{pbit} - 1 \\in \\{-1, +1\\}$. Here $\\sigma$ is the logistic sigmoid and the local field $\\gamma_i$ collects the neighbors and the `drive`.\n",
     "\n",
-    "The draw uses `jax.random.bernoulli`. The `drive` and the coupling parameter the kernel consumes already carry the inverse temperature $\\beta$: we supply $\\text{drive}_i = \\beta\\,b_i$ and $j = \\beta J$, so $\\gamma_i$ is the $\\beta$-scaled local field. The brute-force `exact_distribution` below instead takes the raw physical field $b_i$ and applies $\\beta$ itself.\n",
+    "The draw uses `jax.random.bernoulli`. The `drive` and the coupling parameter the kernel consumes already carry the inverse temperature $\\beta$, because we supply $\\text{drive}_i = \\beta\\,b_i$ and $j = \\beta J$, so $\\gamma_i$ is the $\\beta$-scaled local field. The brute-force `exact_distribution` below instead takes the raw physical field $b_i$ and applies $\\beta$ itself, so the two paths agree on the same physics from different inputs.\n",
     "\n",
     "$$\n",
     "\\gamma_i = \\beta\\,b_i + \\beta J\\,\\sum_{j\\in\\mathcal{N}(i)} s_j,\n",
@@ -433,9 +431,9 @@
    "id": "4bf06659",
    "metadata": {},
    "source": [
-    "Now we probe the factor. We fix the neighbors and `drive` by hand, compute the resulting local field $\\gamma$, draw the update many times, and check that the fraction of $+1$ spins lands on $\\sigma(2\\gamma)$.\n",
+    "Now we probe the factor, because a conditional that is subtly wrong would still produce plausible-looking lattices later. We fix the neighbors and `drive` by hand, compute the resulting local field $\\gamma$, draw the update many times, and check that the fraction of $+1$ spins matches $\\sigma(2\\gamma)$.\n",
     "\n",
-    "This is the single-spin check: the factor samples its conditional and reports the same conditional analytically."
+    "This is the single-spin check: the factor samples its conditional, and it reports that same conditional analytically."
    ]
   },
   {
@@ -485,7 +483,7 @@
    "id": "ea0fe4a6",
    "metadata": {},
    "source": [
-    "With the empirical fraction matched, we read the same conditional back analytically. The analytic value should agree with the sampled one, and the two outcomes should sum to one."
+    "With the empirical fraction matched, we read the same conditional back analytically to confirm that `log_probability` describes the distribution `sample` actually draws from. The analytic value should agree with the sampled one, and the two outcomes should sum to one."
    ]
   },
   {
@@ -531,9 +529,9 @@
    "source": [
     "## Wiring the lattice into a directed factor graph\n",
     "\n",
-    "The two checkerboard colors are the two Gibbs blocks. Every spin in a block updates from the same conditional, so each block is the single `SpinUpdate` factor wrapped in a `TiledFactor`: one tile per spin, eight tiles per block.\n",
+    "The two checkerboard colors are the two Gibbs blocks. Block Gibbs means we resample a whole group of variables in one move instead of one variable at a time, which is valid here because no two spins of the same color are neighbors, so inside a block the conditionals do not depend on each other. Every spin in a block updates from the same conditional, so each block is the single `SpinUpdate` factor wrapped in a `TiledFactor`: one tile per spin, eight tiles per block.\n",
     "\n",
-    "The tiles share one coupling, and each tile receives its own neighbors and `drive` as data. The geometry is fixed, so we precompute each tile's neighbor indices once."
+    "The tiles share one coupling, and each tile receives its own neighbors and `drive` as data. The geometry never changes during sampling, so we precompute each tile's neighbor indices once."
    ]
   },
   {
@@ -605,7 +603,7 @@
    "id": "efdde96e",
    "metadata": {},
    "source": [
-    "Each block needs a porting function that slices its tiles' neighbors and `drive` out of the parent outputs. A third function scatters the two blocks back into one state vector."
+    "Wiring a `Site` into a `DFG` means saying where its inputs come from, which is the job of a porting function. Each block needs one that slices its tiles' neighbors and `drive` out of the parent outputs, and a third function then scatters the two blocks back into one state vector."
    ]
   },
   {
@@ -698,9 +696,9 @@
    "id": "c4f4fb09",
    "metadata": {},
    "source": [
-    "Finally, we wire the three `Site` objects into the `DFG` for one sweep.\n",
+    "With the pieces in hand, we wire the three `Site` objects into the `DFG` that performs one sweep.\n",
     "\n",
-    "Each block updates all of its spins in parallel, so each block appears in the graph as one tiled factor rather than eight separate `Site` objects."
+    "Each block updates all of its spins in parallel, so a block appears in the graph as one tiled factor rather than as eight separate `Site` objects."
    ]
   },
   {
@@ -787,11 +785,11 @@
    "source": [
     "## Running the chain\n",
     "\n",
-    "The `DFG` above computes one sweep, and the full sampler repeats it. A weight-tied `ChainFactor` runs the same sweep for many steps with one shared coupling. In Torx, this is the idiom for a Markov chain Monte Carlo (MCMC) chain.\n",
+    "The `DFG` above performs exactly one Gibbs sweep, so sampling the model means repeating it. A weight-tied `ChainFactor` does that: it runs the same sweep for many steps with one shared coupling, which is the Torx idiom for a Markov chain Monte Carlo (MCMC) chain.\n",
     "\n",
-    "The `drive` input, which carries the $\\beta$-scaled field, is a non-feedback input, so the chain holds it fixed at every step and threads only the spins.\n",
+    "The `drive` input, which carries the $\\beta$-scaled field, is a non-feedback input, so the chain holds it fixed at every step and threads only the spins from one sweep into the next.\n",
     "\n",
-    "We run 4,000 independent chains and keep one final sample from each. The settling trace below is a heuristic view of one order parameter, while the later exact-distribution comparisons provide the quantitative evidence at this 200-sweep runtime."
+    "We then run 200 sweeps on each of 4,000 independent chains and keep one final sample from each, which gives 4,000 draws that are independent by construction rather than 4,000 correlated points along a single trajectory."
    ]
   },
   {
@@ -889,11 +887,9 @@
    "id": "77e99a27",
    "metadata": {},
    "source": [
-    "For a heuristic settling view, we run many chains from a disordered start and track the **order parameter**: the magnitude of the average spin, averaged across chains at each step.\n",
+    "Before comparing distributions, we want a rough sense of whether 200 sweeps gives the chains room to settle. So we start many chains from a disordered state and track the **order parameter** at each sweep: the magnitude of the average spin, averaged across chains. It runs from 0 for a lattice with no net direction to 1 for a fully aligned one.\n",
     "\n",
-    "The bold line is that mean, and the band is the 16th to 84th percentile range across chains. The dashed line is a selected heuristic marker at sweep 80.\n",
-    "\n",
-    "This trace shows only one order parameter, so flattening does not establish stationarity or mixing between the two mirror states. The exact comparisons below check the final-sample distribution at the chosen runtime."
+    "In the figure, the bold line is that mean and the band is the 16th to 84th percentile range across chains. The dashed line marks sweep 80, a reference we picked by hand so we can see whether the trace has levelled off well before the 200th sweep the chain actually runs."
    ]
   },
   {
@@ -983,7 +979,7 @@
    "id": "e9446982",
    "metadata": {},
    "source": [
-    "The order parameter flattens before the selected marker. This is a heuristic settling cue, not a convergence diagnostic."
+    "The order parameter climbs off its disordered start and then flattens before the marker. Read that as a settling cue rather than as proof of mixing, because a single order parameter cannot tell us whether the chains move between the two mirror-image ordered states. The exact-distribution comparisons below are the real test, and they check the final-sample distribution at this 200-sweep runtime."
    ]
   },
   {
@@ -1030,9 +1026,9 @@
    "id": "f5e8b917",
    "metadata": {},
    "source": [
-    "The first comparison uses the total magnetization, the sum of all spins in each sample. We enumerate the exact distribution for the zero-field case and compare it with the sampler.\n",
+    "The first comparison asks whether the sampler reproduces the right distribution of total magnetization, the sum of all spins in each sample. We enumerate the exact distribution for the zero-field case and put the two histograms side by side.\n",
     "\n",
-    "The two peaks are the two mirror-image ordered states. The [total variation distance](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures) is half the summed absolute probability difference across magnetization bins. It ranges from 0 for identical histograms to 1 for disjoint histograms."
+    "At this inverse temperature the magnet is ordered, so the exact histogram should have two peaks, one for each of the two mirror-image ordered states. We summarise the difference between the histograms with the [total variation distance](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures), which is half the summed absolute probability difference across magnetization bins. It ranges from 0 for identical histograms to 1 for disjoint histograms."
    ]
   },
   {
@@ -1127,7 +1123,7 @@
    "id": "afac0889",
    "metadata": {},
    "source": [
-    "Overlaid on the exact line, the sampled counts sit on both peaks with a matching trough between them."
+    "Overlaid on the exact line, the sampled counts reproduce both peaks and the trough between them, at a total variation distance of 0.0222 from the exact distribution."
    ]
   },
   {
@@ -1176,11 +1172,13 @@
    "source": [
     "## Cooling the model\n",
     "\n",
-    "As the magnet cools, it orders. The order parameter measures how strongly it points in one direction, on a scale from 0 to 1.\n",
+    "As the magnet cools, it orders, and the order parameter is how we measure that: 0 when the lattice has no net direction, 1 when it is fully aligned.\n",
     "\n",
-    "We sweep several inverse temperatures and compare three curves: the exact answer by enumeration, the sampler, and the [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory). The sampler curve comes from `sweep_temperatures` in `examples/helpers/_plots_sampling.py`, which runs fresh chains at each inverse temperature and reports their order parameter. Mean field replaces each spin's neighbors with their expected average. Its self-consistent estimate runs high near the [finite-size crossover](#ref-fisher1972), the smooth change a finite system shows instead of a singular phase transition.\n",
+    "We sweep six inverse temperatures from 0.10 to 0.60 and compare three curves, each answering a different question. Enumeration gives the exact order parameter for this $4\\times4$ torus, so it is the ground truth. The sampler curve tells us whether the chain recovers that truth across the whole temperature range rather than only at the baseline we used above. The [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory) replaces each spin's neighbors with their expected average, which discards exactly the fluctuations that dominate near a transition, so we expect it to part company with the other two curves in the middle of the range.\n",
     "\n",
-    "Mean field predicts zero order below its own critical inverse temperature $\\beta = 1/(4J) = 0.25$. The infinite square lattice instead has the [exact critical point](#ref-onsager1944) $\\beta_c J = \\tfrac{1}{2}\\log(1+\\sqrt{2}) \\approx 0.4407$. This $4\\times4$ torus has no true phase transition, only a crossover near that infinite-lattice comparison."
+    "Two reference points explain where that disagreement comes from. Mean field predicts zero order below its own critical inverse temperature $\\beta = 1/(4J) = 0.25$, while the infinite square lattice has the [exact critical point](#ref-onsager1944) $\\beta_c J = \\tfrac{1}{2}\\log(1+\\sqrt{2}) \\approx 0.4407$. This $4\\times4$ torus is too small to have a true phase transition at either value. What it has instead is a [finite-size crossover](#ref-fisher1972), the smooth change a finite system shows in place of a singular transition, near that infinite-lattice point.\n",
+    "\n",
+    "<details class=\"tx-disclosure\"><summary>Where the sampler curve comes from</summary><p>The sampler curve comes from <code>sweep_temperatures</code> in <code>examples/helpers/_plots_sampling.py</code>, which runs fresh chains at each inverse temperature and reports their order parameter.</p></details>"
    ]
   },
   {
@@ -1280,7 +1278,7 @@
    "id": "399f0f13",
    "metadata": {},
    "source": [
-    "Plotted together, the sampler tracks the exact curve while mean-field runs high near the finite-size crossover."
+    "Plotted together, the sampler stays within 0.012 of the exact curve at every inverse temperature, while mean field runs high through the crossover region, reading 0.659 against the exact 0.520 at $\\beta = 0.30$."
    ]
   },
   {
@@ -1329,7 +1327,7 @@
    "source": [
     "## Checking against the exact answer\n",
     "\n",
-    "For a fixed field, the Boltzmann distribution over 16 spins is small enough to enumerate, which is what `exact_distribution` computes. With that exact reference in hand, we match the sampler spin by spin and connection by connection."
+    "Matching a magnetization histogram is a coarse test, because many different samplers could produce the same one. For a fixed field the Boltzmann distribution over 16 spins is small enough to enumerate, which is what `exact_distribution` computes, so with that exact reference in hand we can match the sampler spin by spin and connection by connection instead."
    ]
   },
   {
@@ -1337,11 +1335,9 @@
    "id": "4ef9a5ec",
    "metadata": {},
    "source": [
-    "To make this check meaningful, we drive the model with a field that varies from site to site. The spins are no longer all equivalent.\n",
+    "To make this check meaningful, we drive the model with a field that varies from site to site. The spins are no longer all equivalent, so each one has its own exact marginal to be checked against.\n",
     "\n",
-    "The left panel shows the average value of each spin. The right panel shows the average agreement across each connection, sampler against exact.\n",
-    "\n",
-    "A point on the dashed diagonal means the sampler recovered the exact value. The spread along the diagonal comes from the per-site field."
+    "The left panel shows the average value of each spin. The right panel shows the average agreement across each connection, sampler against exact."
    ]
   },
   {
@@ -1453,7 +1449,7 @@
    "id": "7f98e5d5",
    "metadata": {},
    "source": [
-    "Each spin and each connection becomes one point, sampler against exact. Points on the diagonal mean the sampler recovered the exact value."
+    "Each spin and each connection becomes one point, sampler against exact, so a point on the dashed diagonal means the sampler recovered the exact value. Every point sits on the diagonal to within 0.0293 per spin and 0.0232 per connection, and the spread along the diagonal comes from the per-site field, which pulls different spins to different magnetizations."
    ]
   },
   {
@@ -1504,7 +1500,7 @@
     "\n",
     "Because the `field` is an input, the same graph can perform field-conditioned pattern completion.\n",
     "\n",
-    "We set a field of magnitude 6 on a few sites, leave the rest at zero, and run the chain. The selected spins remain stochastic, but this finite field strongly biases them toward its sign while the zero-field sites fill in around them. The verification below checks the biased-site marginals against the exact field-conditioned distribution rather than the sign alone.\n",
+    "We set a field of magnitude 6 on a few sites, leave the rest at zero, and run the chain. The selected spins remain stochastic, so this finite field biases them strongly toward its sign rather than pinning them, while the zero-field sites fill in around them. That distinction is why the verification below checks the biased-site marginals against the exact field-conditioned distribution rather than checking the sign alone.\n",
     "\n",
     "This is the field-conditioned Boltzmann machine, $P(\\text{spins} \\mid \\text{field})$. Between this and the plots above, only the `field` input changes."
    ]
@@ -1630,7 +1626,7 @@
    "id": "718919ba",
    "metadata": {},
    "source": [
-    "Across the three panels, colored sites show positive or negative bias with $|b_i|=6$, while pale sites have $b_i=0$. The next panels show one field-conditioned sample and the mean spin."
+    "The figure has three panels. The first is the field we imposed, where colored sites carry positive or negative bias with $|b_i|=6$ and pale sites have $b_i=0$. The other two show what the chain did with it: one field-conditioned sample, and the mean spin across all 3,000 chains."
    ]
   },
   {
@@ -1679,7 +1675,7 @@
    "source": [
     "## Verification\n",
     "\n",
-    "We gather the quantitative checks for this tutorial in one place. The single-spin probe compares the draw against its analytic sigmoid conditional. The magnetization, per-spin, per-connection, temperature, and field-completion checks all compare against the brute-force exact distribution."
+    "We gather the quantitative checks for this tutorial in one place, and we assert them rather than only printing them, so a drift in any number fails the notebook. The single-spin probe is checked against its own analytic sigmoid conditional, which tests the factor in isolation from the graph. The magnetization, per-spin, per-connection, temperature, and field-completion checks are all measured against the brute-force exact distribution, which is the one reference here that carries no sampling error of its own."
    ]
   },
   {
@@ -1767,7 +1763,7 @@
     "\n",
     "We built a Boltzmann machine from hand-written factors, sampled it with Gibbs, and checked it against an exact brute-force reference.\n",
     "\n",
-    "- A single spin update is one factor: a directed conditional that draws a pbit with value $1$ with probability $\\sigma(2\\gamma_i)$ and reports that same one-spin conditional through `log_probability`. The probe confirmed that both the draw and the analytic value land on that sigmoid.\n",
+    "- A single spin update is one factor: a directed conditional that draws a pbit with value $1$ with probability $\\sigma(2\\gamma_i)$ and reports that same one-spin conditional through `log_probability`. The probe confirmed that the sampled fraction and the analytic value both reproduce that sigmoid.\n",
     "- The two checkerboard colors are two Gibbs blocks, each with the same factor tiled across its eight spins and one shared coupling. The `DeterministicFactor` object reassembles them into one state, giving an explicit three-site `DFG` for one Gibbs sweep.\n",
     "- The weight-tied `ChainFactor` object repeats the sweep into an MCMC chain. At the chosen 200-sweep runtime, the final-chain samples match the exact distribution within the reported errors, spin by spin and connection by connection.\n",
     "- Cooling the model raises the order parameter through the finite-size crossover. The mean-field approximation overshoots there, and the sampler tracks the exact curve.\n",
@@ -1775,7 +1771,7 @@
     "\n",
     "[Notebook 06](06_ising_sampling_contrastive_divergence.ipynb) applies the same chromatic-Gibbs conditional idea with `PNOT` gates on an 8-spin ring. This tutorial writes that conditional as factors on a $4\\times4$ torus, so the two share the update rule and coloring strategy while their graphs and Ising distributions differ.\n",
     "\n",
-    "This is a `DFG` example. For Gibbs sampling as a tool, use [thrml](https://github.com/extropic-ai/thrml)."
+    "What this notebook is really about is the `DFG`: a custom factor with an analytic conditional, tiling, weight tying, and deterministic reassembly, composed into a graph whose output we can verify exactly. Gibbs sampling was the vehicle for that tour rather than the destination. If you want Gibbs sampling as a working tool, reach for [thrml](https://github.com/extropic-ai/thrml), which is built for it."
    ]
   },
   {

--- a/examples/16_gibbs_sampling_factor_graph.ipynb
+++ b/examples/16_gibbs_sampling_factor_graph.ipynb
@@ -37,7 +37,7 @@
     "\n",
     "A parametrised stochastic circuit (PSC) is an ordered list of stochastic gates applied to an initial state. This tutorial builds nothing of that kind: no PSC, no compiled circuit, and no simulator. Everything below is hand-written factors wired into a graph, which keeps the mechanics visible.\n",
     "\n",
-    "[Gibbs sampling](#ref-geman1984) updates one variable at a time from its conditional, and it is not the main use case Torx is built for. For a dedicated Gibbs sampling library, use [thrml](https://github.com/extropic-ai/thrml). We use it here anyway because a Gibbs sampler happens to exercise the whole `DFG` workflow in one example: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference to check the result against.\n",
+    "[Gibbs sampling](#ref-geman1984) updates one variable at a time from its conditional, and it isn't the main use case Torx is built for. For a dedicated Gibbs sampling library, use [thrml](https://github.com/extropic-ai/thrml). We use it here anyway because a Gibbs sampler happens to exercise the whole `DFG` workflow in one example: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference to check the result against.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Gibbs and chromatic Gibbs sampling</summary><p>Gibbs sampling resamples variables from their conditional target distributions. In <a href=\"#ref-gonzalez2011\">chromatic Gibbs sampling</a>, same-color spins have no edges between them, so they are conditionally independent given the other color and can update together before the colors swap.</p></details>\n",
     "\n",
@@ -45,7 +45,7 @@
     "\n",
     "One design choice matters for everything that follows: the graph receives the per-site `field` as an input rather than as a baked-in weight. With a zero field the model is the symmetric Ising magnet, and with a finite field on selected sites the very same graph performs field-conditioned pattern completion, with no rewiring in between.\n",
     "\n",
-    "The grid is a $4\\times4$ torus, which is small enough that all $2^{16} = 65{,}536$ configurations fit in memory. That is the whole reason we can be strict here: the exact distribution is available by brute force for any fixed field, so every check below compares against it rather than against another sampler.\n",
+    "The grid is a $4\\times4$ torus, which is small enough that all $2^{16} = 65{,}536$ configurations fit in memory. That's the whole reason we can be strict here: the exact distribution is available by brute force for any fixed field, so every check below compares against it rather than against another sampler.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul>\n",
     "<li>Torx runs the stochastic factor, tiling, directed factor graph, and weight-tied chain.</li>\n",
@@ -232,7 +232,7 @@
     "\n",
     "Lower energy means higher probability, and $\\beta$ is the inverse temperature.\n",
     "\n",
-    "With $b = 0$ the model is the symmetric Ising magnet. A finite nonzero $b_i$ biases spin $i$ but does not hold it fixed, which is what makes the pattern completion at the end of the notebook a sampling problem rather than a clamping trick."
+    "With $b = 0$ the model is the symmetric Ising magnet. A finite nonzero $b_i$ biases spin $i$ but doesn't hold it fixed, which is what makes the pattern completion at the end of the notebook a sampling problem rather than a clamping trick."
    ]
   },
   {
@@ -529,7 +529,7 @@
    "source": [
     "## Wiring the lattice into a directed factor graph\n",
     "\n",
-    "The two checkerboard colors are the two Gibbs blocks. Block Gibbs means we resample a whole group of variables in one move instead of one variable at a time, which is valid here because no two spins of the same color are neighbors, so inside a block the conditionals do not depend on each other. Every spin in a block updates from the same conditional, so each block is the single `SpinUpdate` factor wrapped in a `TiledFactor`: one tile per spin, eight tiles per block.\n",
+    "The two checkerboard colors are the two Gibbs blocks. Block Gibbs means we resample a whole group of variables in one move instead of one variable at a time, which is valid here because no two spins of the same color are neighbors, so inside a block the conditionals don't depend on each other. Every spin in a block updates from the same conditional, so each block is the single `SpinUpdate` factor wrapped in a `TiledFactor`: one tile per spin, eight tiles per block.\n",
     "\n",
     "The tiles share one coupling, and each tile receives its own neighbors and `drive` as data. The geometry never changes during sampling, so we precompute each tile's neighbor indices once."
    ]
@@ -979,7 +979,7 @@
    "id": "e9446982",
    "metadata": {},
    "source": [
-    "The order parameter climbs off its disordered start and then flattens before the marker. Read that as a settling cue rather than as proof of mixing, because a single order parameter cannot tell us whether the chains move between the two mirror-image ordered states. The exact-distribution comparisons below are the real test, and they check the final-sample distribution at this 200-sweep runtime."
+    "The order parameter climbs off its disordered start and then flattens before the marker. Read that as a settling cue rather than as proof of mixing, because a single order parameter can't tell us whether the chains move between the two mirror-image ordered states. The exact-distribution comparisons below are the real test, and they check the final-sample distribution at this 200-sweep runtime."
    ]
   },
   {
@@ -1172,9 +1172,9 @@
    "source": [
     "## Cooling the model\n",
     "\n",
-    "As the magnet cools, it orders, and the order parameter is how we measure that: 0 when the lattice has no net direction, 1 when it is fully aligned.\n",
+    "As the magnet cools, it orders, and the order parameter is how we measure that: 0 when the lattice has no net direction, 1 when it's fully aligned.\n",
     "\n",
-    "We sweep six inverse temperatures from 0.10 to 0.60 and compare three curves, each answering a different question. Enumeration gives the exact order parameter for this $4\\times4$ torus, so it is the ground truth. The sampler curve tells us whether the chain recovers that truth across the whole temperature range rather than only at the baseline we used above. The [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory) replaces each spin's neighbors with their expected average, which discards exactly the fluctuations that dominate near a transition, so we expect it to part company with the other two curves in the middle of the range.\n",
+    "We sweep six inverse temperatures from 0.10 to 0.60 and compare three curves, each answering a different question. Enumeration gives the exact order parameter for this $4\\times4$ torus, so it's the ground truth. The sampler curve tells us whether the chain recovers that truth across the whole temperature range rather than only at the baseline we used above. The [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory) replaces each spin's neighbors with their expected average, which discards exactly the fluctuations that dominate near a transition, so we expect it to part company with the other two curves in the middle of the range.\n",
     "\n",
     "Two reference points explain where that disagreement comes from. Mean field predicts zero order below its own critical inverse temperature $\\beta = 1/(4J) = 0.25$, while the infinite square lattice has the [exact critical point](#ref-onsager1944) $\\beta_c J = \\tfrac{1}{2}\\log(1+\\sqrt{2}) \\approx 0.4407$. This $4\\times4$ torus is too small to have a true phase transition at either value. What it has instead is a [finite-size crossover](#ref-fisher1972), the smooth change a finite system shows in place of a singular transition, near that infinite-lattice point.\n",
     "\n",

--- a/examples/basic_usage.ipynb
+++ b/examples/basic_usage.ipynb
@@ -13,7 +13,7 @@
    "id": "0a18b788",
    "metadata": {},
    "source": [
-    "<div class=\"note\"><span class=\"note-t\">TL;DR</span>\n",
+    "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
     "<p>We build a small stochastic circuit, simulate it, and train its parameters with <code>optax</code>. We also run the energy-based <code>PISING</code> gate and check that sampled parameter-shift gradients match exact ones.</p>\n",
     "</div>"
    ]

--- a/examples/basic_usage.ipynb
+++ b/examples/basic_usage.ipynb
@@ -23,7 +23,7 @@
    "id": "5770cbd2",
    "metadata": {},
    "source": [
-    "In this tutorial, we build a parametrised stochastic circuit and train it end to end, so the whole Torx workflow shows up in a single pass before you reach for the detailed guides. It is the quickstart companion to [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb), the full tour that introduces each gate and data primitive at a slower pace.\n",
+    "In this tutorial, we build a parametrised stochastic circuit and train it end to end, so the whole Torx workflow shows up in a single pass before you reach for the detailed guides. It's the quickstart companion to [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb), the full tour that introduces each gate and data primitive at a slower pace.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -462,7 +462,7 @@
     "\n",
     "The `BranchingSimulator` estimates gradients by parameter-shift sampling, while the `StateVectorSimulator` computes them exactly. We train the same circuit from the same starting parameters down both paths and compare the loss curves.\n",
     "\n",
-    "We compile each circuit once, outside the jitted step, and optimize the compiled circuit directly, since its parameters are inexact-array leaves. The sampled simulator bakes the structure into arrays during compilation, and that step cannot be re-run under `jit`, so it has to happen before the training loop."
+    "We compile each circuit once, outside the jitted step, and optimize the compiled circuit directly, since its parameters are inexact-array leaves. The sampled simulator bakes the structure into arrays during compilation, and that step can't be re-run under `jit`, so it has to happen before the training loop."
    ]
   },
   {

--- a/torx/psc/gates/_generator.py
+++ b/torx/psc/gates/_generator.py
@@ -39,13 +39,13 @@ class PISING(AbstractGeneratorGate[list[int], Float[Array, "5"], tuple[int, int]
 
     **Parameters**:
 
-    - `theta[0]` — $J$: coupling strength
+    - `theta[0]`, $J$: coupling strength
       ($J > 0$ ferromagnetic, $J < 0$ antiferromagnetic)
-    - `theta[1]` — $h_1$: external field on first pbit
-    - `theta[2]` — $h_2$: external field on second pbit
-    - `theta[3]` — $\beta$: inverse temperature
+    - `theta[1]`, $h_1$: external field on first pbit
+    - `theta[2]`, $h_2$: external field on second pbit
+    - `theta[3]`, $\beta$: inverse temperature
       ($\beta \to 0$: uniform, $\beta \to \infty$: ground state)
-    - `theta[4]` — $\Delta t$: continuous-time step
+    - `theta[4]`, $\Delta t$: continuous-time step
       ($0$: identity, larger: closer to equilibrium)
     """
 


### PR DESCRIPTION
## What this is

A prose-only pass over all 17 example notebooks. The content was already technically careful. The writing was not: it kept collapsing into compressed, agentless inventories that stated facts next to each other without saying what they were for.

The passage that started this:

```
The back-half occupancy checks mixing toward the uniform stationary
distribution. The terminal mean is compared with an independently assembled
transition matrix for the same discretized Torx chain, then with a
half-timestep propagation and the exact continuous-time Markov-chain mean.
```

Every claim there is true. A reader still cannot tell what question each comparison answers, who ran it, or why three references exist. It now reads:

```
Two questions are left. Has the regime chain settled, and is the sampled
terminal mean correct?

For the first, we read the back half of the occupancy traces, the steps past
T/2, which should sit near the uniform stationary distribution once the chain
has mixed.

For the second, we compare the sampled terminal mean against three
references, each answering a different question. A transition matrix we
assemble by hand from the same stated one-step probabilities gives the exact
answer for the discretized Torx chain we actually run, so it isolates
sampling error. A half-timestep propagation and the exact continuous-time
Markov-chain mean then show how much of the remaining gap comes from the
timestep itself rather than from sampling.
```

## The voice, benchmarked against PennyLane

I read [PennyLane's QCBM tutorial](https://pennylane.ai/demos/tutorial_qcbm) and pulled a rubric from it, then applied one house voice across the gallery:

1. Purpose before mechanics in every section, figure, and code lead-in.
2. Causal connectives instead of adjacency. Two facts side by side with the relation left implicit is a defect.
3. Acting voice. "The terminal mean is compared with" became "we compare the terminal mean against".
4. One validation check per sentence, each naming its claim, its reference, the result, and what the result means.
5. Varied sentence length. No runs of three flat declaratives.
6. Specialist terms glossed in plain words at first use: Gillespie simulation, propensity, detailed balance, MALA, ULA, Trotter and Strang splitting, block Gibbs, mean field, contrastive divergence, REINFORCE, parameter shift, FID, total variation distance, Monte Carlo standard error.
7. Figures narrated once, after they render, with the observation bound to a number the notebook prints.
8. Ownership stated once and positively. The `What runs where?` honesty is a real strength and it all survives, but a given fact is no longer repeated as four separate negations.
9. No unquantified praise.
10. Scoping caveats consolidated, never deleted.

Deliberately not copied from PennyLane: its unquantified quality claims, its unexplained constants, and a training log with an unacknowledged `inf`.

## Correctness fixes found along the way

- **Notebook 15** opened with a sentence that did not parse: "we build with Torx factors from a single probabilistic bit".
- **Notebook 14** cited Carter and Kohn 1994, a state-space Gibbs paper, as the definition of a block Gibbs sweep, via an anonymous inline DOI that bypassed the references list. Now cites Geman and Geman 1984 and routes it through the references section, matching notebook 16.
- **Notebook 06** called something "the ring's third, distinct reset case" before the three cases were ever enumerated. They are now listed where the first one appears.
- **Notebook 16** described a dashed line as "a selected heuristic marker at sweep 80" with no reason. It now says what it is for, without inventing a justification the committed output cannot support.
- **Notebook 11** used "event score", "the drive", and `intent_axis` before any of them were defined. The notebook now opens with the scenario.
- The `PISING` docstring carried em dashes that rendered into `api-gates.html`. Removed.
- The summary callout label is now `In brief` everywhere. It was `TL;DR` in 15 notebooks and `In brief` in one.

## What did not change

No code cell changed, except one teaching comment in notebook 03 that asserted three distances "answer different questions" without naming them. Verified mechanically against `origin/main`:

- every code cell source byte-identical
- every output, execution count, cell id, and metadata block preserved
- cell counts drop only in 02, 03, 08, and 11, where adjacent one-line caption cells were merged into connected prose

## Verification

| Gate | Result |
|---|---|
| Notebook execution (`nbmake`, all 17) | 17 passed in 160s |
| Unit tests | 215 passed, 147 subtests |
| Renderer tests | 5 passed |
| Pre-commit (isort, black, flake8, pyright) | all passed |
| Site build | 16 notebooks + 6 API pages + index + llms.txt, no excerpt drift |
| Rendered audit | 32 pages, 1,655 links, 87 images, 0 broken, 0 missing alt, 0 banned characters |
| Structural diff vs `origin/main` | 0 code changes, 0 output changes, 0 metadata changes |
| Visual check | read the rendered pages at 1440px, crop level, for notebooks 13 and 15 |

Rebuild command:

```
uv run --frozen --extra docs --extra testing --extra examples python docs_site/scripts/build_site.py
```

## Reviewing this

The diff is 714 insertions and 755 deletions across 19 files, all prose. Worth reading first: notebook 13's Verification section, notebook 14's opening box, notebook 11's intro, and notebook 15's first three paragraphs. Those are the four largest register changes.
