### PR TITLE
docs: revise notebook prose against Distill

### DIFF
--- a/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
+++ b/examples/01_introduction_to_parametrised_stochastic_circuits.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We build parametrised stochastic circuits over the three Torx data primitives, <a href=\"#Pbit-gates\">pbits</a>, <a href=\"#Pdit-gates\">pdits</a>, and <a href=\"#Pmode-gates\">pmodes</a>, so that every gate constructor becomes readable as a transition kernel or a Gaussian map. We inspect those gates two ways, because the two answer different questions: we compose some into circuits and sample them to see the distribution that comes out, and we evaluate others directly from their transition matrices to see the kernel itself.</p>\n",
+    "<p>We introduce parametrised stochastic circuits through the three Torx data primitives: <a href=\"#Pbit-gates\">pbits</a>, <a href=\"#Pdit-gates\">pdits</a>, and <a href=\"#Pmode-gates\">pmodes</a>. For each primitive, we connect the gate constructor to its mathematical action—a transition kernel or a Gaussian map. We then inspect gates in two complementary ways: sampling a composed circuit shows the distribution it produces, while evaluating a transition matrix exposes the kernel directly.</p>\n",
     "</div>"
    ]
   },
@@ -23,7 +23,7 @@
    "id": "a404784d",
    "metadata": {},
    "source": [
-    "In this tutorial, we build parametrised stochastic circuits (PSCs) and run them on the three Torx data primitives. Torx is a JAX framework for programs that transform probability distributions, so a circuit here is a recipe for reshaping a distribution. This notebook is the entry point to the example gallery, because the gates and the sampling workflow we set up here reappear throughout the later notebooks. The examples assume basic familiarity with probability distributions and JAX, and use Torx, JAX, NumPy, and Matplotlib.\n",
+    "Probability models often combine binary, finite-state, and continuous variables. How can a single programming model transform distributions over all three? Torx addresses this question with parametrised stochastic circuits (PSCs): JAX programs whose gates reshape probability distributions. This notebook introduces the gates and sampling workflow used throughout the example gallery. It assumes basic familiarity with probability distributions and JAX, and uses Torx, JAX, NumPy, and Matplotlib.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -31,13 +31,13 @@
     "- read each gate as a transition kernel, and\n",
     "- sample pbit and pmode circuits and read the pdit kernel from its transition matrix.\n",
     "\n",
-    "The three data primitives are:\n",
+    "Torx provides three data primitives:\n",
     "\n",
     "- pbits, binary sites, $\\{0,1\\}$,\n",
     "- pdits, $d$-state sites, $\\{0,\\dots,d-1\\}$, and\n",
     "- pmodes, continuous sites, $\\mathbb{R}^N$.\n",
     "\n",
-    "We build a PSC from scratch and meet the core gates for each primitive:\n",
+    "We begin with pbits, whose small transition matrices make every branch explicit. We then extend the same kernel view to a cyclic pdit and finish with continuous Gaussian maps:\n",
     "\n",
     "1. pbit gates `PSWAP`, `PNOT`, and `PISING`, reading each transition matrix and sampling the branch gates,\n",
     "2. the pdit gate that takes a stay/forward/backward random walk on its $d$ states, and\n",
@@ -466,23 +466,23 @@
    "source": [
     "### PISING\n",
     "\n",
-    "The two gates so far choose between staying put and applying one fixed operation. `PISING` is built differently, because its kernel comes out of an energy model rather than a single switching probability, and that changes what shows up in the matrix.\n",
+    "The preceding gates choose between the identity and one fixed operation. `PISING` instead derives its kernel from an energy model, so its finite-time transition matrix can include paths with more than one flip.\n",
     "\n",
-    "The [`PISING`](https://docs.torx.ai/en/latest/api-gates.html#PISING) gate is a finite-time kernel for [Glauber dynamics](https://doi.org/10.1063/1.1703954) on an Ising bond. It integrates a single-spin-flip generator for a time $\\Delta t$, so the resulting kernel includes multi-flip paths.\n",
+    "The [`PISING`](https://docs.torx.ai/en/latest/api-gates.html#PISING) gate is a finite-time kernel for [Glauber dynamics](https://doi.org/10.1063/1.1703954) on an Ising bond. It integrates a single-spin-flip generator for a time $\\Delta t$; exponentiating that generator sums the possible jump sequences over the interval.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Glauber dynamics</summary><p>The generator $Q$ gives instantaneous rates for one-spin jumps. Its matrix exponential sums every allowed jump sequence over $\\Delta t$, so a finite-time transition can contain more than one flip.</p></details>\n",
     "\n",
-    "With $s_i=2b_i-1$ for pbit values $b_i\\in\\{0,1\\}$, the bond energy and the single-flip generator are shown below. [Hamming distance](https://doi.org/10.1002/j.1538-7305.1950.tb00463.x) counts how many pbits differ between two configurations.\n",
+    "Let $s_i=2b_i-1$ for pbit values $b_i\\in\\{0,1\\}$. The bond energy and the single-flip generator are shown below. [Hamming distance](https://doi.org/10.1002/j.1538-7305.1950.tb00463.x) counts the pbits on which two configurations differ.\n",
     "\n",
     "$$E(\\mathbf{s})=-J\\,s_1 s_2-h_1 s_1-h_2 s_2,\\qquad\n",
     "Q_{ab}=\\mathbb{1}[\\mathrm{Hamming}(a,b)=1]\\;\\sigma\\left[-\\beta\\big(E_a-E_b\\big)\\right]\\ (a\\neq b),\\qquad\n",
     "Q_{bb}=-\\!\\!\\sum_{a\\neq b}Q_{ab},$$\n",
     "\n",
-    "so only single-spin-flip neighbors get off-diagonal rates and each column sums to zero. Here $J$ is the bond coupling and $h_1, h_2$ are the local fields. The inverse temperature $\\beta$ scales the energy change of the proposed flip, so larger $\\beta$ means a colder, more selective update.\n",
+    "Only single-spin-flip neighbors receive off-diagonal rates, and the diagonal term makes each column sum to zero. Here $J$ is the bond coupling, while $h_1$ and $h_2$ are local fields. The inverse temperature $\\beta$ scales the energy change of a proposed flip, so increasing $\\beta$ produces a colder, more selective update.\n",
     "\n",
-    "The gate itself is the matrix exponential $\\mathsf{PISING}(\\theta)=\\exp(\\Delta t\\,Q)$. Unlike the branch-table gates above, it's a $4\\times 4$ column-stochastic kernel. Its parameter vector $\\theta=[J,h_1,h_2,\\beta,\\Delta t]$ holds the physical bond parameters.\n",
+    "The finite-time gate is the matrix exponential $\\mathsf{PISING}(\\theta)=\\exp(\\Delta t\\,Q)$. Unlike the branch-table gates above, it is a $4\\times 4$ column-stochastic kernel. Its parameter vector $\\theta=[J,h_1,h_2,\\beta,\\Delta t]$ contains the physical bond parameters.\n",
     "\n",
-    "Rather than sample this gate, we build it and evaluate its transition matrix directly with `get_matrix`, then plot that matrix as a heatmap for the bond parameters chosen below. This is the first place in the notebook where we read a kernel instead of sampling one, and the multi-flip entries are what to watch: they are positive, but at $\\Delta t=0.35$ they are small enough to round to 0.00 in the heatmap."
+    "We evaluate this kernel directly with `get_matrix` rather than estimating it from samples. The heatmap below shows the transition matrix for the selected bond parameters. In particular, finite-time multi-flip entries are positive, although at $\\Delta t=0.35$ they are small enough to display as 0.00 after rounding."
    ]
   },
   {
@@ -569,13 +569,13 @@
    "source": [
     "## Pdit gates\n",
     "\n",
-    "Going from two states to $d$ states changes nothing structural about a gate, and this section is the shortest way to show that.\n",
+    "The same column-stochastic construction applies when a site has more than two states.\n",
     "\n",
-    "A **pdit** is a discrete stochastic site with $d$ states, the generalization of a pbit to more than two states. We use [`PditCycle`](https://docs.torx.ai/en/latest/api-gates.html#PditCycle), a random walk on a cyclic $d$-state pdit with stay, forward, and backward branches. Three branches are easier to check against a matrix than against sampled bars, so we take the same route as `PISING` here and read the column-stochastic transition matrix at $d=3$ directly, plotted below as a heatmap.\n",
+    "A **pdit** is a discrete stochastic site with $d$ states, generalizing a pbit beyond $\\{0,1\\}$. We use [`PditCycle`](https://docs.torx.ai/en/latest/api-gates.html#PditCycle), which defines a random walk on a cyclic $d$-state pdit with stay, forward, and backward branches. Because all three branches appear in each input column, we inspect the transition matrix directly, as we did for `PISING`. The heatmap below uses $d=3$.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: three-way Pdit softmax</summary><p><code>PditCycle</code> applies softmax to $[0,\\theta_0,\\theta_1]$ for the stay, forward, and backward probabilities. Thus $\\theta=\\log([0.30,0.20]/0.50)$ reproduces $[0.50,0.30,0.20]$.</p></details>\n",
     "\n",
-    "Other pdit permutation gates include `PditShift` and `PditSWAP`, and `PditCycle` drives the regime chain in [notebook 13](13_regime_switching_diffusion.ipynb)."
+    "Other pdit permutation gates include `PditShift` and `PditSWAP`. Later, [notebook 13](13_regime_switching_diffusion.ipynb) uses `PditCycle` to drive a regime chain."
    ]
   },
   {
@@ -665,17 +665,17 @@
    "source": [
     "## Pmode gates\n",
     "\n",
-    "Continuous sites are the last primitive, and they need a different kind of gate, because a site valued in $\\mathbb{R}^N$ has no finite transition matrix to write down.\n",
+    "A continuous site requires a different representation: when the state space is $\\mathbb{R}^N$, there is no finite transition matrix to enumerate.\n",
     "\n",
-    "A **pmode** is a continuous stochastic site valued in $\\mathbb{R}^N$. [`AffineGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#AffineGaussianGate) is the general pmode gate we use here: it applies a linear map, adds a bias, and adds diagonal Gaussian noise. This form maps Gaussian inputs to Gaussian outputs:\n",
+    "A **pmode** is a continuous stochastic site valued in $\\mathbb{R}^N$. The [`AffineGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#AffineGaussianGate) applies a linear map, adds a bias, and then adds diagonal Gaussian noise:\n",
     "\n",
     "$$X \\mapsto \\underbrace{A X}_{\\vphantom{\\big|}\\text{linear map}} + \\mathbf{b} + \\varepsilon,\\qquad \\varepsilon \\sim \\mathcal{N}(0, \\Delta),$$\n",
     "\n",
-    "where $A$ is the linear map, $\\mathbf{b}$ the bias shift, and $\\varepsilon$ the diagonal Gaussian noise. On a Gaussian input this is closed form: $\\mathcal{N}(\\mu,\\Sigma)\\mapsto\\mathcal{N}(A\\mu+\\mathbf{b},\\,A\\Sigma A^\\top+\\Delta)$.\n",
+    "where $A$ is the linear map, $\\mathbf{b}$ is the bias shift, and $\\varepsilon$ is the diagonal Gaussian noise. Gaussian inputs remain Gaussian: $\\mathcal{N}(\\mu,\\Sigma)\\mapsto\\mathcal{N}(A\\mu+\\mathbf{b},\\,A\\Sigma A^\\top+\\Delta)$.\n",
     "\n",
-    "The examples below use `AffineGaussianGate` directly, then [`MixtureGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#MixtureGaussianGate), which selects one of several diagonal Gaussian components (a mean shift plus diagonal noise) under a discrete control.\n",
+    "We first use `AffineGaussianGate` directly. We then introduce [`MixtureGaussianGate`](https://docs.torx.ai/en/latest/api-gates.html#MixtureGaussianGate), which uses a discrete control to select one of several diagonal Gaussian components, each defined by a mean shift and diagonal noise.\n",
     "\n",
-    "Those two gates cover more ground than they appear to, since `AffineGaussianGate` already contains the common special cases: shift, scale, rotation, and diffusion."
+    "The affine form includes the common special cases of shift, scale, rotation, and diffusion."
    ]
   },
   {
@@ -846,7 +846,7 @@
    "id": "6581d872",
    "metadata": {},
    "source": [
-    "The output cloud is stretched, tilted, and shifted relative to the input, which is the entire content of the affine map plus its diagonal noise. One caveat about reading the picture: the input cloud is drawn from a separate $\\mathcal{N}(0, I)$ source circuit with its own key, so its points have no one-to-one correspondence with the plotted output points."
+    "The output cloud is stretched, tilted, and shifted relative to the input, as predicted by the affine map and its diagonal noise. The figure does not pair individual input and output points: the input cloud comes from a separate $\\mathcal{N}(0, I)$ source circuit with its own key, so only the two distributions—not pointwise trajectories—can be compared."
    ]
   },
   {
@@ -856,17 +856,17 @@
    "source": [
     "### MixtureGaussianGate\n",
     "\n",
-    "This last gate is the first hybrid one, because it lets a discrete site steer a continuous one.\n",
+    "We now combine a discrete control with a continuous state.\n",
     "\n",
-    "`MixtureGaussianGate` uses the control pdit value to choose which diagonal Gaussian component fires. The gate adds the selected component mean (plus diagonal Gaussian noise) to the input continuous state. We start the pmode at the origin and sample the control from known weights $\\pi$, so the marginal cloud follows the mixture density:\n",
+    "`MixtureGaussianGate` uses the control pdit value to choose a diagonal Gaussian component. The gate adds the selected component mean and diagonal Gaussian noise to the input continuous state. Starting the pmode at the origin and sampling the control with known weights $\\pi$ produces the marginal mixture\n",
     "\n",
     "$$p_{X'}(x)=\\sum_{k=0}^{K-1}\\pi_k\\,\\mathcal{N}(x;\\,\\mu_k,\\,\\Sigma_k),$$\n",
     "\n",
-    "where $\\pi_k$ is the control distribution (how often branch $k$ fires), $\\mu_k$ is branch $k$'s mean, and $\\Sigma_k=\\mathrm{diag}(\\sigma_k^2)$ is its diagonal covariance.\n",
+    "where $\\pi_k$ is the probability that branch $k$ fires, $\\mu_k$ is its mean, and $\\Sigma_k=\\mathrm{diag}(\\sigma_k^2)$ is its diagonal covariance.\n",
     "\n",
-    "Because we chose $\\pi_k$, $\\mu_k$, and $\\Sigma_k$ ourselves, we can check the samples against them before plotting anything. We compare each branch's sample mean against its parameter $\\mu_k$ within a tolerance that shrinks as $1/\\sqrt{n_k}$ in the number of samples that branch received, which tests the component means. We then compare the empirical branch frequencies against $\\pi$ within $3/\\sqrt{N}$, which tests that the control fires at the stated weights.\n",
+    "Because $\\pi_k$, $\\mu_k$, and $\\Sigma_k$ are specified parameters, they also provide direct numerical checks. For each branch, we compare the sample mean with $\\mu_k$ using a tolerance that decreases as $1/\\sqrt{n_k}$, where $n_k$ is the number of samples assigned to that branch. We then compare the empirical branch frequencies with $\\pi$ using the tolerance $3/\\sqrt{N}$. The first check tests the component means; the second tests whether the control selects components with the stated weights.\n",
     "\n",
-    "In `sites=(0, 0)`, the first `0` addresses discrete control site 0 and the second addresses continuous site 0 in a separate namespace. Torx generates the samples and the control labels, and the notebook's own NumPy code both computes the analytic mixture density and runs the assertions that compare those samples against it."
+    "In `sites=(0, 0)`, the first `0` addresses discrete control site 0, and the second addresses continuous site 0 in a separate namespace. Torx generates both the continuous samples and their control labels. The notebook's NumPy code evaluates the analytic mixture density and performs the assertions against those samples."
    ]
   },
   {
@@ -1045,7 +1045,7 @@
    "id": "11caddbe",
    "metadata": {},
    "source": [
-    "The cloud is a single draw from the marginal mixture, colored by the branch label the control gate itself produced rather than by any grouping we imposed afterward. Each colored lobe sits under a peak of the contours, which are the analytic density evaluated from the same $\\pi_k$, $\\mu_k$, and $\\Sigma_k$, so the picture shows visually what the branch-mean and branch-weight checks above already established numerically."
+    "The plot shows one sample from the marginal mixture, with color encoding the branch label produced by the control gate rather than a cluster assigned afterward. The contour lines encode the analytic density computed from the same $\\pi_k$, $\\mu_k$, and $\\Sigma_k$. Each colored lobe lies beneath the corresponding density peak, consistent with the branch-mean and branch-weight checks above; the plot itself remains a finite-sample comparison."
    ]
   },
   {
@@ -1055,9 +1055,9 @@
    "source": [
     "## Gate inventory\n",
     "\n",
-    "This table is the part of the notebook worth coming back to, because it collects every gate we built in this tutorial, grouped by primitive, together with the later notebooks that put each one to work.\n",
+    "The table below collects the gates introduced in this tutorial, groups them by primitive, and links to later notebooks that use them.\n",
     "\n",
-    "Each gate is parametrised by a logit or a small parameter set, then composed through `DiscretePCircuit` or `HybridPCircuit`, so a gate carries structure and its parameters always travel beside it in a separate list. The Used in column points to the notebooks that build each one.\n",
+    "Each gate is parametrised by a logit or a small parameter set and then composed through `DiscretePCircuit` or `HybridPCircuit`. The gate object specifies structure, while its parameters occupy the corresponding entry in a separate list. The Used in column identifies notebooks that compose each gate into a larger model.\n",
     "\n",
     "The Torx gate library extends beyond this introductory set. For example, `PJUMP` is a two-pbit branch gate that moves probability from $|10)$ to $|01)$.\n",
     "\n",
@@ -1078,14 +1078,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "In this tutorial, we built the basic parametrised stochastic circuits used by Torx, and the four points below are what carries forward into the rest of the gallery.\n",
+    "We have now described the three Torx data primitives and connected each introductory gate to the kernel it implements:\n",
     "\n",
     "- Torx programs act on three data primitives: pbits (binary), pdits ($d$-state), and pmodes (continuous, valued in $\\mathbb{R}^N$).\n",
     "- Discrete gates are column-stochastic kernels, while pmode gates are continuous Markov kernels (Gaussian maps). Many discrete branch-table gates combine the identity with a deterministic operation selected with probability $p$, parametrised by the logit $\\theta$ so they train with ordinary gradients. `PISING` uses a physical parameter vector instead.\n",
     "- `PSWAP`, `PNOT`, and `PISING` are the core pbit gates, and `PditCycle` walks a cyclic $d$-state pdit (stay/forward/backward).\n",
     "- `AffineGaussianGate` is an affine-Gaussian map, and `MixtureGaussianGate` selects one of several diagonal Gaussian components under a discrete control.\n",
     "\n",
-    "See also:\n",
+    "The following notebooks develop these constructions in larger circuits:\n",
     "\n",
     "- [`02_random_walks_on_graphs.ipynb`](02_random_walks_on_graphs.ipynb), the `PSWAP` gate tiled over graph edges,\n",
     "- [`06_ising_sampling_contrastive_divergence.ipynb`](06_ising_sampling_contrastive_divergence.ipynb), the `PISING` gate as a Gibbs sampler, and\n",

--- a/examples/02_random_walks_on_graphs.ipynb
+++ b/examples/02_random_walks_on_graphs.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We turn an eight-node random walk into one <code>PSWAP</code> layer per graph sweep, then carry the same construction over to oriented edges with a directed <code>PJUMP</code> cycle. Refining the layer count separates two errors with different causes: the deterministic bias that comes from chopping simultaneous edge updates into an ordered sequence (<a href=\"#ref-trotter-1959\">Trotter</a> splitting), and the random scatter left over from estimating occupancies out of a finite number of sampled walks (Monte Carlo noise). Running the edge order forward and then in reverse, a symmetric <a href=\"#ref-strang-1968\">Strang</a> sweep, squares the rate at which that bias falls.</p>\n",
+    "<p>A continuous-time random walk updates every graph edge simultaneously, whereas a circuit applies gates in an order. This notebook connects the two descriptions on an eight-node graph, using one <code>PSWAP</code> per edge in each graph sweep, and then carries the construction over to oriented edges with a directed <code>PJUMP</code> cycle. Refining the layer count separates the deterministic bias introduced by the ordered updates (<a href=\"#ref-trotter-1959\">Trotter</a> splitting) from the random scatter caused by estimating occupancies with finitely many sampled walks (Monte Carlo noise). A symmetric forward-then-reverse <a href=\"#ref-strang-1968\">Strang</a> sweep squares the rate at which the splitting bias falls.</p>\n",
     "</div>"
    ]
   },
@@ -23,15 +23,15 @@
    "id": "067cb57a",
    "metadata": {},
    "source": [
-    "In this tutorial, we express a random walk on a graph (probability mass moving along its edges) as a **parametrised stochastic circuit**: one graph node is one [**pbit**](01_introduction_to_parametrised_stochastic_circuits.ipynb), each edge is one `PSWAP` gate, and a stack of Trotter layers approximates the graph heat flow.\n",
+    "A random walk can be pictured as probability mass spreading along the edges of a graph. How can a gate-based circuit reproduce that simultaneous flow? We will express the walk as a **parametrised stochastic circuit**: one graph node is one [**pbit**](01_introduction_to_parametrised_stochastic_circuits.ipynb), each edge is one `PSWAP` gate, and a stack of Trotter layers approximates the graph heat flow.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: pbit</summary><p>A pbit is a random binary 0/1 state. Its mean over repeated runs is an occupancy probability.</p></details>\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: Trotter and Strang splitting</summary><p>[Trotter splitting](#ref-trotter-1959) replaces simultaneous evolution by many small ordered edge updates. [Strang splitting](#ref-strang-1968) uses a forward-and-back symmetric edge order to cancel the leading splitting error.</p></details>\n",
+    "<details class=\"tx-disclosure\"><summary>Term: Trotter and Strang splitting</summary><p><a href=\"#ref-trotter-1959\">Trotter splitting</a> replaces simultaneous evolution by many small ordered edge updates. <a href=\"#ref-strang-1968\">Strang splitting</a> uses a forward-and-back symmetric edge order to cancel the leading splitting error.</p></details>\n",
     "\n",
-    "The graph Laplacian is a sum of edge terms, so the continuous-time walk splits into small two-node updates. A single `PSWAP` is the exact update for one edge, which means a layer holding one `PSWAP` per edge, repeated in time, approximates the full walk.\n",
+    "This construction is possible because the graph Laplacian is a sum of edge terms. The continuous-time walk therefore separates into small two-node updates, and a single `PSWAP` gives the exact update for one edge. Repeating a layer that contains one `PSWAP` per edge then approximates the full walk.\n",
     "\n",
-    "We build that up in stages. First we map one edge to one `PSWAP` gate, which implements the exact two-node Markov kernel (the transition rule for one step of the walk). Then we compose an eight-node graph as one Trotter layer of `PSWAP` gates and watch the distribution diffuse. Finally we sweep the Trotter resolution, because that sweep is what pulls Trotter bias apart from Monte Carlo noise, square the convergence rate with a symmetric Strang sweep, and carry the construction over to directed edges with the `PJUMP` gate.\n",
+    "We begin with one edge and its exact two-node Markov kernel (the transition rule for one step of the walk). We then compose an eight-node graph from a Trotter layer of `PSWAP` gates and watch its distribution diffuse. A resolution sweep separates Trotter bias from Monte Carlo noise; after that, we use a symmetric Strang sweep to square the convergence rate and transfer the same construction to directed edges with `PJUMP`.\n",
     "\n",
     "We assume familiarity with the gate set from [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb), and the code uses Torx, JAX, NumPy, and NetworkX.\n"
    ]
@@ -166,11 +166,13 @@
    "source": [
     "## What the circuit computes\n",
     "\n",
-    "Before writing any gates, we establish why a graph walk becomes a circuit at all. The whole construction rests on one structural fact: the generator of the walk is a sum of one term per edge, and each of those terms has an exact gate.\n",
+    "Before writing any gates, we establish the correspondence between the graph walk and the circuit. Let $p(t)$ be the occupancy distribution at time $t$. It obeys the master equation (the rule for how the distribution changes over time) $\\dot p = Qp$, whose exact solution is\n",
     "\n",
-    "The walk spreads an occupancy distribution $p(t)$ over time, and it obeys the master equation (the rule for how the distribution changes over time) $\\dot p = Qp$.\n",
+    "$$\n",
+    "p(t) = e^{tQ}p_0.\n",
+    "$$\n",
     "\n",
-    "The exact answer is the matrix exponential $p(t) = e^{tQ}p_0$. For a symmetric graph walk the generator (the matrix that drives the time evolution) is minus the graph Laplacian, $Q = -L$, where\n",
+    "For a symmetric graph walk, the generator (the matrix that drives the time evolution) is minus the graph Laplacian, $Q=-L$, where\n",
     "\n",
     "$$\n",
     "L \\;=\\; \\sum_{\\{i,j\\} \\in E} w_{ij}\\,(e_i - e_j)(e_i - e_j)^\\top, \\qquad L\\mathbf 1 = 0\n",
@@ -178,22 +180,22 @@
     "\n",
     "In the code below, every edge uses the same walk rate `RATE`, so $w_{ij} = \\texttt{RATE}$ and $w_{ij}\\,\\Delta t = \\texttt{RATE}\\,\\Delta t$ is the first-order term of the exact `PSWAP` probability.\n",
     "\n",
-    "The Laplacian is a sum of edge-local terms, so the heat flow $\\dot p = -Lp$ splits the same way. That per-edge structure gives a circuit layer with one `PSWAP` per edge:\n",
+    "The sum in $L$ assigns one local operator to each edge. We can therefore represent one slice of the heat flow $\\dot p=-Lp$ by a circuit layer containing one `PSWAP` per edge:\n",
     "\n",
     "$$\n",
     "\\underbrace{T}_{\\vphantom{\\big|}\\text{Trotter layer}} \\;=\\; \\prod_{\\{i,j\\} \\in E} \\mathrm{PSWAP}_{ij}(p_{ij}), \\qquad\n",
     "\\mathrm{PSWAP}_{ij}(p_{ij}) = \\mathbb I - \\underbrace{p_{ij}}_{\\vphantom{\\big|}\\text{swap prob}}\\,(e_i - e_j)(e_i - e_j)^\\top\n",
     "$$\n",
     "\n",
-    "The product runs one `PSWAP` per edge, each a two-node walk on edge $\\{i,j\\}$. Its rank-one term $(e_i - e_j)(e_i - e_j)^\\top$ is the same edge-local operator that appears in $L$.\n",
+    "The product applies one two-node walk on every edge $\\{i,j\\}$. Its rank-one term $(e_i-e_j)(e_i-e_j)^\\top$ is precisely the edge-local operator that appears in $L$, which is the bridge between the gate and the Laplacian description.\n",
     "\n",
-    "Each `PSWAP` is the *exact* edge propagator $e^{\\Delta t\\,Q_{ij}}$ on its edge, and the occupancy form $\\mathbb I - p_{ij}(e_i-e_j)(e_i-e_j)^\\top$ above is the single-walker map it induces. The circuit is the *ordered* product of these edge propagators, repeated $N$ times:\n",
+    "Each `PSWAP` is the *exact* edge propagator $e^{\\Delta t\\,Q_{ij}}$ on its edge, and the occupancy form $\\mathbb I-p_{ij}(e_i-e_j)(e_i-e_j)^\\top$ above is the single-walker map it induces. The approximation enters only when we apply the edge propagators in an order and repeat their product $N$ times:\n",
     "\n",
     "$$\n",
     "p(t) \\;\\approx\\; \\underbrace{\\Big(\\textstyle\\prod_{\\{i,j\\}\\in E} e^{\\Delta t\\,Q_{ij}}\\Big)^{N}}_{\\vphantom{\\big|}\\text{the circuit}} p_0 \\;\\xrightarrow[N\\to\\infty]{}\\; \\underbrace{e^{-Lt}\\,p_0}_{\\vphantom{\\big|}\\text{exact heat flow}}, \\qquad \\Delta t = t/N\n",
     "$$\n",
     "\n",
-    "The edge generators don't commute, so the ordered product equals $e^{-Lt}$ only in the limit. This is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). The first-order expansion of one layer is $\\mathbb I - \\Delta t\\,L$ (one Euler step), which is where the $1/N$ Trotter bias studied below comes from."
+    "The edge generators do not commute, so the ordered product equals $e^{-Lt}$ only in the limit. This is the classical Lie-Trotter product formula ([Trotter 1959](#ref-trotter-1959)). Expanding one layer to first order gives $\\mathbb I-\\Delta t\\,L$, the same update as one Euler step; the neglected terms produce the $1/N$ Trotter bias measured below."
    ]
   },
   {
@@ -547,9 +549,9 @@
    "source": [
     "## Watching the walk diffuse\n",
     "\n",
-    "Before sampling anything, we look at what the circuit will have to reproduce: the exact heat flow $p(t) = e^{tQ}p_0$ with $Q = -L$. The helpers `build_graph_generator` and `reference_heat_flow` assemble $Q$ and evaluate this matrix exponential, so the panels below are ground truth rather than an estimate.\n",
+    "Before sampling the circuit, we compute the flow it is meant to reproduce. The reference is the exact heat flow $p(t)=e^{tQ}p_0$ with $Q=-L$. The helpers `build_graph_generator` and `reference_heat_flow` assemble $Q$ and evaluate this matrix exponential, so the panels below show a deterministic reference rather than a sampled estimate.\n",
     "\n",
-    "The first snapshot is the initial state, and its peak is far taller than anything that follows. We therefore clip the shared color scale to roughly the 98th percentile of the post-initial snapshots, which keeps the later spread readable while the $t=0$ peak saturates the warm end."
+    "The initial state contains a peak much taller than any later value. A color scale spanning that peak would compress the variation in the remaining panels, so the figure clips its shared scale to roughly the 98th percentile of the post-initial snapshots. This keeps the later spread readable while allowing the $t=0$ peak to saturate the warm end; color comparisons among the later panels remain on the same scale."
    ]
   },
   {
@@ -636,9 +638,9 @@
    "source": [
     "## Building the Torx circuit\n",
     "\n",
-    "Now we build the circuit whose job is to approximate that flow. For a Trotter resolution of $m$ steps, each layer applies one `PSWAP` per edge with the swap probability for the slice time $\\Delta t = t/m$, and the `DiscretePCircuit` constructor with `reps=m` repeats the whole layer $m$ times.\n",
+    "We now build the circuit that approximates this reference flow. At Trotter resolution $m$, one layer applies a `PSWAP` to every edge using the swap probability for the slice duration $\\Delta t=t/m$. Passing `reps=m` to `DiscretePCircuit` repeats the complete edge layer $m$ times.\n",
     "\n",
-    "That repetition is the product $T^m \\approx e^{tQ}p_0$ from the heat-flow construction above."
+    "This repeated circuit is the product $T^m \\approx e^{tQ}p_0$ introduced above. Increasing $m$ shortens each slice while keeping the total interval $t$ fixed."
    ]
   },
   {
@@ -696,7 +698,7 @@
    "id": "2872dbe2",
    "metadata": {},
    "source": [
-    "The eight-node layer carries twelve gates, one per edge, which is more than a diagram can show clearly. A four-node ring uses the same repeated-layer pattern with few enough wires to follow."
+    "The eight-node graph has twelve edges, so its layer contains twelve gates. That is too dense for a circuit diagram in which every wire and repeated gate remains easy to follow. The four-node ring below uses the same repeated-layer construction with fewer wires: each repetition applies one `PSWAP` per ring edge, and the repetition marker encodes the stack in time."
    ]
   },
   {
@@ -777,9 +779,9 @@
    "source": [
     "## Coarse and fine checks\n",
     "\n",
-    "The first question is whether the Trotter resolution matters at all, so we run the same edge layer at a coarse $m=2$ and a finer $m=32$, changing only the resolution: `reps` and the per-slice swap probability that goes with it. The exact $e^{tQ}p_0$ is the reference for both runs, and the printed $L_2$ errors say how far each estimate sits from it.\n",
+    "Does the Trotter resolution visibly affect the approximation? We compare the same ordered edge layer at a coarse $m=2$ and a finer $m=32$. Only `reps` and the corresponding per-slice swap probability change; the graph, total time, rate, initial distribution, and sample count remain fixed. The exact $e^{tQ}p_0$ is the reference for both runs, and the printed $L_2$ errors measure the distance from that reference.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: L2 error</summary><p>The [$L_2$ norm](https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html) is the Euclidean distance across all node occupancies. Zero means the two distributions agree at every node.</p></details>"
+    "<details class=\"tx-disclosure\"><summary>Term: L2 error</summary><p>The <a href=\"https://numpy.org/doc/stable/reference/generated/numpy.linalg.norm.html\">$L_2$ norm</a> is the Euclidean distance across all node occupancies. Zero means the two distributions agree at every node.</p></details>"
    ]
   },
   {
@@ -929,12 +931,12 @@
    "source": [
     "## Trotter convergence\n",
     "\n",
-    "Refining $m$ doesn't improve a sampled estimate forever, because two error sources contribute to the measured gap and they behave differently as $m$ grows.\n",
+    "The coarse-and-fine comparison suggests that increasing $m$ helps, but a sampled estimate cannot improve indefinitely. Its measured error combines two contributions with different scaling:\n",
     "\n",
-    "- **Trotter bias** is the gap between the product formula and exact $e^{tQ}p_0$. First-order Trotter shrinks it as $1/m$: slope $-1$ on a log-log plot.\n",
-    "- **Monte Carlo noise** is the gap between the sampled estimate and the deterministic Trotter mean. By the central limit theorem its scale is $O(1/\\sqrt{N})$ in the sample count. It depends on the terminal probabilities, which vary with $m$, but is roughly flat here once the terminal distribution has stabilized.\n",
+    "- **Trotter bias** is the gap between the deterministic product formula and the exact $e^{tQ}p_0$. For first-order Trotter splitting, it falls as $1/m$, which appears as slope $-1$ on a log-log plot.\n",
+    "- **Monte Carlo noise** is the gap between the sampled estimate and the deterministic Trotter mean. By the central limit theorem, its scale is $O(1/\\sqrt{N})$ in the sample count. It depends on the terminal probabilities, which vary with $m$, but is roughly flat here once the terminal distribution has stabilized.\n",
     "\n",
-    "The deterministic product formula, computed as an exact matrix product per edge, measures pure bias. The sampled Torx estimate uses 12k trajectories per occupied source, 36k total trajectories per seed, across four seeds. The band is the sample standard deviation of those four seeds, so it's an indicative spread rather than a tight confidence interval."
+    "To separate them, we compute the product formula twice. An exact matrix product over the ordered edges gives the deterministic bias with no sampling noise. Torx then estimates the same product formula using 12k trajectories per occupied source, or 36k total trajectories per seed, across four seeds. The plotted band is the sample standard deviation of those four seeds; it indicates their spread but is not a tight confidence interval."
    ]
   },
   {
@@ -1374,7 +1376,7 @@
    "id": "a7bdf0c8",
    "metadata": {},
    "source": [
-    "A slope fit turns the order claim into a number we can check. We regress log error on log $m$ over the five finest resolutions and compare each fitted slope with its expected value, allowing 0.3 of slack: near $-1$ for the first-order product formula, near $-2$ for Strang. The next cell also asserts that Strang is the more accurate of the two at the finest resolution, which is what the steeper slope has to mean once $m$ is large enough."
+    "We quantify the convergence order by fitting a line to log error versus log $m$ over the five finest resolutions. The fitted slopes are compared with their expected values, with 0.3 of slack: near $-1$ for the first-order product formula and near $-2$ for Strang. The next cell also requires Strang to have the smaller deterministic error at the finest resolution, connecting the steeper fitted slope to the accuracy of the final approximation."
    ]
   },
   {
@@ -1422,7 +1424,7 @@
    "id": "fc038516",
    "metadata": {},
    "source": [
-    "Putting the two bias curves on one log-log axis turns the order difference into a difference in slope."
+    "The following log-log plot places the two deterministic bias curves on the same axes. Their slopes encode the order of the methods: first-order Trotter follows $1/m$, while the symmetric Strang construction follows $1/m^2$."
    ]
   },
   {
@@ -1477,9 +1479,9 @@
    "id": "88693044",
    "metadata": {},
    "source": [
-    "The two NumPy curves fall at the deterministic $1/m$ and $1/m^2$ bias rates, and the single Torx marker is the sampled Strang result already computed at $m=32$, which is where the sampled circuit can be read against the deterministic second-order curve.\n",
+    "The two NumPy curves follow the deterministic $1/m$ and $1/m^2$ bias rates. The single Torx marker is the sampled Strang result at $m=32$, so it can be compared with the deterministic second-order curve at the same resolution.\n",
     "\n",
-    "The symmetric Torx circuit costs one extra edge sweep per step. That's a constant factor, so it pays off whenever Trotter bias rather than sample count dominates the target error."
+    "A symmetric Torx layer requires one additional edge sweep per step. This is a constant-factor cost, and it improves accuracy when splitting bias, rather than finite-sample noise, dominates the target error. Once the Monte Carlo floor is larger than the bias, increasing the splitting order cannot reduce the sampled error by itself."
    ]
   },
   {
@@ -1489,9 +1491,9 @@
    "source": [
     "## Directed transport: the PJUMP gate\n",
     "\n",
-    "The `PSWAP` edge above is symmetric: probability flows both ways along an edge. Its directed counterpart is the `PJUMP` gate, which moves a token along an *oriented* edge $a \\to b$ at rate $r$. Over a slice $\\Delta t$ it sends the token from $a$ to $b$ with probability $p = 1 - e^{-r\\,\\Delta t}$, and it fires only when $a$ is occupied and $b$ is empty ($a = 1$, $b = 0$), leaving the pair untouched in every other case.\n",
+    "The `PSWAP` construction describes an undirected edge: probability can flow in either direction. For an oriented edge $a\\to b$, Torx provides the `PJUMP` gate. At rate $r$ over a slice $\\Delta t$, it moves a token from $a$ to $b$ with probability $p=1-e^{-r\\,\\Delta t}$. The gate fires only when the source is occupied and the destination is empty, $(a,b)=(1,0)$; every other pair is left unchanged.\n",
     "\n",
-    "Like `PSWAP`, the gate is parametrised by the logit $\\theta = \\log\\!\\big(p / (1 - p)\\big)$, and the same Trotter-layer machinery carries over: one `PJUMP` per directed edge is a single layer, and `DiscretePCircuit(gates, reps=m)` repeats it to cover $[0, t]$. The only change from the rest of this tutorial is that the graph is now directed."
+    "Like `PSWAP`, `PJUMP` is parametrised by the logit $\\theta=\\log\\!\\big(p/(1-p)\\big)$. The Trotter construction is otherwise unchanged: one `PJUMP` per directed edge forms a layer, and `DiscretePCircuit(gates, reps=m)` repeats it over $[0,t]$. We will apply this directed layer to a five-node cycle with two edge rates."
    ]
   },
   {
@@ -1727,7 +1729,7 @@
    "id": "9bb4c706",
    "metadata": {},
    "source": [
-    "Across all five snapshots the largest occupancy gap is under 0.05, and every snapshot still sums to one within $5\\times10^{-3}$, so the sampled walk tracks the exact directed flow to within sampling scatter. The figure below overlays the two."
+    "Across the five snapshots, the maximum occupancy difference is below 0.05, and every sampled distribution sums to one within $5\\times10^{-3}$. These checks show that the sampled circuit follows the exact directed flow at the scale of the sampling scatter. The figure below makes the comparison node by node: continuous lines show the NumPy reference, and dots show the Torx means from 20k samples."
    ]
   },
   {
@@ -1801,14 +1803,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "In this tutorial, we represented a continuous-time random walk on a graph as a stack of per-edge `PSWAP` gates, one pbit per node, and checked it against the exact heat flow.\n",
+    "We represented a continuous-time random walk on a graph as a circuit with one pbit per node and one edge-local gate per graph edge. The comparison with exact heat flow shows both where the construction is exact and where approximation enters:\n",
     "\n",
-    "- Each edge becomes one `PSWAP` gate, and the `DiscretePCircuit` constructor with `reps=m` repeats that layer to cover the time interval.\n",
+    "- Each edge becomes one `PSWAP` gate, and the `DiscretePCircuit` constructor with `reps=m` repeats that layer over the time interval.\n",
     "- The `expval_all` method of `BranchingSimulator` reads out node occupancies, recovering the spreading heat front across the eight-node graph.\n",
-    "- Refining the Trotter resolution drives the deterministic product formula toward the exact $e^{tQ}p_0$, with the bias falling as $1/m$.\n",
-    "- Reordering the same edge gates into a symmetric Strang sweep squares the convergence rate, dropping the bias as $1/m^2$.\n",
-    "- The directed `PJUMP` gate reuses the same layer construction on oriented edges, and the sampled walk tracks the exact directed flow $e^{Qt}p_0$.\n",
-    "- The same Laplacian-splits-per-edge pattern carries over to a mesh in [`03_bunny_graph_diffusion.ipynb`](03_bunny_graph_diffusion.ipynb)."
+    "- Refining the Trotter resolution drives the deterministic product formula toward the exact $e^{tQ}p_0$, with bias falling as $1/m$.\n",
+    "- Reordering the same edge gates into a symmetric Strang sweep squares the convergence rate, reducing the bias as $1/m^2$.\n",
+    "- Replacing undirected `PSWAP` gates with directed `PJUMP` gates carries the layer construction to oriented edges, where the sampled walk follows the exact directed flow $e^{Qt}p_0$.\n",
+    "- The same pattern—decompose a Laplacian into edge terms, then repeat the corresponding gate layer—extends from this graph to the mesh in [`03_bunny_graph_diffusion.ipynb`](03_bunny_graph_diffusion.ipynb)."
    ]
   },
   {

--- a/examples/03_bunny_graph_diffusion.ipynb
+++ b/examples/03_bunny_graph_diffusion.ipynb
@@ -23,15 +23,15 @@
    "id": "139813e7",
    "metadata": {},
    "source": [
-    "In this tutorial, we diffuse a probability distribution on the connectivity graph induced by the Stanford bunny mesh. This is the mesh-scale version of [notebook 02](02_random_walks_on_graphs.ipynb): the same `PSWAP`-per-edge primitive, now on a few hundred vertices.\n",
+    "The Stanford bunny is usually presented as a surface, but its mesh also defines a graph: vertices become nodes and triangle sides become edges. How can the edge-local `PSWAP` rule from [notebook 02](02_random_walks_on_graphs.ipynb) reproduce diffusion on this graph when the same rule must be applied across a few hundred vertices?\n",
     "\n",
-    "The setup is short to state. We map each unweighted mesh edge to one `PSWAP` gate, a single excitation starts at one ear vertex, and $x_i(t)$ is the probability that it occupies vertex $i$ after averaging repeated one-hot runs, each of which carries the excitation on exactly one vertex at a time.\n",
+    "We begin with a single excitation at one ear vertex. Each unweighted mesh edge contributes one `PSWAP` gate, and $x_i(t)$ denotes the probability that the excitation occupies vertex $i$ after averaging repeated one-hot runs. Every run therefore places the excitation on exactly one vertex, while the average over runs gives a probability field on the graph.\n",
     "\n",
-    "One gate per edge is enough because the combinatorial graph Laplacian $L = D - A$ splits into one symmetric two-node term per edge. An ordered layer of `PSWAP` gates therefore approximates the simultaneous graph evolution, and repeating that layer moves probability through the connectivity graph.\n",
+    "This construction follows from the combinatorial graph Laplacian $L = D - A$, which splits into one symmetric two-node term per edge. A layer of ordered `PSWAP` gates approximates the simultaneous graph evolution, and repeating the layer propagates probability through the connectivity graph.\n",
     "\n",
-    "A sampled field on its own tells us nothing about how far it can be trusted, so once the full Torx circuit is built we compare its multi-seed sample mean against two NumPy references that answer different questions. The deterministic mean of the same ordered sweep runs the identical update rule without ever sampling, so it isolates how much of the gap is sampling error. The exact reference then shows how much of the gap the ordered sweep introduces on its own. We finish by checking the same primitive on a closed 32-vertex patch, which is small enough to read vertex by vertex.\n",
+    "A sampled field alone does not tell us whether a discrepancy comes from finite sampling or from the ordered approximation. We therefore compare the full Torx result with two NumPy references. The deterministic ordered-sweep mean applies exactly the same updates without sampling, which isolates sampling error. The exact graph-diffusion solution then exposes the error introduced by the finite ordered sweep itself. Finally, we repeat the parity comparison on a closed 32-vertex patch, where the result can be inspected vertex by vertex.\n",
     "\n",
-    "One note on the word diffusion. We use only the unweighted connectivity graph, which records which vertices are adjacent and nothing else, so this construction doesn't model physical surface heat: edge lengths, triangle angles, vertex areas, and a mesh mass matrix play no part in it."
+    "Throughout the notebook, **diffusion** refers only to the unweighted connectivity graph. It is not a model of physical heat flow over the surface: edge lengths, triangle angles, vertex areas, and a mesh mass matrix do not enter the construction."
    ]
   },
   {
@@ -185,9 +185,9 @@
    "source": [
     "## Graph connectivity, the Laplacian, and one swap per edge\n",
     "\n",
-    "Before running anything on a few hundred vertices, this section establishes why a single two-site gate per edge is a legitimate way to diffuse probability on a graph.\n",
+    "Before applying a circuit to a graph with a few hundred vertices, we establish why one two-site gate per edge can represent a step of graph diffusion.\n",
     "\n",
-    "A triangle mesh induces a graph $G = (V, E)$: each vertex is a [pbit](01_introduction_to_parametrised_stochastic_circuits.ipynb), and each triangle side contributes an unweighted edge. The **combinatorial graph Laplacian** $L = D - A$, built from the degree matrix $D$ and adjacency matrix $A$, compares each vertex with its neighbors and defines\n",
+    "A triangle mesh induces a graph $G = (V, E)$: each vertex is a [pbit](01_introduction_to_parametrised_stochastic_circuits.ipynb), and each triangle side contributes an unweighted edge. Let $A$ be the adjacency matrix and $D$ the degree matrix. Their difference, the **combinatorial graph Laplacian** $L = D - A$, compares the value at each vertex with the values at its neighbors. Graph diffusion is then defined by\n",
     "\n",
     "$$\n",
     "\\dot x = -Lx,\n",
@@ -195,9 +195,9 @@
     "x(t) = e^{-Lt}x(0).\n",
     "$$\n",
     "\n",
-    "Under this equation probability flows between adjacent vertices and nowhere else, which is the master equation from [notebook 02](02_random_walks_on_graphs.ipynb) with generator $Q=-L$.\n",
+    "Under this equation, probability moves only between adjacent vertices. This is the master equation from [notebook 02](02_random_walks_on_graphs.ipynb), with generator $Q=-L$.\n",
     "\n",
-    "The structural fact we need is that the Laplacian splits into one symmetric two-node block per edge, $L=\\sum_{(i,j)\\in E}L_{ij}$. [Lie-Trotter splitting](#ref-trotter-1959) turns that sum into a product, rewriting the exact propagator as the limit of ordered per-edge products:\n",
+    "To connect this simultaneous evolution to edge-local gates, we use the decomposition $L=\\sum_{(i,j)\\in E}L_{ij}$, in which each $L_{ij}$ is a symmetric two-node block. [Lie-Trotter splitting](#ref-trotter-1959) rewrites the exact propagator as the limit of ordered products over these blocks:\n",
     "\n",
     "$$\n",
     "x(t) = \\lim_{N\\to\\infty}\\Bigl(\\underbrace{\\textstyle\\prod_{(i,j)\\in E}e^{\\Delta t Q_{ij}}}_{\\vphantom{\\big|}\\text{ordered per-edge sweep}}\\Bigr)^N x(0),\n",
@@ -205,9 +205,9 @@
     "\\Delta t=t/N.\n",
     "$$\n",
     "\n",
-    "At finite $N$, Torx executes each product as a sequential sweep over the edge list, where each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$ for this unit-rate graph. Overlapping edge blocks share a vertex, so they don't commute and the ordered product misses the exact propagator at finite $N$. That residual difference is the splitting bias, and it's one of the two errors we measure later.\n",
+    "For finite $N$, Torx evaluates each product as a sequential sweep over the edge list. On this unit-rate graph, each factor $e^{\\Delta t Q_{ij}}$ is one `PSWAP` with $p=\\tfrac12(1-e^{-2\\Delta t})$. Overlapping factors share a vertex and do not commute, so the finite ordered product differs from $e^{-Lt}$. We call this residual difference the **splitting bias** and measure it below.\n",
     "\n",
-    "Torx works with those per-edge factors alone and never forms the dense propagator $e^{-Lt}$, so both quantities we compare against come from NumPy: the exact eigensolution, and the deterministic mean of the same ordered sweep.\n"
+    "Torx constructs only the per-edge factors and never forms the dense propagator $e^{-Lt}$. NumPy consequently provides both references used in the comparison: the exact eigensolution and the deterministic mean of the same ordered sweep.\n"
    ]
   },
   {
@@ -217,15 +217,13 @@
    "source": [
     "## Diffusion on the bunny connectivity graph\n",
     "\n",
-    "Now we build the graph itself, and we set out what the two figures in this section can and can't show.\n",
+    "We now construct the graph and define what each of the two diffusion figures is intended to compare.\n",
     "\n",
-    "All probability starts on one ear vertex and spreads through graph edges.\n",
+    "All probability begins at one ear vertex and then spreads along graph edges. We load the `bun_zipper_res3` reconstruction from the [Stanford bunny dataset](#ref-stanford-bunny), retain its largest connected component, and coarsen it with `decimate_mesh` from `examples/helpers/_stanford_bunny.py`. The decimator snaps vertices to a uniform 3-D grid, replaces occupied cells with centroids, remaps faces, and drops collapsed triangles. This preprocessing produces the 450-vertex, 1,352-edge graph used below.\n",
     "\n",
-    "We load the `bun_zipper_res3` reconstruction from the [Stanford bunny dataset](#ref-stanford-bunny), keep its largest connected component, then coarsen it with `decimate_mesh` from `examples/helpers/_stanford_bunny.py`. The decimator snaps vertices to a uniform 3-D grid, replaces occupied cells with centroids, remaps faces, and drops collapsed triangles. This preprocessing determines the 450-vertex, 1,352-edge graph used below.\n",
+    "Torx samples the full graph only at $t=1.5$. Sampling $t=10$ or $t=40$ by the same construction would require many more repetitions of every gate in the layer, each evaluated over its own batch of samples. The $t=10$ and $t=40$ panels are therefore **NumPy exact references**, not Torx results.\n",
     "\n",
-    "Torx samples the full graph at $t=1.5$, and at that time only. Reaching $t=10$ or $t=40$ the same way would take many more repetitions of every gate in the layer, each with its own batch of samples, which is expensive, so the $t=10$ and $t=40$ panels are **NumPy exact references** rather than Torx results.\n",
-    "\n",
-    "That division also decides how we color the panels, and the two figures use different conventions deliberately. The same-time Torx and NumPy comparison puts both panels on one shared absolute color scale, because a comparison is only fair when equal probabilities get equal colors. The time progression instead uses per-panel peak normalization, since the field flattens as it spreads and one shared scale would leave the late panels nearly blank. Per-panel normalization hides how much the absolute magnitude has shrunk, so we print each raw peak in its panel title."
+    "The two figures answer different questions and use different color conventions. The same-time comparison places the Torx and NumPy fields on a shared absolute scale, so the same color denotes the same probability in both panels. The time progression instead normalizes each panel by its own peak. This keeps the later, flatter fields visible, but it no longer encodes the decrease in absolute magnitude; each panel title therefore reports its unnormalized peak."
    ]
   },
   {
@@ -584,9 +582,9 @@
    "id": "8041e2fb",
    "metadata": {},
    "source": [
-    "The Torx multi-seed mean is our primary sampled result, and the panels above place it beside the NumPy exact field at the same $t=1.5$ on one shared color scale. Both keep the excitation concentrated near the source, with peaks of 0.040 and 0.037 and 9% of vertices above 15% of their own peak.\n",
+    "The first figure compares the Torx multi-seed mean with the NumPy exact field at the same $t=1.5$. Because the panels share an absolute color scale, equal colors represent equal probabilities. Both fields remain concentrated near the source: their peaks are 0.040 and 0.037, and 9% of vertices lie above 15% of each field's own peak.\n",
     "\n",
-    "The three distances printed above say how close that agreement is and where the remaining difference comes from. The sampling L2 of 0.0051 compares the Torx mean with the NumPy mean of the same ordered sweep, which uses the identical edge order, repetition count, and swap probability but never samples, so that number is sampling error on its own. The splitting bias L2 of 0.0159 compares that deterministic mean with the exact NumPy graph diffusion, and it's the price of running the per-edge factors in sequence at finite $N$ rather than simultaneously. The total L2 of 0.0154 compares the Torx mean directly with the exact field, so it carries both effects at once, and because the two can partly cancel the three numbers need not add up."
+    "The three distances separate the sources of the remaining difference. The sampling L2 of 0.0051 compares the Torx mean with the deterministic NumPy mean of the identical ordered sweep—same edge order, repetition count, and swap probability—so it measures sampling error alone. The splitting bias L2 of 0.0159 compares that ordered-sweep mean with exact graph diffusion, isolating the finite-$N$ approximation. Finally, the total L2 of 0.0154 compares Torx directly with the exact field and therefore includes both effects. These errors are vector differences rather than independent scalar contributions, so partial cancellation is possible and the three values need not add."
    ]
   },
   {
@@ -594,7 +592,7 @@
    "id": "c2868609",
    "metadata": {},
    "source": [
-    "Diffusion on a connected graph has to end somewhere, so next we look at where it's heading, laying the three NumPy exact times out as a left-to-right row that is easier to read than a stack."
+    "The same-time comparison establishes agreement near the source. To see where exact diffusion is heading on this connected graph, we next place the three NumPy reference times in a left-to-right sequence."
    ]
   },
   {
@@ -653,7 +651,7 @@
    "id": "5c326c67",
    "metadata": {},
    "source": [
-    "The peaks printed in the titles fall from 0.037 at $t=1.5$ to 0.004 at $t=40$, and by $t=40$ every vertex sits above 15% of that peak while the field is only 0.0172 away in L2 from the uniform distribution. What the last panel shows is therefore near-uniform occupancy across the connected graph rather than a localized front."
+    "In the time sequence, the peaks reported in the titles fall from 0.037 at $t=1.5$ to 0.004 at $t=40$. By $t=40$, every vertex exceeds 15% of that panel's peak, and the field is only 0.0172 away in L2 from the uniform distribution. The final panel therefore represents near-uniform occupancy across the connected graph, not a localized front. Because each panel has its own normalization, the titles—not the colors across panels—show the decrease in absolute peak probability."
    ]
   },
   {
@@ -690,7 +688,7 @@
    "id": "d8b1fdfc",
    "metadata": {},
    "source": [
-    "The schematic below draws that single gate, with the two sites it connects and the parameter that sets the swap probability."
+    "The schematic below encodes the two sites joined by a single gate and the parameter that sets their swap probability. It describes the local operation, but not the behavior of the repeated full-graph circuit."
    ]
   },
   {
@@ -737,13 +735,13 @@
    "id": "2fdf5984",
    "metadata": {},
    "source": [
-    "That one gate is what Torx repeats once per graph edge in each ordered layer, and the full construction and repetition count remain visible above.\n",
+    "The full construction repeats this gate once per graph edge in each ordered layer, with the layer and repetition count shown above.\n",
     "\n",
-    "A drawing shows the rule but not whether the repeated circuit implements it correctly, so we now compare Torx with the NumPy deterministic mean of the same ordered sweep on a 32-vertex patch grown outward from the source by breadth-first search (BFS).\n",
+    "To check the repeated update directly, we compare Torx with the deterministic NumPy mean of the same ordered sweep on a 32-vertex patch grown outward from the source by breadth-first search (BFS).\n",
     "\n",
-    "We close the patch first, which means we remove every edge running from those 32 vertices to the rest of the bunny and keep only the edges among the 32 themselves. Graph theory calls the result an induced subgraph, and closing it earns its keep twice: no probability leaks out through a cut edge, and Torx and NumPy are guaranteed to run on exactly the same finite graph. That guarantee is what makes this an implementation-parity check, a test of whether the sampled circuit reproduces the deterministic mean of an identical update rule, rather than an attempt to approximate the full-graph field on a smaller canvas, since removing the boundary edges changes the diffusion inside the patch.\n",
+    "We first close the patch by removing every edge from those 32 vertices to the rest of the bunny and retaining all edges among the 32 vertices. The resulting graph is the induced subgraph on the selected vertices. Closing it serves two purposes: probability cannot leave through a cut edge, and Torx and NumPy operate on exactly the same finite graph. This makes the comparison an implementation-parity check rather than an approximation of the full-graph field on a smaller domain. Removing the boundary edges changes the diffusion within the patch, so the patch result should not be interpreted as a cropped version of the full-graph result.\n",
     "\n",
-    "We use swap probability `0.12` for three repetitions. The code below converts it back to the equivalent unit-rate slice time and prints the patch's effective total time, which is a number of its own and distinct from the full-graph $t=1.5$ result."
+    "For this check, we use swap probability `0.12` for three repetitions. The code converts this probability to the equivalent unit-rate slice time and reports the patch's effective total time, which is distinct from the full-graph $t=1.5$ result."
    ]
   },
   {
@@ -1038,13 +1036,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We applied Torx graph diffusion to the Stanford bunny's unweighted mesh connectivity and measured how far the sampled field sits from the exact answer.\n",
+    "We began with the bunny mesh, retained only its connectivity, and used one edge-local `PSWAP` factor for each term in the graph Laplacian. This construction produced three related fields whose comparisons distinguish sampled execution from the finite ordered approximation.\n",
     "\n",
-    "- The decimated mesh defines a 450-vertex, 1,352-edge graph built from adjacency alone, so it carries connectivity rather than mesh geometry and isn't a geometry-aware physical heat model.\n",
-    "- Torx executes one `PSWAP` per edge for 11 repetitions and supplies the primary multi-seed sampled result at $t=1.5$.\n",
-    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references, which Torx doesn't sample because doing so would cost many more repetitions of every gate.\n",
-    "- The full-graph error report separates sampling error from splitting bias, and it can do so only because we compute the ordered-sweep mean, the one reference that shares Torx's update rule exactly. The total error follows from comparing Torx with the exact field.\n",
-    "- The closed 32-vertex patch then checks one seeded Torx run against the matching NumPy ordered mean at its own effective time, which is where implementation parity is easiest to read directly.\n",
+    "- The decimated mesh defines a 450-vertex, 1,352-edge graph from adjacency alone. It represents connectivity rather than mesh geometry and is not a geometry-aware model of physical heat.\n",
+    "- Torx applies one `PSWAP` per edge for 11 repetitions and supplies the primary multi-seed sampled result at $t=1.5$.\n",
+    "- NumPy supplies the deterministic ordered-sweep mean, the exact eigensolution, all error metrics, and the $t=10$ and $t=40$ references. Torx does not sample the later times because doing so would require many more repetitions of every gate.\n",
+    "- Comparing Torx with the ordered-sweep mean isolates sampling error; comparing that mean with the exact field isolates splitting bias; and comparing Torx directly with the exact field gives the total error.\n",
+    "- On the closed 32-vertex patch, a seeded Torx run and the matching NumPy ordered mean use the same finite graph and effective time, allowing their occupancies to be compared vertex by vertex.\n",
     "\n",
     "See also:\n",
     "\n",

--- a/examples/04_execution_interface_readouts.ipynb
+++ b/examples/04_execution_interface_readouts.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We build a Torx circuit with two <a href=\"https://doi.org/10.1063/1.5055860\">probabilistic bits (pbits)</a> and turn its raw samples into histograms, expectations, and Monte Carlo error bars, all with ordinary array reductions. Both readouts converge at the expected $1/\\sqrt{N}$ rate.</p>\n",
+    "<p>We build a Torx circuit with two <a href=\"https://doi.org/10.1063/1.5055860\">probabilistic bits (pbits)</a>, compute its exact readouts, and estimate the same quantities from raw samples. Ordinary array reductions produce histograms and expectations, while block estimates show both sampled readouts concentrating at the expected $1/\\sqrt{N}$ rate.</p>\n",
     "</div>"
    ]
   },
@@ -23,9 +23,9 @@
    "id": "0048c297",
    "metadata": {},
    "source": [
-    "In this tutorial, we sample a small Torx circuit and turn its terminal bitstrings into readouts.\n",
+    "Executing a stochastic circuit returns bitstrings rather than a preselected statistic. How do we turn those bitstrings into a density or an expectation, and how can we tell whether the result is close to the quantity we intended to measure?\n",
     "\n",
-    "A readout is a function $f$ averaged against the circuit's output distribution, and sampling estimates that average. Here the readouts reduce the terminal bitstrings to a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function), the probability assigned to each finite basis state, or to a mean. The Monte Carlo error bars shown later are diagnostics that quantify the uncertainty of those estimators.\n",
+    "A readout is a function $f$ averaged against the circuit's output distribution. In this tutorial, the readouts reduce terminal bitstrings either to a [probability mass function](https://en.wikipedia.org/wiki/Probability_mass_function), which assigns a probability to each finite basis state, or to a mean. We then use Monte Carlo error bars to quantify the uncertainty of these sampled estimates.\n",
     "\n",
     "The code uses Torx, JAX, NumPy, and Matplotlib. It assumes basic familiarity with probability distributions and expectations.\n",
     "\n",
@@ -36,9 +36,9 @@
     "- plot histogram concentration toward the exact density, and\n",
     "- estimate the Monte Carlo rate $1/\\sqrt{N}$ from a block analysis.\n",
     "\n",
-    "Every one of those readouts comes out of a single object, because `BranchingSimulator.sample` hands back the full stochastic output as a `(num_samples, num_pbits)` integer array. Histograms, sample means, and confidence summaries are then standard NumPy reductions over the rows of `samples`.\n",
+    "All of these sampled readouts begin with the same object: `BranchingSimulator.sample` returns the stochastic output as a `(num_samples, num_pbits)` integer array. Histograms, sample means, and confidence summaries are standard NumPy reductions over its rows.\n",
     "\n",
-    "We first build the circuit and compute the exact reference. Then we sample the circuit, compare two readout paths, and measure how the sampling error shrinks with $N$.\n",
+    "We begin by building the circuit and computing an exact reference. We then sample the circuit, compare two ways to obtain an expectation, and measure how the sampling error changes with $N$.\n",
     "\n"
    ]
   },
@@ -193,27 +193,23 @@
    "source": [
     "## The readout as an expectation\n",
     "\n",
-    "A Torx circuit is a **stochastic kernel** $K$ (a map that turns one probability distribution into another) acting on the input distribution.\n",
+    "A Torx circuit defines a **stochastic kernel** $K$, a map from one probability distribution to another. Applied to an input distribution, it produces\n",
     "\n",
-    "The output distribution is\n",
+    "$$\\rho_{\\text{out}} = K\\,\\rho_{\\text{in}}.$$\n",
     "\n",
-    "$$\\rho_{\\text{out}} = K\\,\\rho_{\\text{in}},$$\n",
-    "\n",
-    "and any readout is an expectation against $\\rho_{\\text{out}}$:\n",
+    "We define a readout by choosing a function $f$ on the output configurations and averaging it against $\\rho_{\\text{out}}$:\n",
     "\n",
     "$$\\langle f, \\rho \\rangle = \\sum_{a} f(a)\\,\\rho_a.$$\n",
     "\n",
-    "A ket like $|a)$ (or $|00)$ below) labels one basis configuration of the sites, and $\\rho_a$ is its probability. The bracket $\\langle f, \\rho \\rangle$ reads off the expectation of the readout $f$ against the distribution $\\rho$.\n",
+    "Here a ket such as $|a)$, or $|00)$ below, labels one basis configuration of the sites, and $\\rho_a$ is its probability. Thus $\\langle f, \\rho \\rangle$ is the expectation of $f$ under the distribution $\\rho$.\n",
     "\n",
-    "The `StateVectorSimulator` returns the exact $\\rho_{\\text{out}}$. The `BranchingSimulator.sample` method draws $N$ bitstrings $s_n \\sim \\rho_{\\text{out}}$, and the corresponding estimator averages $f$ over them:\n",
+    "There are two ways to obtain this expectation in the notebook. The `StateVectorSimulator` enumerates the output distribution and returns the exact $\\rho_{\\text{out}}$. In contrast, `BranchingSimulator.sample` draws $N$ bitstrings $s_n \\sim \\rho_{\\text{out}}$, from which we estimate the expectation by\n",
     "\n",
     "$$\\widehat{\\langle f \\rangle}_N = \\underbrace{\\frac{1}{N} \\sum_{n=1}^{N}}_{\\vphantom{\\big|}\\text{sample average}} f(s_n).$$\n",
     "\n",
-    "The sum runs over the $N$ drawn bitstrings, and $f(s_n)$ is the readout evaluated on each one. If $f$ is the indicator of a basis state, the estimator gives the empirical density $\\hat\\rho_N$.\n",
+    "The sum runs over the $N$ drawn bitstrings, with $f(s_n)$ evaluated on each one. If $f$ is the indicator of a basis state, the estimator gives the empirical density $\\hat\\rho_N$. If $f(s) = s_i$, it gives the per-pbit expectation returned by `expval_all`, which we introduce below.\n",
     "\n",
-    "If $f(s) = s_i$, the estimator gives the per-pbit expectation returned by `expval_all` (introduced below).\n",
-    "\n",
-    "Both estimators concentrate at the Monte Carlo rate. Saying so needs a single number for how far a sampled density sits from the exact one, and the [**total-variation distance**](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures) supplies it: half the absolute gap in probability, summed over the basis states. Between the empirical and exact densities it scales as $\\mathrm{TV}(\\hat\\rho_N, \\rho) = O(N^{-1/2})$. A two-pbit circuit keeps the exact $\\rho$ cheap to enumerate, so we can compare every estimate with a ground-truth reference."
+    "Both estimators fluctuate because they use a finite sample. To compare an empirical density with the exact density using one number, we use the [**total-variation distance**](https://en.wikipedia.org/wiki/Total_variation_distance_of_probability_measures): half the absolute probability gap, summed over the basis states. For the empirical and exact densities, this distance scales as $\\mathrm{TV}(\\hat\\rho_N, \\rho) = O(N^{-1/2})$. With two pbits, enumerating the exact $\\rho$ is inexpensive, so every sampled estimate can be compared with this reference."
    ]
   },
   {
@@ -309,7 +305,7 @@
    "id": "e146f02e",
    "metadata": {},
    "source": [
-    "The circuit diagram shows the three gates applied to the two pbits in execution order. The single-pbit `PNOT` gates are drawn in slate, and the two-pbit `PCNOT` coupling gate is drawn in orange."
+    "The diagram encodes the execution order of the three gates along the two pbit wires. Slate marks the single-pbit `PNOT` gates, while orange marks the two-pbit `PCNOT` coupling gate. It shows the circuit structure, but not the probability assigned to each output state; we compute that distribution next."
    ]
   },
   {
@@ -372,7 +368,7 @@
    "id": "b6cee0f6",
    "metadata": {},
    "source": [
-    "Sampling hands back raw material rather than finished statistics, which is what keeps every readout in this notebook explicit. One call to `BranchingSimulator.sample` draws 5,000 terminal bitstrings and returns them as a `(num_samples, num_pbits)` integer array."
+    "The sampling interface returns the underlying observations rather than a finished statistic. One call to `BranchingSimulator.sample` draws 5,000 terminal bitstrings and stores them in a `(num_samples, num_pbits)` integer array, leaving the choice of readout to the subsequent reduction."
    ]
   },
   {
@@ -426,11 +422,11 @@
    "source": [
     "## Histogram and expectation\n",
     "\n",
-    "Both readouts come out of the same array, because each one is an ordinary NumPy reduction of `samples`.\n",
+    "We now compute two readouts from the same sample array.\n",
     "\n",
-    "For the density we encode each row as a basis-state index, count the indices with `np.bincount`, and divide by $N$. The per-pbit expectation is simpler still, since averaging the columns with `samples.mean(axis=0)` already gives $\\langle s_i \\rangle$.\n",
+    "For the density, we encode each row as a basis-state index, count the indices with `np.bincount`, and divide by $N$. For the per-pbit expectation, averaging each column with `samples.mean(axis=0)` directly estimates $\\langle s_i \\rangle$.\n",
     "\n",
-    "Torx also exposes that second statistic directly as `BranchingSimulator.expval_all`, which draws a fresh sample internally and returns the mean. At $N = 5{,}000$ both estimators agree with the `StateVectorSimulator` reference to within `atol = 0.04`, the tolerance the next cell asserts."
+    "Torx also provides the latter readout through `BranchingSimulator.expval_all`. This method draws a fresh sample internally and returns its mean, so its result need not match `samples.mean(axis=0)` exactly. At $N = 5{,}000$, both sampled estimators agree with the `StateVectorSimulator` reference within the `atol = 0.04` tolerance asserted in the next cell."
    ]
   },
   {
@@ -526,7 +522,7 @@
    "id": "f248d585",
    "metadata": {},
    "source": [
-    "The empirical-density bars track `exact_density`, and the `expval_all` cross sits against both the sample-mean and exact-expectation bars even though it comes from a separate `SEED + 1` draw. That's the observation that matters: the `sample_mean` reduction and `expval_all` are two routes to the same expectation, and here they agree within Monte Carlo error.\n"
+    "The empirical-density bars can be compared state by state with `exact_density`. In the expectation panel, the `expval_all` cross lies near both the sample-mean and exact-expectation bars, although it comes from the separate `SEED + 1` draw. Thus `sample_mean` and `expval_all` provide two sampled estimates of the same expectation in this run. The figure shows their agreement at $N = 5{,}000$; by itself, it does not show how either error changes with sample size.\n"
    ]
   },
   {
@@ -536,13 +532,13 @@
    "source": [
     "## Histogram concentration\n",
     "\n",
-    "Concentration is easier to see than to assert, so we redraw the histogram at $N \\in \\{100, 500, 2000, 5000\\}$ and let the panels show how the estimate sharpens.\n",
+    "To examine the dependence on sample size, we redraw the empirical histogram for $N \\in \\{100, 500, 2000, 5000\\}$. Across the panels, the exact density remains fixed while the sampled bars change with $N$.\n",
     "\n",
     "Each panel also reports the total-variation distance to `exact_density`, averaged over 16 non-overlapping blocks:\n",
     "\n",
     "$$\\overline{\\mathrm{TV}}(\\hat\\rho, \\rho) = \\underbrace{\\frac{1}{16} \\sum_{k=1}^{16}}_{\\vphantom{\\big|}\\text{block average}} \\underbrace{\\tfrac{1}{2} \\sum_{s} |\\hat\\rho_k(s) - \\rho(s)|}_{\\vphantom{\\big|}\\text{TV per block}}.$$\n",
     "\n",
-    "The inner sum is the total-variation distance of one block $\\hat\\rho_k$ to the exact density $\\rho$, and the outer factor averages it over the 16 blocks, because a single block is itself noisy at small $N$. That averaged distance falls like $1/\\sqrt{N}$, the convergence measured in the next figure."
+    "The inner sum compares the empirical density $\\hat\\rho_k$ from one block with the exact density $\\rho$. The outer average combines the 16 block distances, reducing the influence of any one noisy block at small $N$. We use the resulting values to examine the expected $1/\\sqrt{N}$ decrease."
    ]
   },
   {
@@ -591,7 +587,7 @@
    "id": "b167978b",
    "metadata": {},
    "source": [
-    "For each $N$ we form the empirical density and the block-averaged total-variation distance from this one run, which means the estimates at different $N$ share samples. The block analysis below spells out that correlation and what it does and doesn't license."
+    "For each $N$, we use a prefix of the run for the displayed empirical density and 16 equal-size blocks for the mean total-variation distance. Because every sample size is derived from the same run, estimates at different $N$ share observations and are correlated. The block analysis therefore describes concentration in this run; it does not provide independent experiments at each sample size."
    ]
   },
   {
@@ -682,7 +678,7 @@
    "id": "1dc937dd",
    "metadata": {},
    "source": [
-    "The histogram bars tighten onto `exact_density` from left to right. Each annotation is the mean total-variation distance from 16 separate blocks, not the distance of the histogram shown in that panel. The annotated means decrease with $N$, and their log-log least-squares slope is near $-1/2$ (printed above), consistent with the $1/\\sqrt{N}$ Monte Carlo rate.\n"
+    "From left to right, the empirical bars approach `exact_density`. The annotation in each panel is the mean total-variation distance from 16 blocks, not the distance between the particular bars shown in that panel and the exact density. These block means decrease with $N$, and their printed log-log least-squares slope is near $-1/2$, consistent with the $1/\\sqrt{N}$ Monte Carlo rate. Since the four sample sizes share one finite run, the figure illustrates this scaling rather than establishing it from independent datasets.\n"
    ]
   },
   {
@@ -692,17 +688,15 @@
    "source": [
     "## Sample-mean concentration\n",
     "\n",
-    "We now measure how the `sample_mean` error shrinks as the sample size grows, using a block analysis.\n",
-    "\n",
-    "A single estimate can't reveal a scaling law, because one number has no spread to read. So we cut one long run into blocks and treat each block as its own estimate of the same quantity, which turns the spread across blocks into a measurement of the error at that block size. We apply the block analysis to pbit 1:\n",
+    "We next ask whether the expectation readout exhibits the same dependence on sample size. A single sample mean provides one error value, but not the distribution of that error. We therefore divide one long run into blocks and compute the pbit-1 mean separately in each block:\n",
     "\n",
     "1. draw one long $32{,}000$-sample run,\n",
     "2. split it into non-overlapping blocks of size $N \\in \\{25, 50, 100, 200, 500, 1000\\}$,\n",
     "3. average pbit 1 within each block to form one estimator of $\\langle s_1 \\rangle$.\n",
     "\n",
-    "The blocks for a single $N$ are disjoint, but every per-$N$ estimator reuses a prefix of the same long run, so estimators across $N$ share samples and are correlated, which is acceptable here because we're reading the slope of the curve rather than testing any single point against a tolerance.\n",
+    "For any fixed $N$, the blocks are disjoint. Across different values of $N$, however, the construction reuses prefixes of the same long run, so those collections of estimators are correlated. This is sufficient for describing the slope of the curve, but it does not make the points independent tests of the rate.\n",
     "\n",
-    "With 32 blocks per $N$ we report the mean absolute error against the exact pbit-1 expectation. The shaded band is the **Monte Carlo standard error** of that mean across the 32 blocks, meaning how far the 32-block average would typically move if we redrew the run. The $N^{-1/2}$ reference is the [central limit theorem (CLT)](https://www.itl.nist.gov/div898/handbook/eda/section3/eda3661.htm) slope on a log-log plot."
+    "Using 32 blocks at each $N$, we report the mean absolute error relative to the exact pbit-1 expectation. The shaded band is the **Monte Carlo standard error** of that mean across the 32 blocks: the typical variation of the 32-block average under a new run. On the log-log plot, the [central limit theorem (CLT)](https://www.itl.nist.gov/div898/handbook/eda/section3/eda3661.htm) supplies the $N^{-1/2}$ reference slope."
    ]
   },
   {
@@ -835,7 +829,7 @@
    "id": "6e0682ab",
    "metadata": {},
    "source": [
-    "The log-log curve follows the $N^{-1/2}$ reference for the pbit-1 readout error, and the least-squares slope above is close to $-1/2$, consistent with the Monte Carlo rate. The reference line is pinned at the smallest-$N$ point, so the first point agrees by construction and the demonstration is that the remaining points fall along it."
+    "The pbit-1 error curve lies close to the $N^{-1/2}$ reference, and the printed least-squares slope is near $-1/2$, consistent with the Monte Carlo rate. The reference line is anchored at the smallest-$N$ point, so agreement there holds by construction; the remaining points provide the visual comparison. Because they reuse prefixes from one finite run, the curve and fitted slope are descriptive diagnostics rather than independent estimates at each $N$."
    ]
   },
   {
@@ -845,12 +839,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "This tutorial turned a Torx circuit's `samples` into densities, expectations, and a measured convergence rate.\n",
+    "The exact calculation and the sampled calculation answer different questions. `StateVectorSimulator` enumerates the output distribution, while `BranchingSimulator.sample` provides finite observations from which we estimate readouts. For the two-pbit circuit, their comparison gives the following results:\n",
     "\n",
-    "- `BranchingSimulator.sample` returns a `(num_samples, num_pbits)` integer array, and that array is the full stochastic output.\n",
-    "- `np.bincount` over the bitstrings approximates the exact `StateVectorSimulator` density to within sampling error (`atol = 0.04` at $N = 5000$). Separately, `samples.mean(axis=0)` and the independent `expval_all` draw are two estimators of the same expectation, and both agree with the exact value to within that same tolerance.\n",
-    "- The sampling error shrinks as $1/\\sqrt{N}$: a log-log fit of the block analysis on pbit 1 gives a slope near the $N^{-1/2}$ reference, consistent with the Monte Carlo rate.\n",
-    "- The terminal bitstring readouts shown here are ordinary NumPy reductions on the returned `samples` array. Differentiable or `jit`-transformable readouts use `jnp` or the Torx expectation APIs instead.\n",
+    "- `BranchingSimulator.sample` returns a `(num_samples, num_pbits)` integer array containing the full stochastic output.\n",
+    "- Applying `np.bincount` to the sampled bitstrings approximates the exact `StateVectorSimulator` density within sampling error (`atol = 0.04` at $N = 5000$).\n",
+    "- `samples.mean(axis=0)` and the independent `expval_all` draw estimate the same expectation, and both agree with the exact value within the same tolerance.\n",
+    "- In the block analyses, the histogram and pbit-1 expectation errors decrease consistently with $1/\\sqrt{N}$, with log-log slopes near the $N^{-1/2}$ reference. The shared finite runs make these figures diagnostics of concentration rather than independent measurements at each $N$.\n",
+    "- These terminal-bitstring readouts are ordinary NumPy reductions on `samples`. Differentiable or `jit`-transformable readouts instead use `jnp` or the Torx expectation APIs.\n",
     "\n",
     "See also:\n",
     "\n",

--- a/examples/05_chemical_reaction_networks.ipynb
+++ b/examples/05_chemical_reaction_networks.ipynb
@@ -23,17 +23,15 @@
    "id": "06a4e27d",
    "metadata": {},
    "source": [
-    "In this tutorial we run two mass-action reaction networks in Torx and check the result against two independent references.\n",
+    "A chemical reaction network is a continuous-time Markov chain on molecule counts. Its state records how many molecules of each species are present, and a reaction event changes those counts by a fixed amount. The rate attached to a reaction is its **propensity**, the probability per unit time that this reaction is the next one to fire. Under mass action, this propensity counts the distinct groups of reactant molecules currently available to react.\n",
     "\n",
-    "A chemical reaction network is a continuous-time Markov chain on molecule counts. The state records how many molecules of each species are present, and each reaction event moves that state by a fixed amount. The rate attached to a reaction is its **propensity**, the probability per unit time that this reaction is the next one to fire, and under mass action the propensity counts how many distinct groups of reactant molecules are currently available to react.\n",
+    "We will study two networks with different long-run behavior. The irreversible water reaction $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ fires in one direction until a reactant is exhausted, so its counts run toward completion. Reversible binding, $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$, continues in both directions and instead settles into a mass-action equilibrium.\n",
     "\n",
-    "We run two networks with deliberately different long-run behaviour. The irreversible water reaction $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ fires in a single direction until a reactant is exhausted, so its counts run toward completion. The reversible binding $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ runs forward and backward at once, so its counts settle into a mass-action equilibrium instead.\n",
+    "How can a circuit built from single hopping excitations represent either network? A reaction such as $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ consumes and produces several molecules at once (stoichiometry), while its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$). A single excitation cannot express either feature directly.\n",
     "\n",
-    "Neither network fits a single hopping excitation directly, because a reaction like $2\\,\\mathrm{H_2} + \\mathrm{O_2} \\to 2\\,\\mathrm{H_2O}$ has two features such an excitation can't express. It consumes and produces several molecules at once (stoichiometry), and its rate is nonlinear in the counts (mass action, $a = c\\,\\binom{n_{\\mathrm{H_2}}}{2}\\,n_{\\mathrm{O_2}}$).\n",
+    "We therefore enumerate the reachable **count configurations** and treat each configuration as one state. A reaction event becomes a directed edge between two such states, with the nonlinear propensity assigned as the edge rate. The resulting system has a single token—one occupied bit—moving between one-hot configurations, so we can assign one `PJUMP` to each edge, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Applying those edge kernels sequentially approximates the global CTMC evolution.\n",
     "\n",
-    "The key step is therefore to enumerate the reachable **count configurations** and treat each one as a state in its own right. Each reaction event then moves the whole system from one configuration to another, and the nonlinear propensity becomes that edge's rate. What's left is a single token, one occupied bit hopping between one-hot configurations, walking on a directed configuration graph, so one `PJUMP` per edge applies, as in a [graph random walk](02_random_walks_on_graphs.ipynb). Sequentially applying those edge kernels approximates the global CTMC evolution.\n",
-    "\n",
-    "Two references keep that approximation honest. The matrix exponential $e^{Q t}$ solves the configuration chain exactly, and a Gillespie simulation, an exact event-driven simulation that samples which reaction fires next and when, samples the raw molecule counts without ever seeing the configuration graph.\n",
+    "We compare this approximation with two references. The matrix exponential $e^{Q t}$ solves the configuration chain exactly. A Gillespie simulation is also exact and event driven, but it samples which reaction fires next and when directly from the molecule counts, without using the configuration graph.\n",
     "\n",
     "We assume basic familiarity with continuous-time Markov chains and JAX. The code uses Torx, JAX, NumPy, and SciPy. By the end, you'll be able to:\n",
     "\n",
@@ -51,7 +49,7 @@
     "\n",
     "We configure the helper path, the shared plotting style, and the `savefig` utility here so that the later cells can stay focused on the reaction networks themselves.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx builds and samples the sequential `PJUMP` circuits.</li><li>Notebook code builds configuration graphs, references, and checks.</li><li>Reaction plots live in <code>examples/helpers/_nb05_crn.py</code>.</li></ul></details>\n"
+    "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx builds and samples the sequential <code>PJUMP</code> circuits.</li><li>Notebook code builds configuration graphs, references, and checks.</li><li>Reaction plots live in <code>examples/helpers/_nb05_crn.py</code>.</li></ul></details>\n"
    ]
   },
   {
@@ -187,9 +185,9 @@
    "id": "f6c3c190",
    "metadata": {},
    "source": [
-    "Before any chemistry appears, we need the one number that turns a reaction rate into a Torx gate parameter. For one isolated CTMC edge with rate $r$, the transition probability over a slice of length `dt` is exactly $1 - e^{-r\\,dt}$, so the `pjump_prob` function below computes that probability and `PJUMP` reads it through a logit.\n",
+    "We begin by converting a reaction rate into a Torx gate parameter. For an isolated CTMC edge with rate $r$, the transition probability over a slice of length `dt` is exactly $1 - e^{-r\\,dt}$. The `pjump_prob` function computes this probability, which `PJUMP` receives through a logit.\n",
     "\n",
-    "Each edge kernel is exact on its own, but neighbouring edges share configurations, which means applying them one after another is a [Lie-Trotter operator splitting](https://doi.org/10.1090/S0002-9939-1959-0108732-6) of the global generator: we replace one joint update with an ordered product of single-edge updates. The product therefore approximates $e^{Q\\,dt}$ rather than reproducing it, and the approximation improves as `dt` decreases.\n"
+    "This local result is exact, but the global update is not. Neighboring edges share configurations, so applying their kernels one after another gives a [Lie-Trotter operator splitting](https://doi.org/10.1090/S0002-9939-1959-0108732-6) of the global generator: an ordered product of single-edge updates replaces one joint update. The product approximates $e^{Q\\,dt}$, and the approximation improves as `dt` decreases.\n"
    ]
   },
   {
@@ -218,7 +216,7 @@
    "source": [
     "## The reaction and its configuration space\n",
     "\n",
-    "We start with the irreversible water reaction, because its configuration space is small enough to print in full and read. Starting from four $\\mathrm{H_2}$ and two $\\mathrm{O_2}$, the single reaction can fire until either reactant runs out, so the reachable configurations form a short chain rather than a branching graph. Along that chain the mass-action propensity drops sharply as $\\mathrm{H_2}$ is consumed, and carrying that drop faithfully is the whole point of the encoding.\n"
+    "We begin with the irreversible water reaction because its complete configuration space is small enough to inspect. Starting from four $\\mathrm{H_2}$ and two $\\mathrm{O_2}$, the reaction can fire only until one reactant is exhausted. The reachable configurations therefore form a short chain rather than a branching graph. As $\\mathrm{H_2}$ is consumed along this chain, the mass-action propensity falls sharply; the encoding must preserve that changing rate.\n"
    ]
   },
   {
@@ -383,9 +381,9 @@
    "source": [
     "## Dynamics: Torx against two references\n",
     "\n",
-    "With the configuration graph in hand, we can ask whether the encoding reproduces the reaction's dynamics. To answer that we compute three trajectories of the expected molecule counts, each a different way. The exact $e^{Qt}p_0$ on the configuration generator is what the encoding has to match, since it solves the same chain with no splitting and no sampling. A [Gillespie (1977)](https://doi.org/10.1021/j100540a008) simulation, an exact event-driven simulation that samples which reaction fires next and when, runs on the raw counts and never touches the configuration graph, so it serves as an independent reference sampler that would expose a mistake in the enumeration itself. The Torx split-step sample mean from snapshot circuits is the quantity under test, and it carries both split-step error and sampling error.\n",
+    "We now compute the expected molecule counts in three ways. The exact solution $e^{Qt}p_0$ uses the configuration generator directly, with neither operator splitting nor sampling, so it is the reference that the encoding must match. A [Gillespie (1977)](https://doi.org/10.1021/j100540a008) simulation instead samples the raw molecule counts without using the configuration graph. Because it independently samples which reaction fires next and when, it can reveal an error in the configuration enumeration. Finally, the Torx snapshot circuits produce the split-step sample mean under test, which contains both split-step error and sampling error.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: Gillespie stochastic simulation algorithm (SSA)</summary><p>The <a href=\"https://doi.org/10.1021/j100540a008\">Gillespie SSA</a> represents reactions as competing stochastic clocks. At each step, draw an exponential waiting time using the total propensity, choose a reaction in proportion to its propensity, update the counts, and repeat.</p></details>\n"
+    "<details class=\"tx-disclosure\"><summary>Term: Gillespie stochastic simulation algorithm (SSA)</summary><p>The <a href=\"https://doi.org/10.1021/j100540a008\">Gillespie SSA</a> represents reactions as competing stochastic clocks. At each step, it draws an exponential waiting time from the total propensity, chooses a reaction in proportion to its propensity, updates the counts, and repeats.</p></details>\n"
    ]
   },
   {
@@ -531,7 +529,9 @@
    "id": "457b12cb",
    "metadata": {},
    "source": [
-    "Now we build the Torx circuit itself. Each slice applies one `PJUMP` per configuration edge, with parameter $\\mathrm{logit}(1 - e^{-r\\,dt})$ for rate $r$, and because those kernels are applied in sequence rather than jointly, their ordered product is the split-step approximation and not the exact global CTMC kernel. The refinement check just printed is what tells us the resulting gap is a timestep artifact rather than an error in the encoding: halving `dt` from $0.05$ to $0.025$ cut the deterministic residual at $T = 12$ from $0.000830$ to $0.000413$. Sampling these circuits at selected repetition counts gives the Torx count estimates below.\n"
+    "Now we build the Torx circuit. Each slice applies one `PJUMP` per configuration edge, using the parameter $\\mathrm{logit}(1 - e^{-r\\,dt})$ for rate $r$. Since the kernels act sequentially rather than jointly, their ordered product is the split-step approximation, not the exact global CTMC kernel.\n",
+    "\n",
+    "The refinement result distinguishes this approximation error from an encoding error. Halving `dt` from $0.05$ to $0.025$ reduces the deterministic residual at $T = 12$ from $0.000830$ to $0.000413$. We then sample circuits at selected repetition counts to obtain the Torx count estimates below.\n"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "id": "39155d5e",
    "metadata": {},
    "source": [
-    "We plot the expected counts from all three methods together, with a residual panel underneath, because the disagreements are far too small to see in the trajectories alone.\n"
+    "The upper panel compares the expected counts from all three methods. Since their trajectories nearly coincide, the lower panel plots each sampled estimate minus the exact result, making the remaining disagreements visible.\n"
    ]
   },
   {
@@ -645,13 +645,11 @@
    "source": [
     "## Verification\n",
     "\n",
-    "If the configuration-graph encoding is faithful, two things have to hold: every edge must respect the chemistry it stands for, and every method that solves the same chain must agree at the sampled times, and the next cell tests both claims in the three passes described below.\n",
+    "A faithful configuration-graph encoding must preserve the reaction's chemistry, and all three methods must describe the same chain. We check these requirements separately:\n",
     "\n",
-    "The first check tests the edges. We recompute the H and O atom totals at both endpoints of every reaction edge and require them to be equal, so a stoichiometry mistake in the enumeration fails the assertion outright instead of hiding as a small numerical drift.\n",
-    "\n",
-    "The second check tests Torx. We compare the Torx snapshot counts against the exact matrix exponential at the same times and require the largest absolute deviation to stay under $0.05$, which bounds the combined split-step and sampling error.\n",
-    "\n",
-    "The third check tests the reference sampler the same way. We compare the Gillespie means against the exact matrix exponential under the same $0.05$ bound, so agreement here confirms that the raw-count simulation and the configuration-graph solution are describing one reaction rather than two.\n"
+    "- **Stoichiometry.** We recompute the H and O atom totals at both endpoints of every reaction edge and require equality. This makes an enumeration error fail directly rather than appear as a small numerical drift.\n",
+    "- **Torx against exact.** At each snapshot time, we compare the Torx counts with the exact matrix exponential and require the largest absolute deviation to remain below $0.05$. This bound contains the combined split-step and sampling error.\n",
+    "- **Gillespie against exact.** We apply the same $0.05$ bound to the Gillespie means. Agreement confirms that the raw-count simulation and the configuration-graph solution represent the same reaction.\n"
    ]
   },
   {
@@ -700,7 +698,9 @@
    "source": [
     "## A reversible reaction: binding equilibrium\n",
     "\n",
-    "The second network puts the same encoding to work on dynamics that never stop. The water reaction above is irreversible, firing in one direction until a reactant runs out, so its molecule counts run to completion. Binding behaves differently, and the reaction $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$ shows why, because it has a forward step $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ with propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$ and a reverse step $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ with propensity $k_r\\,n_{\\mathrm{C}}$, and because both directions stay active the network never absorbs. It relaxes instead to a stochastic mass-action equilibrium, meaning a steady distribution in which the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except that the configuration graph now carries edges in both directions.\n"
+    "The water reaction fires in one direction until a reactant is exhausted, so its counts run to completion. We now apply the same encoding to reversible binding, $\\mathrm{A} + \\mathrm{B} \\rightleftharpoons \\mathrm{C}$, whose dynamics do not absorb.\n",
+    "\n",
+    "The forward reaction $\\mathrm{A} + \\mathrm{B} \\to \\mathrm{C}$ has propensity $k_f\\,n_{\\mathrm{A}}\\,n_{\\mathrm{B}}$, while the reverse reaction $\\mathrm{C} \\to \\mathrm{A} + \\mathrm{B}$ has propensity $k_r\\,n_{\\mathrm{C}}$. Because both directions remain active, the network relaxes to a stochastic mass-action equilibrium: a steady distribution in which the ensemble forward and reverse fluxes balance. The split-step construction is unchanged, except that the configuration graph now contains edges in both directions.\n"
    ]
   },
   {
@@ -997,7 +997,7 @@
    "id": "83b5138b",
    "metadata": {},
    "source": [
-    "We plot the binding trajectories from all three methods, and the thing to watch for is whether the counts level off rather than running to completion.\n"
+    "As before, the upper panel compares the three count trajectories and the lower panel shows their residuals from the exact solution. Here the long-run comparison is different: equilibrium appears as counts that level off rather than run to completion.\n"
    ]
   },
   {
@@ -1051,7 +1051,9 @@
    "id": "b610d9cd",
    "metadata": {},
    "source": [
-    "The counts do level off, well short of completion, which is the visible difference from the irreversible water reaction and the sign that this network reaches equilibrium instead of absorbing. $\\mathrm{A}$ and $\\mathrm{B}$ start equal and stay equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ along every reachable configuration, so they trace one curve. Their means settle near $2.19$ while the mean of $\\mathrm{C}$ settles near $1.81$. The residual panel again makes the small Torx and Gillespie deviations from the exact curves visible. One caution about reading those plateaus: the relation that actually holds at stochastic equilibrium is the ensemble identity $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$, which isn't the same as substituting the mean counts into the rate law.\n"
+    "The counts level off well before completion, distinguishing this equilibrium from the absorbing endpoint of the water reaction. $\\mathrm{A}$ and $\\mathrm{B}$ begin equal and remain equal because $n_{\\mathrm{A}} - n_{\\mathrm{B}} = 0$ in every reachable configuration, so they follow the same curve. Their means settle near $2.19$, while the mean of $\\mathrm{C}$ settles near $1.81$. The residual panel again reveals the small Torx and Gillespie deviations from the exact curves.\n",
+    "\n",
+    "The plateaus alone do not specify the equilibrium relation. At stochastic equilibrium, the ensemble fluxes satisfy $k_f\\,\\mathbb{E}[n_{\\mathrm{A}}n_{\\mathrm{B}}] = k_r\\,\\mathbb{E}[n_{\\mathrm{C}}]$. This is not equivalent to substituting the mean counts into the rate law.\n"
    ]
   },
   {
@@ -1059,8 +1061,8 @@
    "id": "975661b4",
    "metadata": {},
    "source": [
-    "The same faithfulness question applies to the binding network, with one addition, because a reversible network has something to conserve and something to balance.\n",
     "\n",
+    "The same faithfulness question applies to the binding network, with one addition, because a reversible network has something to conserve and something to balance.\n",
     "Binding leaves $n_{\\mathrm{A}} + n_{\\mathrm{C}}$ and $n_{\\mathrm{B}} + n_{\\mathrm{C}}$ unchanged, so we recompute both totals at the endpoints of every edge and require them to match, which is the analogue of the atom balance from the water network.\n",
     "\n",
     "We then repeat the two method comparisons, requiring the largest deviation of the Torx snapshot counts and of the Gillespie means from the exact matrix exponential to stay below $0.05$ at the sampled times.\n",
@@ -1122,7 +1124,9 @@
    "source": [
     "## The cost: configuration count\n",
     "\n",
-    "Both networks above were small. What decides whether this encoding scales is how fast the configuration count grows when they aren't, because Torx spends one pbit per reachable configuration and the circuit width follows that count rather than the number of species. For the one-way water family measured below there is a single reaction extent to vary, so the count grows linearly. For the particular water-plus-ammonia family there are two independently variable extents, so it grows quadratically. Other networks scale differently, since conservation laws and feasibility constraints decide how much of the count lattice is reachable at all.\n"
+    "The two examples above have small reachable sets, but the encoding width is determined by the number of configurations rather than the number of species. Torx uses one pbit for each reachable configuration, so growth in that count directly increases the circuit width.\n",
+    "\n",
+    "For the one-way water family below, only one reaction extent varies and the configuration count grows linearly. The particular water-plus-ammonia family has two independently variable extents, producing quadratic growth. This behavior is not universal: in other networks, conservation laws and feasibility constraints determine which part of the count lattice is reachable.\n"
    ]
   },
   {

--- a/examples/06_ising_sampling_contrastive_divergence.ipynb
+++ b/examples/06_ising_sampling_contrastive_divergence.ipynb
@@ -23,30 +23,30 @@
    "id": "ecebfbfe",
    "metadata": {},
    "source": [
-    "In this tutorial, we study Ising sampling with Torx's single-site and bond-local kernels.\n",
+    "An eight-site Ising ring is small enough to enumerate exactly, but it still contains the local interactions needed to compare Torx's single-site and bond-local kernels. We use that setting to ask how the boundary of a local update affects the distribution it samples.\n",
     "\n",
-    "An [**Ising model**](https://www.scholarpedia.org/article/Ising_model) is a graph with a coupling on every edge and a field at every site. It defines the Boltzmann distribution $\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})}$ over all $2^N$ spin configurations, and that distribution is the target every sampler in this notebook is trying to reproduce.\n",
+    "An [**Ising model**](https://www.scholarpedia.org/article/Ising_model) is a graph with a coupling on every edge and a field at every site. It defines the Boltzmann distribution $\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})}$ over all $2^N$ spin configurations. This is the target distribution for both samplers in the notebook.\n",
     "\n",
-    "This is also a Boltzmann machine ([Ackley et al. 1985](#ref-ackley)): a network whose joint distribution is set by pairwise couplings and per-site biases. So the same object serves twice here, first as something to sample from and later as something to learn.\n",
+    "The same model is also a Boltzmann machine ([Ackley et al. 1985](#ref-ackley)): a network whose joint distribution is determined by pairwise couplings and per-site biases. We therefore use it first as a distribution to sample and then as a model whose parameters can be learned.\n",
     "\n",
-    "Locality makes fast sampling possible. Each spin's conditional depends only on its graph neighbors, so a whole color class of conditionally independent sites can update at once. This parallel single-site sampler is **chromatic Gibbs sampling**.\n",
+    "Sampling can exploit the graph's locality. The conditional distribution of one spin depends only on its neighbors, so conditionally independent sites in the same color class can update in parallel. This gives **chromatic Gibbs sampling**.\n",
     "\n",
-    "Three experiments follow, and each answers a different question.\n",
+    "We examine the model in three experiments.\n",
     "\n",
-    "First, does one site behave like the ideal Gibbs conditional when we run it as a real circuit? We build a small probe from Torx's reset and conditional-flip operations, `PReset` and `PNOT`, run it on the `BranchingSimulator`, and check its sampled mean against a target probability. The reset strength is finite rather than infinite, so the probe tests a close approximation of the ideal update instead of the ideal update itself.\n",
+    "First, how closely does an executable one-site circuit reproduce the ideal Gibbs conditional? We build a probe from Torx's reset and conditional-flip operations, `PReset` and `PNOT`, run it on the `BranchingSimulator`, and compare its sampled mean with a target probability. Since the reset strength is finite rather than infinite, this experiment measures a close approximation to the ideal update.\n",
     "\n",
-    "Second, does a full ring sampler reproduce the Boltzmann law? We answer this twice over, with two samplers that are both local but local in different ways. One runs every single-site draw through Torx as a manual-zero `PNOT` update, which hands the gate an exact zero state instead of resetting it. The other stays bond-local: it asks Torx to generate one two-spin transition matrix per edge with `PISING`, then walks those matrices on the host. Because the 8-site ring is small enough to enumerate all $2^8 = 256$ states, we have an exact Boltzmann reference and the gap between the two samplers becomes a measurement rather than an argument.\n",
+    "Second, do full-ring samplers reproduce the Boltzmann law? We compare two forms of locality. The chromatic sampler runs every single-site draw through Torx as a manual-zero `PNOT` update, supplying the gate with an exact zero state instead of resetting it. The bond-local sampler asks Torx to generate one two-spin transition matrix per edge with `PISING`, then walks those matrices on the host. For this 8-site ring, exact enumeration of all $2^8 = 256$ states provides a reference against which both samplers can be measured.\n",
     "\n",
-    "That gap is where the interesting failure lives. A bond matrix carries its own bond energy and half of each endpoint's field, but it can't see the live energy each endpoint shares with its neighbor outside the pair, so the resulting pair update isn't conditioned on the rest of the ring. Composing eight such updates therefore need not obey [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution, the condition that every pair of configurations exchanges probability equally in both directions, which is what pins a sampler to its target, and the moment comparison later in the notebook is what makes that bias visible.\n",
+    "The bond update uses its own coupling and half of the field at each endpoint. It does not include the live energy that either endpoint shares with the neighboring spin outside the pair. Consequently, the pair transition is not conditioned on the rest of the ring, and composing the eight pair updates need not satisfy [detailed balance](https://en.wikipedia.org/wiki/Detailed_balance) for the global Boltzmann distribution. At stationarity, detailed balance requires the probability flux between every pair of configurations to match in both directions, and it is sufficient to make the target distribution stationary. We use the distribution and moment comparisons below to measure the bias introduced when the external-neighbor terms are omitted.\n",
     "\n",
-    "Third, can we recover the parameters from data? We fit the couplings and fields with persistent contrastive divergence. That fit is host-only: it runs in notebook NumPy, and Torx's contribution to it is the earlier evidence that the same update rule samples correctly.\n",
+    "Third, can samples identify the parameters that generated them? We fit the couplings and fields with persistent contrastive divergence. This fit is host-only: it runs in notebook NumPy, while the preceding experiments establish how the corresponding sampling updates behave when executed through Torx.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li>Torx: the finite-reset probe and every chromatic-Gibbs site draw.</li><li>Notebook code: exact enumeration, <code>PISING</code> matrix construction, moments, and parameter updates.</li><li><code>examples/helpers/_plots_sampling.py</code>: the Torx chromatic loop, host <code>PISING</code> matrix walker, and host PCD loop.</li></ul></details>\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
     "- distinguish the ideal infinite reset from the finite probe and the ring's manual-zero implementation,\n",
-    "- compare Torx chromatic Gibbs with host sampling from Torx-generated `PISING` matrices against an exact 8-site reference, and\n",
+    "- compare Torx chromatic Gibbs and host sampling from Torx-generated `PISING` matrices against an exact 8-site reference, and\n",
     "- fit Ising parameters with host-only persistent contrastive divergence."
    ]
   },
@@ -175,7 +175,7 @@
    "source": [
     "## The Ising model\n",
     "\n",
-    "Before any Torx call, we fix the two objects the rest of the notebook keeps referring back to: the energy of a spin configuration, and the one-site conditional a Gibbs sampler draws from.\n",
+    "Before calling Torx, we define the two objects used throughout the notebook: the energy of a spin configuration and the one-site conditional from which a Gibbs sampler draws.\n",
     "\n",
     "A spin configuration $\\mathbf{s} \\in \\{-1, +1\\}^N$ has energy\n",
     "\n",
@@ -183,13 +183,13 @@
     "H(\\mathbf{s}) = \\underbrace{-\\sum_{(i,j)\\in E} J_{ij}\\, s_i s_j}_{\\vphantom{\\big|}\\text{bond energy}} \\;\\underbrace{-\\sum_i h_i\\, s_i}_{\\vphantom{\\big|}\\text{field energy}} ,\n",
     "$$\n",
     "\n",
-    "where the first sum runs over the edges $E$ and the second over the sites. The Boltzmann distribution at inverse temperature $\\beta$ is\n",
+    "where the first sum runs over the edges $E$ and the second over the sites. At inverse temperature $\\beta$, this energy defines the Boltzmann distribution\n",
     "\n",
     "$$\n",
     "\\pi(\\mathbf{s}) \\propto e^{-\\beta H(\\mathbf{s})} .\n",
     "$$\n",
     "\n",
-    "Because the energy is a sum of purely local terms, we never have to touch the whole configuration at once. Single-site Gibbs sampling resamples one spin at a time from its exact conditional. For site $i$ with neighbors $N(i)$, we write the local field\n",
+    "Although this is a joint distribution over the entire configuration, a single-site Gibbs update requires only local terms. For a site $i$ with neighbors $N(i)$, define the local field\n",
     "\n",
     "$$\n",
     "\\ell_i = h_i + \\underbrace{\\sum_{j \\in N(i)} J_{ij}\\,(2\\sigma_j - 1)}_{\\vphantom{\\big|}\\text{neighbor sum}},\n",
@@ -197,9 +197,9 @@
     "\\pi(\\sigma_i = 1 \\mid \\sigma_{N(i)}) = \\frac{1}{1 + e^{-2\\beta\\ell_i}} ,\n",
     "$$\n",
     "\n",
-    "using bits $\\sigma \\in \\{0, 1\\}$ with $s = 2\\sigma - 1$. The neighbor sum runs only over $N(i)$.\n",
+    "where $\\sigma \\in \\{0, 1\\}$ is the bit representation of the spin, with $s = 2\\sigma - 1$. The neighbor sum includes only sites in $N(i)$.\n",
     "\n",
-    "The conditional is a Bernoulli whose logit (the log-odds of the spin being up) is $2\\beta\\ell_i$, and this one-site conditional is all the sampler needs. Everything that follows is a question about how faithfully some piece of machinery reproduces it."
+    "The conditional is Bernoulli, with logit—the log-odds that the spin is up—equal to $2\\beta\\ell_i$. The experiments below compare an update that includes this complete local field with a bond-local update that omits the external-neighbor contributions."
    ]
   },
   {
@@ -209,19 +209,19 @@
    "source": [
     "## The per-site update\n",
     "\n",
-    "Our first job is to get one site right, because a ring sampler is only as trustworthy as the single update it repeats. An ideal Gibbs update discards the current spin, then draws a Bernoulli bit from the conditional above. In Torx notation that identity is\n",
+    "We begin with a single site. An ideal Gibbs update discards the current spin and draws a Bernoulli bit from the conditional above. In Torx notation,\n",
     "\n",
     "$$\n",
     "\\mathsf{PColor}_i = \\mathsf{PNOT}(2\\beta\\ell_i) \\circ \\mathsf{PReset}(\\infty).\n",
     "$$\n",
     "\n",
-    "That identity is stated with an infinite reset, which no circuit can execute, so the notebook works with three distinct reset cases in total. We name all three now, because later sections refer back to this list:\n",
+    "The identity uses an infinite reset, which cannot be executed by a circuit. The notebook therefore distinguishes three reset cases:\n",
     "\n",
-    "1. **The ideal infinite reset**, `PReset(∞)`, which appears in the identity above and is a mathematical statement rather than something we run.\n",
-    "2. **The finite reset**, `PReset(12.0)`, used by the probe in this section. It drives the input close to zero rather than exactly to zero, so it tests a close approximation of case 1 with a small reset-leak contribution.\n",
-    "3. **The ring's manual zero**, used from the chromatic Gibbs section onward. It supplies an exact zero initial state and applies only `PNOT`, so it uses no reset gate at all and leaks nothing.\n",
+    "1. **The ideal infinite reset**, `PReset(∞)`, which appears in the identity above and specifies the mathematical update rather than an executable gate.\n",
+    "2. **The finite reset**, `PReset(12.0)`, used by the probe in this section. It drives the input close to zero rather than exactly to zero, so the result includes a small reset-leak contribution.\n",
+    "3. **The ring's manual zero**, used from the chromatic Gibbs section onward. It supplies an exact zero initial state and applies only `PNOT`, so no reset gate or reset leakage is present.\n",
     "\n",
-    "For the finite probe, choose a target probability $p = 0.73$:"
+    "We evaluate the finite-reset case at a target probability $p = 0.73$:"
    ]
   },
   {
@@ -366,9 +366,9 @@
    "source": [
     "## Chromatic Gibbs sampling on a ring\n",
     "\n",
-    "With one site validated, we scale the same update out to a whole graph. The ring has $N = 8$ sites, one pbit per site, one $J_{ij}$ per edge, and one $h_i$ per site.\n",
+    "We now apply the same one-site conditional to the full graph. The ring has $N = 8$ sites, one pbit per site, one $J_{ij}$ per edge, and one $h_i$ per site.\n",
     "\n",
-    "We color the sites by parity: evens in one color, odds in the other. No neighboring sites share a color, so all sites of one color can update at once while conditioned on the other color."
+    "We color sites by parity, placing even sites in one class and odd sites in the other. Since no adjacent sites share a color, all sites in one class are conditionally independent given the other class and can be updated in parallel."
    ]
   },
   {
@@ -500,7 +500,7 @@
    "id": "00d62908",
    "metadata": {},
    "source": [
-    "The even and odd classes carry distinct outlines and never touch, which is what lets a whole class update in parallel, and the dark incident edges marking the local field for $s_2$ show how narrow each conditional is: a site only reads its two ring neighbors."
+    "The outlines encode the two color classes: even and odd sites never share an edge, so either class can update in parallel. The dark incident edges identify the terms used to compute the local field for $s_2$ and show that its conditional reads only the two neighboring spins."
    ]
   },
   {
@@ -508,9 +508,9 @@
    "id": "c5297316",
    "metadata": {},
    "source": [
-    "We now run the sampler itself: 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This is case 3 from the reset list above, the ring's manual zero. Every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`, and because it doesn't execute `PReset`, there's no finite-reset leakage to account for here.\n",
+    "We run 6000 independent chains for 240 sweeps with `torx_chromatic_gibbs` in `examples/helpers/_plots_sampling.py`. This uses case 3 from the reset list: every site update supplies an exact zero state to a one-gate Torx `PNOT` circuit on `BranchingSimulator`. Because the sweep does not execute `PReset`, finite-reset leakage does not enter this comparison.\n",
     "\n",
-    "Its claim-bearing core is:\n",
+    "The helper implements the site draw as follows:\n",
     "\n",
     "```python\n",
     "def torx_chromatic_gibbs(init_bits, J, h, *, N, beta, colors, sweeps, key):\n",
@@ -532,7 +532,7 @@
     "    sample_bits = jax.vmap(sample_bit)\n",
     "```\n",
     "\n",
-    "Each chain's conditional logit $2\\beta\\ell_i$ is folded into the `PNOT` gate theta and `sample_bit` is vmapped over every chain and color site, so one batched Torx call draws an entire color class. We then compare the empirical distribution and moments with the exact reference through total variation distance, which measures how far apart two distributions are, and we require it to come in under 0.08:"
+    "For each chain, the conditional logit $2\\beta\\ell_i$ becomes the theta of the `PNOT` gate. `sample_bit` is vmapped over chains and sites in a color class, so one batched Torx call draws that entire class. We compare the resulting empirical distribution and moments with the exact reference. The distribution comparison uses total variation distance, and we require it to be below 0.08:"
    ]
   },
   {
@@ -587,17 +587,17 @@
    "source": [
     "## Host sampling from Torx-generated PISING matrices\n",
     "\n",
-    "Chromatic Gibbs is one way to be local. This section builds the other, so that we can measure what changes when locality is drawn around a bond instead of a site. The bond-local alternative updates one edge at a time.\n",
+    "Both samplers use local information, but they place the boundary of an update differently. Chromatic Gibbs updates one site conditioned on its neighbors; the alternative in this section updates one edge at a time using a two-spin matrix.\n",
     "\n",
-    "The Torx `PISING` operation, constructed as `PISING([i, j])` with theta `[J, h_i, h_j, beta, dt]`, generates a column-stochastic Glauber matrix for the two incident spins. Column-stochastic means every column of transition probabilities sums to one. Its transition matrix is\n",
+    "Constructed as `PISING([i, j])` with theta `[J, h_i, h_j, beta, dt]`, the Torx `PISING` operation generates a column-stochastic Glauber matrix for the two incident spins. Column-stochastic means that each column of transition probabilities sums to one. The matrix is\n",
     "\n",
     "$$\n",
     "P = \\exp(Q\\,\\Delta t),\n",
     "$$\n",
     "\n",
-    "where $Q$ is the single-spin-flip generator of the bond energy $E(s_i, s_j) = -J s_i s_j - h_i s_i - h_j s_j$. Here $\\Delta t$ is `pising_dt` in the next cell.\n",
+    "where $Q$ is the single-spin-flip generator for the bond energy $E(s_i, s_j) = -J s_i s_j - h_i s_i - h_j s_j$, and $\\Delta t$ is `pising_dt` in the next cell.\n",
     "\n",
-    "We generate one matrix for each ring edge and split each site's field in half so its two incident bonds sum to $h_i$. The fields therefore add up correctly, but these two-spin matrices still omit the live energy contribution from the external neighbor of each endpoint. A block-Gibbs pair update would condition on those neighbors, and this bond matrix doesn't, so the composed host walk need not preserve the ring Boltzmann law, meaning the distribution the walk would leave unchanged once mixed isn't guaranteed to be the one we want."
+    "We generate one matrix per ring edge and split each site's field in half, so its two incident bonds contribute a total field of $h_i$. This accounting recovers the field sum across the ring, but it does not make an individual two-spin transition conditional on the full configuration. Each endpoint also interacts with a neighboring spin outside the pair, and the corresponding live energy contribution is absent from the bond matrix. A block-Gibbs pair update would condition on those external neighbors. Since `PISING` does not, the composed host walk need not preserve the ring's Boltzmann law and may have a different stationary distribution."
    ]
   },
   {
@@ -640,7 +640,7 @@
    "id": "e6befb22",
    "metadata": {},
    "source": [
-    "We draw a representative slice of the bond sweep, the first three of eight gates for legibility, to show the gate structure the matrices come from. Torx's role at this stage is generation: we ask each `PISING` gate for its matrix and then sample on the host, so this circuit is never handed to a Torx simulator:"
+    "For legibility, we draw the first three of the eight gates in a bond sweep. The diagram shows the gate structure from which the matrices are generated. Torx constructs each `PISING` matrix, after which the host performs the sampling; the displayed circuit is therefore not passed to a Torx simulator:"
    ]
   },
   {
@@ -753,11 +753,11 @@
    "id": "7dda24bb",
    "metadata": {},
    "source": [
-    "The distance puts a number on the difference. The host sampler using Torx-generated `PISING` matrices sits at total variation 0.4020 from the exact Boltzmann distribution, about six times the 0.0634 that Torx chromatic Gibbs reaches, and that ratio is what the omitted-neighbor bias costs.\n",
+    "The total variation distances separate the two update rules. The host walk over Torx-generated `PISING` matrices is 0.4020 from the exact Boltzmann distribution, about six times the 0.0634 distance obtained by Torx chromatic Gibbs. The pair update's omitted external-neighbor terms provide the mechanism for this larger bias.\n",
     "\n",
     "### Comparing the moments\n",
     "\n",
-    "One distance tells us the samplers differ but not where, so we look at the statistics the difference lives in: the per-site magnetizations $\\langle s_i\\rangle$, the average spin at each site, and per-edge correlations $\\langle s_i s_j\\rangle$, the average neighboring-spin product. The panels place the exact reference, Torx chromatic Gibbs, and the host sampler using Torx-generated `PISING` matrices side by side. Torx chromatic Gibbs tracks the exact moments, while the host matrix walker gets most signs right but underestimates the magnitudes, far enough that at $s_6$, where the exact magnetization is nearly zero, even the sign flips."
+    "Total variation summarizes the difference between distributions but does not identify which statistics differ. We therefore compare the per-site magnetizations $\\langle s_i\\rangle$, the average spin at each site, and the per-edge correlations $\\langle s_i s_j\\rangle$, the average product of neighboring spins. The panels show the exact reference, Torx chromatic Gibbs, and the host sampler over Torx-generated `PISING` matrices. Chromatic Gibbs follows the exact moments. The host matrix walk preserves most signs but underestimates the magnitudes; at $s_6$, where the exact magnetization is nearly zero, the estimated sign also changes."
    ]
   },
   {
@@ -823,9 +823,9 @@
    "source": [
     "## Host-only persistent contrastive divergence\n",
     "\n",
-    "So far the parameters were given and we sampled from them. Now we run that backwards: given samples, recover the parameters.\n",
+    "Thus far, the parameters have been fixed and the experiments have sampled from the resulting distribution. We now reverse the problem and recover the parameters from samples.\n",
     "\n",
-    "Contrastive divergence learns by comparison. It measures a few statistics of the data, measures the same statistics on samples the current model produces, and moves the parameters until the two agree. [**Persistent contrastive divergence** (Tieleman 2008)](#ref-tieleman) makes one change to that recipe: it keeps Gibbs chains running instead of resetting them from data, so at each step it contrasts the moments of long-lived chains with the data moments. The log-likelihood gradients are the moment differences:\n",
+    "Contrastive divergence compares statistics measured in the data with the same statistics measured in samples from the current model, then updates the parameters to reduce those differences. [**Persistent contrastive divergence** (Tieleman 2008)](#ref-tieleman) retains its Gibbs chains between updates rather than restarting them from the data. At each step, it therefore compares data moments with moments from long-lived model chains. The log-likelihood gradients are\n",
     "\n",
     "$$\n",
     "\\partial_{J_{ij}}\\log\\mathcal{L} = \\beta\\bigl(\\langle s_i s_j\\rangle_{\\text{data}} - \\langle s_i s_j\\rangle_{\\text{model}}\\bigr),\n",
@@ -833,7 +833,7 @@
     "\\partial_{h_i}\\log\\mathcal{L} = \\beta\\bigl(\\langle s_i\\rangle_{\\text{data}} - \\langle s_i\\rangle_{\\text{model}}\\bigr).\n",
     "$$\n",
     "\n",
-    "Because the exact ring law is enumerable, we can draw honest training data from it directly: 2048 training samples from the exact Boltzmann distribution."
+    "Since the exact ring distribution is enumerable, we draw the training data directly from it: 2048 samples from the exact Boltzmann distribution."
    ]
   },
   {
@@ -892,7 +892,7 @@
    "id": "92d379c4",
    "metadata": {},
    "source": [
-    "Each step calls the host NumPy `chromatic_gibbs` loop in `examples/helpers/_plots_sampling.py` for two sweeps, then the notebook updates $J$ and $h$ from the data-minus-model moment gap. This fit runs entirely on the host: Torx's contribution came earlier, when the chromatic sweep it executed reproduced the exact Boltzmann distribution to 0.0634 in total variation, which is what lets us use the fast NumPy mirror of the same update rule inside the training loop:"
+    "At each of 300 steps, the host NumPy `chromatic_gibbs` loop in `examples/helpers/_plots_sampling.py` advances the persistent chains for two sweeps. The notebook then updates $J$ and $h$ from the data-minus-model moment differences. This fitting loop runs entirely on the host. Torx was used in the preceding experiment, where the same chromatic update rule produced a total variation distance of 0.0634 from the exact Boltzmann distribution; the fit uses the faster NumPy implementation of that rule."
    ]
   },
   {
@@ -925,7 +925,7 @@
    "id": "b2219106",
    "metadata": {},
    "source": [
-    "The claim is that 300 steps of this loop are enough to identify the model, so we compare every learned coupling and field against the true values that generated the data, with a tolerance of 0.05:"
+    "After 300 updates, we compare every learned coupling and field with the values used to generate the data. The tolerance for each parameter is 0.05:"
    ]
   },
   {
@@ -964,7 +964,7 @@
    "source": [
     "### Parameter recovery\n",
     "\n",
-    "Assertions confirm the fit succeeded, and the parity panels show how it succeeded. They plot the learned couplings and fields against the true values after 300 persistent contrastive divergence steps, so points on the dotted diagonal indicate exact recovery."
+    "The assertions check every parameter numerically. The two parity panels provide the corresponding visual comparison by plotting learned values against true values after 300 persistent contrastive-divergence steps. A point on the dotted diagonal represents exact recovery."
    ]
   },
   {
@@ -1011,7 +1011,7 @@
    "id": "1afc1888",
    "metadata": {},
    "source": [
-    "Both panels hug the diagonal to within the printed maxima of 0.0373 for the couplings and 0.0386 for the fields, so this host-only fit recovered the full parameter set well inside the 0.05 tolerance."
+    "The largest absolute errors are 0.0373 for the couplings and 0.0386 for the fields. Thus every learned parameter lies within the specified tolerance of 0.05."
    ]
   },
   {

--- a/examples/07_discrete_diffusion.ipynb
+++ b/examples/07_discrete_diffusion.ipynb
@@ -23,20 +23,20 @@
    "id": "cell-02",
    "metadata": {},
    "source": [
-    "In this tutorial we take the corrupted-image side of discrete diffusion and hand the reverse step to Torx. The forward process is the independent bit-flip corruption of [Austin et al. 2021](#ref-austin) in the continuous-time Markov-chain form of [Campbell et al. 2022](#ref-campbell), which sets the context rather than the method we execute. What we actually run is narrower: a host UNet predicts each clean pixel's posterior probability, and Torx independently resamples the pixels from those probabilities.\n",
+    "Discrete diffusion begins with a process we can specify exactly: starting from a clean binary image, independently flip its pixels until the image is corrupted. The reverse problem is less direct. Given the corrupted image $x_t$, how can we turn a denoiser's beliefs about the clean pixels into a stochastic step that Torx can execute?\n",
     "\n",
-    "A **forward process** corrupts a clean binary image by flipping pixels at random, so the reverse step has to guess which pixels were flipped. The posterior denoiser estimates $\\hat p_i = P(x_{0,i}=1 \\mid x_t)$ from the corrupted image $x_t$.\n",
+    "We use the independent bit-flip process of [Austin et al. 2021](#ref-austin), written as the continuous-time Markov chain of [Campbell et al. 2022](#ref-campbell), to define the corruption. This forward process provides the context rather than the method executed by the circuit. The computation we run is narrower: a host UNet estimates $\\hat p_i = P(x_{0,i}=1 \\mid x_t)$ for each pixel, and Torx independently resamples the pixels from those posterior probabilities.\n",
     "\n",
-    "We treat each pixel as a probabilistic bit, or **pbit**, because that's the unit Torx samples. One `PNOT` gate turns the current pixel into a Bernoulli draw with parameter $\\hat p_i$.\n",
+    "Each binary pixel is therefore a probabilistic bit, or **pbit**, which is the unit sampled by Torx. A single `PNOT` gate maps the current pixel and its corresponding probability to a Bernoulli draw with parameter $\\hat p_i$.\n",
     "\n",
-    "The [UNet](https://arxiv.org/abs/1505.04597) that supplies those probabilities has 472,545 parameters and was trained offline, so we load its committed weights and evaluation artifacts and the page stays fast. The training and FID evaluation script is not in the repository, which is why nothing here reproduces the checkpoint's training split or its FID protocol.\n",
+    "The [UNet](https://arxiv.org/abs/1505.04597) has 472,545 parameters and was trained offline. We load its committed weights and evaluation artifacts rather than training it on this page, which keeps the example fast but also limits what it can establish: the repository does not contain the training and FID evaluation script, so this notebook cannot reproduce the checkpoint's training split or FID protocol.\n",
     "\n",
-    "By the end, you'll be able to:\n",
+    "We will:\n",
     "\n",
     "- set up the forward bit-flip kernel and load the committed corrupted MNIST batch,\n",
-    "- turn the UNet's per-pixel clean probabilities into one `PNOT` logit per pbit,\n",
-    "- distinguish one stochastic Torx draw from a thresholded 64-draw ensemble estimator, and\n",
-    "- report the eight-image display-batch error separately from offline UNet artifact metrics."
+    "- map the UNet's per-pixel clean probabilities to one `PNOT` logit per pbit,\n",
+    "- compare one stochastic Torx draw with a thresholded 64-draw ensemble estimator, and\n",
+    "- keep the eight-image display-batch error separate from the offline UNet artifact metrics."
    ]
   },
   {
@@ -284,15 +284,15 @@
    "source": [
     "## Binarized pixels as pbits\n",
     "\n",
-    "A reverse step is only as good as the corruption model it inverts, so we start by writing that model down. We represent a binary image as one pbit per pixel.\n",
+    "To interpret the reverse step, we first specify the corruption it is meant to undo. We represent a binary image with one pbit for each pixel.\n",
     "\n",
-    "The forward process is a continuous-time Markov chain, a random process that jumps between states at random times. It flips every bit independently using the uniform rate matrix, which sets a single flip rate shared by all pixels:\n",
+    "The forward process is a continuous-time Markov chain: a random process that jumps between states at random times. For a single pixel, the uniform rate matrix below defines the shared flip rate:\n",
     "\n",
     "$$\n",
     "Q = \\begin{pmatrix} -1 & 1 \\\\ 1 & -1 \\end{pmatrix}.\n",
     "$$\n",
     "\n",
-    "Its time-$\\sigma$ transition kernel is:\n",
+    "At noise time $\\sigma$, exponentiating this rate matrix gives the transition kernel:\n",
     "\n",
     "$$\n",
     "e^{\\sigma Q} = \\begin{pmatrix}\n",
@@ -301,9 +301,9 @@
     "\\end{pmatrix}.\n",
     "$$\n",
     "\n",
-    "The off-diagonal entry $\\tfrac12(1 - e^{-2\\sigma})$ is the chance a bit has flipped by time $\\sigma$, and the diagonal $\\tfrac12(1 + e^{-2\\sigma})$ is the chance it stayed put. At $\\sigma = 0$ no bits have flipped, and as $\\sigma \\to \\infty$ the flip probability rises toward $\\tfrac12$, which is pure noise.\n",
+    "The off-diagonal entry $\\tfrac12(1 - e^{-2\\sigma})$ is the probability that a bit has flipped by time $\\sigma$; the diagonal entry $\\tfrac12(1 + e^{-2\\sigma})$ is the probability that it remains unchanged. At $\\sigma = 0$, no bits have flipped. As $\\sigma \\to \\infty$, the flip probability approaches $\\tfrac12$, and the initial bit is lost in pure noise.\n",
     "\n",
-    "The committed `noisy` grids are clean MNIST images corrupted at the checkpoint's evaluation level, a per-bit flip probability `forward_p = 0.30`, meaning each pixel is flipped independently with probability 0.30. The next cell selects a display batch of eight images, and the check after it compares that stated rate against the bit error we actually observe."
+    "The committed `noisy` grids use the checkpoint's evaluation level, `forward_p = 0.30`: each pixel in a clean MNIST image is flipped independently with probability 0.30. We next select eight images for display, then compare this specified rate with the bit error observed in that batch."
    ]
   },
   {
@@ -375,7 +375,7 @@
    "id": "cell-11",
    "metadata": {},
    "source": [
-    "We plot the flip probability against noise time to see where the checkpoint's corruption level sits relative to pure noise."
+    "The following plot shows how the flip probability changes with noise time and marks the corruption level used by the checkpoint."
    ]
   },
   {
@@ -432,11 +432,11 @@
    "source": [
     "## Posterior clean-bit probabilities\n",
     "\n",
-    "No gate can sample anything until something tells it what a clean pixel probably was, and that's the host denoiser's job.\n",
+    "The forward kernel tells us how pixels are corrupted, but it does not by itself tell a gate which clean value to sample. That information comes from the host denoiser.\n",
     "\n",
-    "It's a 472k-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections, where each block uses two `GroupNorm`-normalized $3\\times3$ convolutions. Its per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. The model definition and loader live in `examples/helpers/_nb07_diffusion.py`. That fixes the division of labor for the rest of the page: the offline UNet contributes the per-pixel probabilities, and Torx contributes every random bit that comes out.\n",
+    "The denoiser is a 472,545-parameter UNet with two downsampling blocks, a bottleneck, and two upsampling blocks with skip connections. Each block uses two `GroupNorm`-normalized $3\\times3$ convolutions, and the final per-pixel sigmoid output $\\hat p_i$ estimates $P(x_{0,i}=1 \\mid x_t)$. Its definition and loader are in `examples/helpers/_nb07_diffusion.py`. This establishes the division of computation used throughout the notebook: the offline UNet computes the posterior probabilities, while Torx samples the output bits.\n",
     "\n",
-    "A gate needs a flip probability rather than a clean probability, so for current pixel $x_{t,i}$ we set the `PNOT` flip probability to\n",
+    "`PNOT` is parameterized by a flip probability rather than a clean-pixel probability. For current pixel $x_{t,i}$, we therefore set\n",
     "\n",
     "$$\n",
     "p^{(i)}_{\\text{flip}} = \\begin{cases} 1 - \\hat p_i & x_{t,i} = 1 \\\\ \\hat p_i & x_{t,i} = 0. \\end{cases}\n",
@@ -444,9 +444,9 @@
     "\\theta^{(i)} = \\log \\frac{p^{(i)}_{\\text{flip}}}{1 - p^{(i)}_{\\text{flip}}}.\n",
     "$$\n",
     "\n",
-    "If the input is 0, the output is 1 exactly when `PNOT` flips. If the input is 1, the output stays 1 exactly when it doesn't flip. Either way the output bit is Bernoulli($\\hat p_i$).\n",
+    "This mapping has the same interpretation for either input value. When the input is 0, the output becomes 1 exactly when `PNOT` flips; when the input is 1, the output remains 1 exactly when it does not flip. In both cases, the output bit is Bernoulli($\\hat p_i$).\n",
     "\n",
-    "That makes this posterior per-pixel denoising rather than a joint time-transition kernel derived from the forward process, and the trade is worth naming. We give up any account of how neighboring pixels move together within one reverse step. What we buy is a reverse step that costs one gate per pbit."
+    "The resulting construction performs posterior per-pixel denoising rather than sampling from a joint time-transition kernel derived from the forward process. Its limitation is explicit: neighboring pixels do not move jointly within a reverse step. In exchange, the circuit uses only one gate per pbit."
    ]
   },
   {
@@ -503,7 +503,7 @@
    "id": "cell-17",
    "metadata": {},
    "source": [
-    "The curve flattens toward that final value, which tells us the offline run had stopped changing much by step 30,000 and little else, because the committed artifact arrived without a validation loss, a stopping rule, or the training script that would let us speak to convergence or generalization."
+    "The curve flattens near the saved value by step 30,000, showing that the recorded training loss changed little near the end of the run. It does not establish convergence or generalization: the committed artifacts include neither a validation loss nor a stopping rule, and they omit the training script needed to examine either claim."
    ]
   },
   {
@@ -606,7 +606,7 @@
    "id": "cell-29",
    "metadata": {},
    "source": [
-    "Now we assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once and every image reuses it, so the build cost is paid a single time. The `num_draws` argument decides what the returned mean means: with one draw it's the binary sample itself, and with many draws it's a Monte Carlo estimate of each pixel's posterior marginal, that is, the average over independent draws."
+    "We next assemble the 784-gate circuit template. `eqx.filter_jit` compiles the `vmap`-batched sampler once, after which every image reuses it and the build cost is paid only once. The `num_draws` argument controls how to interpret the returned mean. With one draw, the mean is the binary sample itself; with multiple independent draws, it is a Monte Carlo estimate of each pixel's posterior marginal."
    ]
   },
   {
@@ -807,11 +807,11 @@
    "source": [
     "## Offline UNet artifact metric\n",
     "\n",
-    "The checkpoint was scored offline with FID and those numbers travel with the artifacts, so the first thing to settle is what they describe.\n",
+    "The checkpoint metadata includes FID scores from an offline evaluation. Before interpreting their change, we must specify which outputs they measure.\n",
     "\n",
-    "[Fréchet inception distance](https://arxiv.org/abs/1706.08500) compares Gaussians fitted to Inception features from two image sets, and a lower value means the two sets look more alike to that feature extractor.\n",
+    "[Fréchet inception distance](https://arxiv.org/abs/1706.08500) fits Gaussians to Inception features from two image sets and compares those distributions; lower values indicate greater similarity in that feature space.\n",
     "\n",
-    "The committed metadata records 19.21 for the corrupted images and 2.63 for the offline UNet-denoised images. Both numbers score the UNet checkpoint's own outputs, and neither scores a Torx draw, because no Torx output was ever put through an FID evaluation. The evaluation split, sample count, preprocessing, and FID implementation weren't committed either, so read the figure below as checkpoint metadata rather than as a result this notebook reproduced."
+    "The committed values are 19.21 for corrupted images and 2.63 for images denoised by the offline UNet. Neither value scores a Torx draw, because the Torx outputs in this notebook were never evaluated with FID. Moreover, the artifacts omit the evaluation split, sample count, preprocessing, and FID implementation. The following figure should therefore be read as checkpoint metadata, not as a reproduced result."
    ]
   },
   {

--- a/examples/08_stochastic_convolutional_networks.ipynb
+++ b/examples/08_stochastic_convolutional_networks.ipynb
@@ -23,21 +23,17 @@
    "id": "14a94005",
    "metadata": {},
    "source": [
-    "In this tutorial, we build a stochastic convolution layer: a small probabilistic kernel that slides across a $4\\times4$ bars-and-stripes image. It plays the same role as a CNN filter, with gates that fire randomly in place of a fixed dot product.\n",
+    "Bars-and-stripes images differ in a simple but spatial way: rows are constant in one class, while columns are constant in the other. How can a stochastic circuit detect this distinction using the same local computation across a $4\\times4$ image?\n",
     "\n",
-    "Each image has 16 **[probabilistic bits (p-bits)](https://doi.org/10.1063/1.4975355)**, Bernoulli-valued states with one state per pixel, so the layer is a parametrised stochastic circuit over those p-bits. What makes it convolutional is weight sharing: one small set of parameters is reused at every position instead of each position learning its own. Here that means the same local kernel runs on every horizontal pixel pair.\n",
+    "We begin with a small probabilistic kernel that acts on adjacent horizontal pixels. It plays the role of a CNN filter, except that its gates fire randomly rather than computing a fixed dot product. Each image is represented by 16 **[probabilistic bits (p-bits)](https://doi.org/10.1063/1.4975355)**, one Bernoulli-valued state per pixel, so the layer is a parametrised stochastic circuit over those p-bits.\n",
     "\n",
-    "Two `PCNOT` pooling stages then funnel the state into a small set of readout sites. Because the reuse runs across columns only, the layer applies a convolution-like stencil with horizontal weight sharing.\n",
+    "The convolutional structure comes from reusing one set of kernel parameters at every horizontal position. Two `PCNOT` pooling stages then collect the resulting state at a small set of readout sites. Because the kernel is reused across columns but not rows, this is a convolution-like stencil with horizontal weight sharing rather than a fully shift-symmetric convolution.\n",
     "\n",
     "This tutorial uses Torx, JAX, Equinox, Optax, NumPy, and Matplotlib. It assumes basic familiarity with binary classifiers and gradients.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li><strong>Torx:</strong> <code>SampleSimulator</code> runs and differentiates the stochastic feature circuit.</li><li><strong>Notebook code:</strong> Equinox supplies the linear classifier, JAX supplies transformations, and Optax applies Adam updates.</li><li><strong>Helpers:</strong> <code>examples/helpers/_notebook_paths.py</code> and <code>examples/helpers/_notebook_style.py</code> handle paths and style. <code>examples/helpers/_plots_schematics.py</code> and <code>examples/helpers/_plots_training.py</code> draw the figures.</li></ul></details>\n",
     "\n",
-    "By the end, you'll be able to:\n",
-    "\n",
-    "- build one shared four-gate kernel (`PJUMP`, `PReset`, `PNOT`, `PJUMP`) and tie all 60 gate positions to 5 logits with `param_map`,\n",
-    "- train those logits end to end with a sample-based parameter-shift gradient and the Adam optimizer, and\n",
-    "- check that gradient against a finite-difference probe, so you can trust the differentiable path through the sampler.\n"
+    "We will construct the four-gate kernel (`PJUMP`, `PReset`, `PNOT`, `PJUMP`), use `param_map` to tie 60 physical gate positions to 5 logits, and train those logits end to end with a sample-based parameter-shift gradient and Adam. Finally, we will compare one gradient with a finite-difference estimate to check the differentiable path through the sampler.\n"
    ]
   },
   {
@@ -317,15 +313,15 @@
    "source": [
     "## Building the kernel circuit\n",
     "\n",
-    "Weight sharing is the whole point of this layer, so we should be precise about what is shared. The local kernel applies four gates to each adjacent horizontal pixel pair, `PJUMP`, `PReset`, `PNOT`, and `PJUMP`, and `param_map` points all 12 horizontal-pair applications of that kernel at the same logits, which is the stochastic analogue of weight tying in a CNN. The reuse runs across columns only, so we get horizontal weight sharing (a convolution-like stencil) rather than an exact shift symmetry, and there's no vertical shared kernel.\n",
+    "The circuit has two kinds of repeated structure. First, a local kernel applies four gates—`PJUMP`, `PReset`, `PNOT`, and `PJUMP`—to each adjacent horizontal pixel pair. The 12 applications occupy different sites, but `param_map` assigns their corresponding gates to the same kernel logits. Thus every pair is processed by the same learned stochastic operation, as pixels at different locations share a filter in a CNN. Since the reuse is horizontal only, the resulting stencil is convolution-like but does not have exact shift symmetry, and there is no shared vertical kernel.\n",
     "\n",
-    "After the convolution comes column-then-row `PCNOT` pooling, which reduces the 16 pbits to 4 readout sites and adds two more shared logits of its own.\n",
+    "Second, column-then-row `PCNOT` pooling reduces the 16 p-bits to 4 readout sites and introduces two additional shared logits.\n",
     "\n",
-    "To count the logits, look at what a single one controls. Each gate is a convex combination (a probability-weighted blend) of the identity and a deterministic operation $B$, applied with probability $\\sigma(\\theta)$:\n",
+    "To count the parameters, consider what one logit controls. Each gate is a convex combination of the identity and a deterministic operation $B$, applied with probability $\\sigma(\\theta)$:\n",
     "\n",
     "$$G(\\theta)=\\underbrace{(1-\\sigma(\\theta))\\,I}_{\\vphantom{\\big|}\\text{do nothing}}+\\underbrace{\\sigma(\\theta)\\,B}_{\\vphantom{\\big|}\\text{apply }B}.$$\n",
     "\n",
-    "The mixing weight is the logistic $\\sigma(\\theta)=1/(1+e^{-\\theta})$, the gate-on probability, so one logit sets one gate-on probability and nothing else. The two `PJUMP` gates in the kernel share logit 0, which means the 4 kernel gates need only 3 logits, and the two pooling stages contribute 2 more. That's 5 trainable logits driving 60 physical gates.\n"
+    "Here $\\sigma(\\theta)=1/(1+e^{-\\theta})$ is the gate-on probability. The two `PJUMP` gates in the local kernel share logit 0, so its 4 gates require only 3 logits. The two pooling stages contribute 2 more, giving 5 trainable logits for 60 physical gates.\n"
    ]
   },
   {
@@ -461,7 +457,7 @@
    "id": "b49f65a0",
    "metadata": {},
    "source": [
-    "Before wiring up the whole grid, we look at the kernel on its own, so the four-gate sequence is legible in one picture. Orange marks the two-site `PJUMP` coupling gates, and slate marks the single-site gates, `PReset` and `PNOT`."
+    "We first draw the local kernel by itself, where the four-gate sequence is easiest to inspect. Orange denotes the two-site `PJUMP` coupling gates; slate denotes the single-site `PReset` and `PNOT` gates. This view shows the operation applied at one location, but not yet how its parameters are reused across the grid."
    ]
   },
   {
@@ -509,9 +505,9 @@
    "id": "3c7953b1",
    "metadata": {},
    "source": [
-    "The kernel picture says nothing about where that kernel is reused, so we now draw the full `circuit` and show where its five logits appear. We recover the spatial wiring from `circuit` and `param_map` themselves rather than redeclaring it, which means the schematic can only show sharing the circuit actually has.\n",
+    "To show that reuse, we next draw the full `circuit` and encode the positions governed by each of its five logits. The schematic recovers the spatial wiring from `circuit` and `param_map` rather than declaring it separately, so it displays the sharing present in the constructed circuit.\n",
     "\n",
-    "The 16 pbits sit on the $4\\times4$ grid, each horizontal pair receives the same local kernel, and the two-stage `PCNOT` pooling funnels the state into 4 readout sites. Gold and copper distinguish the two `PCNOT` pooling stages."
+    "The 16 p-bits occupy a $4\\times4$ grid. Each horizontal pair receives the same local kernel, after which two stages of `PCNOT` pooling collect the state at 4 readout sites. Gold and copper distinguish the two pooling stages."
    ]
   },
   {
@@ -635,9 +631,9 @@
    "source": [
     "## Training the kernel\n",
     "\n",
-    "To train through the sampler, we need a derivative that works with samples. A parameter-shift estimator supplies one without differentiating the sampling step itself: it re-runs the circuit with a gate parameter forced to special values, then combines the resulting expectations into the derivative.\n",
+    "Training requires derivatives of expectations produced by a sampler. A parameter-shift estimator obtains these derivatives without differentiating the discrete sampling operation: it evaluates the circuit with a gate parameter fixed at special values and combines the resulting expectations.\n",
     "\n",
-    "`BranchingSimulator` with `diff_method=\"param_shift_inf\"` and `num_samples=256` gives differentiable expected readouts. For a gate $G(\\theta)=(1-\\sigma(\\theta))I+\\sigma(\\theta)B$, those special values are the two extremes of the logit, so the method evaluates the branches by clamping the gate logit to $-\\infty$ and $+\\infty$. Those limits force the identity branch and the $B$ branch deterministically.\n",
+    "We use `BranchingSimulator` with `diff_method=\"param_shift_inf\"` and `num_samples=256`. For a gate $G(\\theta)=(1-\\sigma(\\theta))I+\\sigma(\\theta)B$, the special values are the two logit limits, $-\\infty$ and $+\\infty$, which deterministically select the identity branch and the $B$ branch.\n",
     "\n",
     "For a readout $O$, the derivative of the expected readout with respect to the gate logit is\n",
     "\n",
@@ -645,7 +641,7 @@
     "\\frac{\\mathrm{d}}{\\mathrm{d}\\theta}\\,\\mathbb E[O]\\;=\\;\\sigma(\\theta)\\,\\bigl(\\mathbb E[O\\mid B]-\\mathbb E[O]\\bigr),\n",
     "$$\n",
     "\n",
-    "where the $\\pm\\infty$ clamps supply the branch expectations $\\mathbb E[O\\mid I]$ and $\\mathbb E[O\\mid B]$, and $\\mathbb E[O]=(1-\\sigma(\\theta))\\,\\mathbb E[O\\mid I]+\\sigma(\\theta)\\,\\mathbb E[O\\mid B]$ is the expectation under the current circuit. Each expectation is estimated from samples, which is why the gradient carries Monte Carlo noise and why we probe it with a finite difference later. Unlike the finite-shift quantum rules in [Mitarai et al. (2018)](#ref-mitarai-2018) and [Schuld et al. (2019)](#ref-schuld-2019), this classical stochastic rule evaluates the two deterministic branches directly.\n"
+    "where the two clamps provide the branch expectations $\\mathbb E[O\\mid I]$ and $\\mathbb E[O\\mid B]$, and $\\mathbb E[O]=(1-\\sigma(\\theta))\\,\\mathbb E[O\\mid I]+\\sigma(\\theta)\\,\\mathbb E[O\\mid B]$ is the expectation under the current circuit. Each expectation is estimated from samples, so the gradient contains Monte Carlo noise. We will measure its agreement with a finite difference below. Unlike the finite-shift quantum rules in [Mitarai et al. (2018)](#ref-mitarai-2018) and [Schuld et al. (2019)](#ref-schuld-2019), this classical stochastic rule evaluates the two deterministic branches directly.\n"
    ]
   },
   {
@@ -683,7 +679,7 @@
    "id": "b039e3c2",
    "metadata": {},
    "source": [
-    "`SCNN` is where weight sharing becomes an array operation. Indexing the 5 shared logits by `param_map` broadcasts them onto all 60 gate positions, so a gradient arriving at any position accumulates back into its shared logit, and the 4 readout sites are the only features the linear sigmoid classifier ever sees."
+    "`SCNN` implements the sharing as an array operation. Indexing the 5 shared logits by `param_map` expands them to the 60 gate positions. During differentiation, contributions from every position assigned to the same index accumulate into that shared logit. The sampler returns expected p-bit values, and only the 4 readout sites are passed to the linear sigmoid classifier."
    ]
   },
   {
@@ -724,7 +720,7 @@
    "id": "433a37db",
    "metadata": {},
    "source": [
-    "We draw the split once, from `rng` and seed 123, so the same 6 images serve as validation for every epoch and the trace is never disturbed by a shifting split. The cell also prints the validation majority baseline, the accuracy you would get by always predicting whichever class is more common in those 6 images, which is the floor real learning has to clear."
+    "We draw the train-validation split once from `rng` with seed 123. The same 6 images are therefore evaluated after every epoch, rather than changing with the training randomness. We also compute the validation majority baseline: the accuracy obtained by always predicting the more frequent class among those 6 images."
    ]
   },
   {
@@ -821,9 +817,9 @@
    "id": "f70c4286",
    "metadata": {},
    "source": [
-    "The objective is ordinary binary cross-entropy over the batch, with predictions clipped away from 0 and 1 so the logarithm stays finite. Wrapping `bce_loss` in `eqx.filter_value_and_grad` is what pulls the parameter-shift gradient back through the sampler, so `loss_fn` returns the loss and the gradient with respect to the shared logits together, and the undecorated `bce_loss` stays available because the finite-difference check later needs loss values only.\n",
+    "The objective is binary cross-entropy over the batch. Predictions are clipped away from 0 and 1 so that the logarithms remain finite. Applying `eqx.filter_value_and_grad` to `bce_loss` propagates the parameter-shift derivative through the sampler and returns gradients with respect to the shared logits. We retain the undecorated `bce_loss` because the finite-difference calculation later needs loss values without gradients.\n",
     "\n",
-    "Two thin wrappers finish the loop: `train_step` takes one Adam step, computing the loss and gradients and then applying the updates, and `evaluate` returns validation loss and accuracy for each epoch without changing the parameters."
+    "The remaining wrappers separate the two operations used in each epoch: `train_step` computes one Adam update, while `evaluate` returns validation loss and accuracy without changing the parameters."
    ]
   },
   {
@@ -910,7 +906,7 @@
    "id": "7d03e1a2",
    "metadata": {},
    "source": [
-    "Training runs 90 full-batch epochs, and the one subtlety is randomness. `fit_model` splits the seed-123 key once per epoch so the sampler noise in the training step is independent of the noise in the evaluation, which keeps the recorded six-example validation trace from echoing the training samples. We then run it and report the final validation loss and accuracy for n=6."
+    "We train for 90 full-batch epochs. At each epoch, `fit_model` splits the seed-123 key into independent keys for the training update and validation evaluation, so their sampler estimates do not reuse the same random draws. The function records validation loss and accuracy on the fixed six-example set, after which we report the final values for n=6."
    ]
   },
   {
@@ -987,7 +983,7 @@
    "source": [
     "### Gradient check\n",
     "\n",
-    "A gradient that flows and a gradient that is correct are different things, and so far we have only seen the first. So we test one shared `PJUMP` logit (`LOGIT_IDX = 0`), whose `param_shift_inf` gradient should agree with a finite-difference estimate up to Monte Carlo noise, the random scatter that comes from estimating expectations with finitely many samples. In the next cells we compute the analytic gradient on one small batch of 4 bars and 4 stripes, probe the same logit numerically, and report the relative error. The check covers only one of the five logits, at 30% tolerance, so it's evidence that the differentiable path is wired correctly rather than a verification of all five."
+    "The existence of a gradient does not establish that its value is correct. We therefore examine one shared `PJUMP` logit (`LOGIT_IDX = 0`) by comparing its `param_shift_inf` gradient with a central finite-difference estimate. Both calculations use the same small batch of 4 bars and 4 stripes. Because both expectations are sample estimates, agreement is required only within 30% relative error. The check covers one of the five logits, so it tests the wiring of one differentiable path rather than verifying every parameter."
    ]
   },
   {
@@ -1020,7 +1016,7 @@
    "id": "21e2752f",
    "metadata": {},
    "source": [
-    "The reference is a central finite difference on the same logit, a cruder estimate but one that never runs the parameter-shift code, so agreement between the two is real evidence rather than a tautology. `fd_grad` builds a fresh `BranchingSimulator` at the requested sample count for each probe, because the cure for a noisy comparison is more samples."
+    "The reference calculation is a central finite difference of the loss with respect to the same logit. It does not invoke the parameter-shift gradient code, so agreement compares two independent derivative constructions. `fd_grad` creates a `BranchingSimulator` with the requested sample count for each probe, allowing later probes to reduce sampling noise."
    ]
   },
   {
@@ -1062,7 +1058,7 @@
    "id": "c92cbfdc",
    "metadata": {},
    "source": [
-    "Now we compare the two numbers. The finite difference is itself a sample estimate, so a single probe can fail on noise alone, which is why we walk a ladder of probes at 256, 1024, and 2048 samples per side and stop at the first relative error under `REL_ERR_TOL = 0.30`. The assertion that follows uses that same tolerance, so a genuinely broken gradient path fails the notebook instead of passing quietly."
+    "We now compare the estimates. A finite difference computed from samples can miss the tolerance because of Monte Carlo noise, so we try probes with 256, 1024, and 2048 samples per side, stopping at the first relative error below `REL_ERR_TOL = 0.30`. The following assertion applies the same threshold. This procedure distinguishes a persistent disagreement from the scatter of a single finite-sample probe, while retaining the stated 30% tolerance."
    ]
   },
   {
@@ -1138,7 +1134,7 @@
    "source": [
     "## Kernel parameter shifts\n",
     "\n",
-    "A model can reach good accuracy by training the linear head alone and leaving the kernel where it started, so accuracy on its own doesn't tell us the gradient reached the shared gates. The table lists the initial logit, the trained logit, and the shift for each shared gate, and a nonzero shift is what shows that the gradient reached the shared kernel. The cell asserts that the movement is real: an L2 shift above 1e-3, a maximum absolute shift above 0.05, and a final accuracy of at least 0.75."
+    "Validation accuracy alone cannot show that the stochastic kernel was trained, because the linear head might improve while the kernel remains at its initial values. We therefore compare the initial and trained logits for each shared gate. The checks require an L2 shift above 1e-3, a maximum absolute shift above 0.05, and final accuracy of at least 0.75. Nonzero movement in the gate logits establishes that the gradient reached the shared kernel, although it does not by itself identify which learned settings caused the accuracy change."
    ]
   },
   {
@@ -1214,7 +1210,7 @@
    "source": [
     "## Training curve\n",
     "\n",
-    "Finally we look at what the optimizer was scored on: validation BCE and validation accuracy on the same six examples after every epoch. Accuracy moves in $1/6$ increments, so that panel climbs as a staircase, and the 67% line is the seed-specific validation majority baseline a trivial classifier would already reach. The inset encodes black pixels as 1 and white pixels as 0. Because those six images are scored every epoch rather than held back, this repeated validation trace is an optimization diagnostic, not an estimate from an untouched test set."
+    "The final figure shows the quantities evaluated after every epoch: validation BCE and validation accuracy on the same six examples. Since accuracy changes by $1/6$ for each corrected example, its panel forms a staircase. The 67% line marks the majority-class accuracy for this seed-specific validation split, and the inset encodes black pixels as 1 and white pixels as 0. Because the six images are evaluated repeatedly rather than reserved as an untouched test set, these curves describe optimization on a fixed validation set; they are not an independent estimate of generalization."
    ]
   },
   {
@@ -1309,14 +1305,14 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "You have now built a stochastic convolution layer over 16 p-bits, one per pixel, that classifies bars-and-stripes images by taking gradients through the sampler.\n",
+    "We have constructed a stochastic convolutional network over 16 p-bits, one per pixel, and trained it to classify bars-and-stripes images by differentiating expected readouts from the sampler.\n",
     "\n",
-    "- A four-gate kernel (`PJUMP`, `PReset`, `PNOT`, `PJUMP`) runs on every horizontal adjacent pixel pair, with `PCNOT` pooling down to 4 readout sites.\n",
-    "- `param_map` ties all 60 physical gates to 5 shared logits, giving a convolution-like horizontal stencil rather than an exact shift symmetry.\n",
-    "- `param_shift_inf` returns a sample-based gradient through the sampler, and `optax.adam` trains the shared logits and a linear head together.\n",
-    "- A finite-difference probe sanity-checks one shared `PJUMP` logit against the `param_shift_inf` gradient (one logit, one small batch, 30% tolerance), which gives evidence that the sampler path is differentiable while stopping short of a full multi-logit verification.\n",
+    "- A four-gate kernel (`PJUMP`, `PReset`, `PNOT`, `PJUMP`) is applied to every adjacent horizontal pixel pair, followed by `PCNOT` pooling to 4 readout sites.\n",
+    "- `param_map` ties the 60 physical gates to 5 shared logits. This parameter reuse defines a convolution-like horizontal stencil, but not exact shift symmetry.\n",
+    "- `param_shift_inf` estimates gradients through the sampler, and `optax.adam` updates the shared logits and linear head together.\n",
+    "- A central finite-difference probe compares one shared `PJUMP` gradient with the `param_shift_inf` estimate on one small batch, using a 30% tolerance. This supports the differentiable path for that logit without constituting a full five-logit verification.\n",
     "\n",
-    "[`09_stochastic_graph_networks.ipynb`](09_stochastic_graph_networks.ipynb) shows another stochastic-circuit learning pattern with shared parameters.\n",
+    "The next notebook, [`09_stochastic_graph_networks.ipynb`](09_stochastic_graph_networks.ipynb), applies another shared-parameter learning pattern to a stochastic graph circuit.\n",
     "\n",
     "## References\n",
     "\n",

--- a/examples/09_stochastic_graph_networks.ipynb
+++ b/examples/09_stochastic_graph_networks.ipynb
@@ -23,13 +23,13 @@
    "id": "c48d4bf6",
    "metadata": {},
    "source": [
-    "In this tutorial, we train a **stochastic graph network** for MaxCut. MaxCut asks us to split a graph's nodes into two groups so that as many edges as possible have one endpoint in each group, and the number of such crossing edges is the cut we're trying to make large.\n",
+    "In this tutorial, we ask how an edge-local stochastic circuit can learn a global graph partition. The example is MaxCut: split a graph's nodes into two groups so that as many edges as possible have one endpoint in each group. The number of crossing edges is the cut value we seek to maximize.\n",
     "\n",
-    "One **[probabilistic bit (p-bit)](https://doi.org/10.1063/1.4975355)**, a Bernoulli-valued state, sits on each graph node and records which of the two groups that node currently belongs to. The circuit places one edge-local `PISING` gate on each of the graph's 12 edges. A sweep applies those 12 gates sequentially in fixed edge-list order, and the circuit repeats that sweep 20 times.\n",
+    "We place one **[probabilistic bit (p-bit)](https://doi.org/10.1063/1.4975355)**, a Bernoulli-valued state, on each graph node. Its value records which of the two groups the node currently belongs to. The circuit then places one edge-local `PISING` gate on each of the graph's 12 edges. A sweep applies these 12 gates sequentially in fixed edge-list order, and the circuit repeats the sweep 20 times.\n",
     "\n",
-    "The cut of any single sampled partition is a count rather than a differentiable function of the couplings, so we train them with the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992), a rule for learning from distributions you can sample but can't differentiate through: draw samples from the circuit, score each one by its cut, and raise the probability of the samples that scored above the batch average. In this demonstration, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
+    "The difficulty is that the cut of one sampled partition is a discrete count, not a differentiable function of the couplings. We therefore use the [REINFORCE gradient estimator (Williams 1992)](#ref-williams-1992), which learns from a distribution by sampling from it, scoring each sample, and increasing the probability of samples that score above the batch average. Here, `StateVectorSimulator` computes the exact 256-entry probability vector, sampling uses that vector, and JAX differentiates its exact log probabilities.\n",
     "\n",
-    "This tutorial uses Torx, JAX, Optax, and NumPy, with NetworkX behind the graph helper, and it assumes you're comfortable with basic graph and probability notation.\n",
+    "This tutorial uses Torx, JAX, Optax, and NumPy, with NetworkX behind the graph helper, and assumes basic graph and probability notation.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul><li><strong>Torx:</strong> <code>StateVectorSimulator</code> computes the full classical probability vector for the 8-node circuit.</li><li><strong>Notebook code:</strong> JAX differentiates exact log probabilities in the REINFORCE surrogate, and Optax applies Adam updates.</li><li><strong>Computational helper:</strong> <code>examples/helpers/_nb09_maxcut.py</code> builds the circuit, exact diagnostic, graph reference, and result figures.</li><li><strong>Plot helper:</strong> <code>examples/helpers/_plots_schematics.py</code> draws the edge-local circuit primitive.</li></ul></details>\n",
     "\n",
@@ -263,21 +263,21 @@
    "source": [
     "## One PISING per edge\n",
     "\n",
-    "Before assembling the network, we look at the single gate it's tiled from and at the loss that gate has to lower.\n",
+    "Before assembling the full network, we examine the edge-local gate from which it is tiled and connect that gate to the global loss.\n",
     "\n",
-    "We write each spin as $s_i = 2\\sigma_i - 1 \\in \\{-1, +1\\}$, so that maximizing the expected cut is the same as minimizing the loss\n",
+    "Write each spin as $s_i = 2\\sigma_i - 1 \\in \\{-1, +1\\}$. With this encoding, maximizing the expected cut is equivalent to minimizing\n",
     "\n",
     "$$\n",
     "\\mathcal{L} = \\underbrace{-\\,\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]}_{\\vphantom{\\big|}\\text{negative cut}} = -\\sum_{(i,j)\\in\\mathcal{E}}\\underbrace{\\frac{1 - \\langle s_i s_j\\rangle_{p_\\theta}}{2}}_{\\vphantom{\\big|}\\text{per-edge cut}},\n",
     "$$\n",
     "\n",
-    "where $\\langle s_i s_j\\rangle_{p_\\theta}$ is the spin-spin correlation under the circuit. A cut edge ($s_i \\neq s_j$) contributes $1$ and an aligned edge contributes $0$, so lowering $\\mathcal{L}$ makes endpoints disagree, which is exactly what an antiferromagnetic coupling does.\n",
+    "Here, $\\langle s_i s_j\\rangle_{p_\\theta}$ is the spin-spin correlation under the circuit. A cut edge has $s_i \\neq s_j$ and contributes $1$, whereas an aligned edge contributes $0$. Lowering $\\mathcal{L}$ therefore favors disagreement between adjacent spins, as an antiferromagnetic coupling should.\n",
     "\n",
-    "The primitive is the `PISING` operation: we construct `gate = PISING([i, j])` and supply the theta `[J, h_i, h_j, beta, dt]` separately to `get_matrix` or `build_circuit`. It's a $4\\times4$ column-stochastic [Glauber kernel](#ref-glauber-1963), a single-spin thermal flip rule, on a pair of p-bits. With local fields $h=0$ it biases the joint state toward agreement when $J>0$ and disagreement when $J<0$.\n",
+    "The local primitive is the `PISING` operation. We construct `gate = PISING([i, j])`, then pass the parameter vector `[J, h_i, h_j, beta, dt]` separately to `get_matrix` or `build_circuit`. The resulting $4\\times4$ column-stochastic [Glauber kernel](#ref-glauber-1963) applies a single-spin thermal flip rule to a pair of p-bits. When the local fields are $h=0$, positive $J$ favors agreement and negative $J$ favors disagreement.\n",
     "\n",
-    "How hard each update pushes is set by the inverse temperature $\\beta$, where higher is greedier, together with the timestep $\\Delta t$. For this 3-regular 8-node graph, one sweep applies 12 `PISING` gates sequentially in the printed `edges` order, and the same fixed order repeats for 20 sweeps. The order matters because these stochastic matrices generally don't commute.\n",
+    "The inverse temperature $\\beta$ and timestep $\\Delta t$ determine how strongly each update acts; increasing $\\beta$ makes the update greedier. On this 3-regular 8-node graph, a sweep applies 12 `PISING` gates sequentially in the printed `edges` order, and the circuit repeats that same order for 20 sweeps. This ordering is part of the computation because the stochastic matrices generally do not commute.\n",
     "\n",
-    "The next cell constructs one edge-local kernel and inspects its stochastic matrix."
+    "We now construct one edge-local kernel and inspect its stochastic matrix."
    ]
   },
   {
@@ -390,7 +390,7 @@
    "id": "1f44f291",
    "metadata": {},
    "source": [
-    "The schematic isolates the one edge-local update that the rest of the circuit is built from. A sweep is the fixed ordered list of 12 edges printed below rather than 12 simultaneous gates, so the picture shows a primitive, not a layer."
+    "The schematic isolates the edge-local primitive from which the circuit is assembled. The two wires encode the endpoint spins, while the box applies their `PISING` update. It does not depict a simultaneous 12-edge layer: a sweep is the ordered list of 12 edges printed below, with one matrix applied after another."
    ]
   },
   {
@@ -476,9 +476,9 @@
    "source": [
     "## The exact classical probability vector\n",
     "\n",
-    "Everything downstream, both the training gradient and the diagnostic curve, comes out of one helper, so we build that helper first.\n",
+    "Both the training gradient and the diagnostic curve begin with the circuit's exact distribution, so we construct that common primitive first.\n",
     "\n",
-    "`make_expected_cut` returns two pure-`jax` functions of the couplings: `density(J)`, the circuit's exact 256-entry classical probability vector, and `expected_cut(J)`, the cut averaged over it. Its core is excerpted from `examples/helpers/_nb09_maxcut.py`:\n",
+    "`make_expected_cut` returns two pure-`jax` functions of the couplings. `density(J)` is the circuit's exact 256-entry classical probability vector, while `expected_cut(J)` averages the cut over that vector. The core implementation from `examples/helpers/_nb09_maxcut.py` is:\n",
     "\n",
     "```python\n",
     "def make_expected_cut(\n",
@@ -511,11 +511,11 @@
     "    return expected_cut, density\n",
     "```\n",
     "\n",
-    "Within each sweep, `DiscretePCircuit` applies the 12 `PISING` gates sequentially in `edges` order, then repeats that ordered sweep `REPS` times.\n",
+    "Within each sweep, `DiscretePCircuit` applies the 12 `PISING` gates sequentially in `edges` order and then repeats the ordered sweep `REPS` times.\n",
     "\n",
-    "Training draws samples from `density` and differentiates the selected entries of its exact full log-probability vector, so gradients reach the couplings only through those sampled log probabilities, whereas `expected_cut` never touches an update and is evaluated purely to record the exact simulator diagnostic that we plot beside the sampled batch objective.\n",
+    "The two returned functions serve different roles. Training samples indices from `density` and differentiates the corresponding entries of its exact log-probability vector, so the couplings receive gradients only through sampled log probabilities. By contrast, `expected_cut` does not drive an update; it is evaluated only as an exact simulator diagnostic beside the sampled batch objective.\n",
     "\n",
-    "Before training starts, we evaluate that diagnostic at the initial couplings and compare it with the mean cut of a uniform random assignment and with the brute-force optimum, which gives us the two reference levels the training curves are read against."
+    "Before training, we evaluate this diagnostic at the initial couplings. We also compute the mean cut of a uniform random assignment and the brute-force optimum. These values provide the two reference levels against which we will read the training curves."
    ]
   },
   {
@@ -560,9 +560,9 @@
    "source": [
     "## Training by REINFORCE\n",
     "\n",
-    "We now run the training loop and watch two curves, one that drives the optimizer and one that checks it.\n",
+    "We now run the training loop and compare two curves: the sampled quantity that drives the optimizer and the exact quantity that checks it.\n",
     "\n",
-    "We maximize $\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]$ with a likelihood-based REINFORCE estimator and `optax.adam`. Each step computes the exact full vector `density_fn(J)`, draws `NUM_SAMPLES` bitstrings from it, and differentiates the selected exact log probabilities. For a batch of $M>1$ bitstrings with $\\bar c$ the same-batch mean cut, the implemented estimator is\n",
+    "We maximize $\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]$ with a likelihood-based REINFORCE estimator and `optax.adam`. At each step, the code computes the complete vector `density_fn(J)`, draws `NUM_SAMPLES` bitstrings from it, and differentiates the selected exact log probabilities. For a batch of $M>1$ bitstrings, with $\\bar c$ denoting the same-batch mean cut, the implemented estimator is\n",
     "\n",
     "$$\n",
     "\\nabla_\\theta\\,\\mathbb{E}_{p_\\theta}[\\mathrm{cut}]\n",
@@ -571,9 +571,9 @@
     "\\qquad x_m\\sim p_\\theta.\n",
     "$$\n",
     "\n",
-    "The code multiplies the centered same-batch surrogate by $M/(M-1)$, which exactly corrects the finite-batch factor introduced by reusing the samples in their own baseline and leaves the estimator unbiased.\n",
+    "Because the samples also determine $\\bar c$, simply averaging the centered terms would introduce a finite-batch factor. The code multiplies the centered same-batch surrogate by $M/(M-1)$, which corrects that factor exactly and leaves the estimator unbiased.\n",
     "\n",
-    "The first curve is the batch-mean cut. That's the number the optimizer actually sees, so it's our evidence that training is working. The second curve is the exact expected cut, which we compute separately from the full 256-entry probability vector, never feed to a gradient, and plot only to confirm that the sampled objective is telling the truth."
+    "The batch-mean cut is the quantity observed by the optimizer. The exact expected cut is computed separately from all 256 probabilities, never supplied to a gradient, and used only to test whether the sampled objective tracks the underlying distribution. Keeping these curves separate lets us compare optimization evidence with an exact diagnostic."
    ]
   },
   {
@@ -816,7 +816,7 @@
    "id": "ca77445c",
    "metadata": {},
    "source": [
-    "The distribution has a clear mode, so the natural question is which partition it is. We decode the most probable trained bitstring and draw it on the graph with its cut edges highlighted."
+    "The cut distribution identifies the dominant score but not the corresponding partition. We therefore decode the most probable trained bitstring and draw it on the graph, highlighting the edges that cross between its two groups."
    ]
   },
   {

--- a/examples/10_pmode_gaussian_gates.ipynb
+++ b/examples/10_pmode_gaussian_gates.ipynb
@@ -23,13 +23,13 @@
    "id": "37852692",
    "metadata": {},
    "source": [
-    "In this tutorial we build Torx's continuous **pmode** gate set and check it three ways: sampled point clouds, exact moment propagation, and closed-form conditioning.\n",
+    "In this tutorial we build Torx's continuous **pmode** gate set and examine it in three ways: sampled point clouds, exact moment propagation, and closed-form conditioning.\n",
     "\n",
-    "The pmode is Torx's continuous data primitive. A pmode site has a value in $\\mathbb{R}^N$, and because a Gaussian is fixed by its first two moments, the mean and [covariance](https://www.itl.nist.gov/div898/handbook/pmc/section5/pmc541.htm) are all we track. Every gate in this tutorial acts on pmode sites.\n",
+    "The pmode is Torx's continuous data primitive, and every gate in this tutorial acts on pmode sites. A site takes a value in $\\mathbb{R}^N$. If its distribution is Gaussian, how much of that distribution must we carry through the circuit?\n",
     "\n",
-    "The most general of them is `AffineGaussianGate`, which takes a point, applies a linear map, adds a bias, and adds Gaussian noise. The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` fix some of those parameters to cover common choices.\n",
+    "A Gaussian is fixed by its first two moments, so it is enough to track the mean and [covariance](https://www.itl.nist.gov/div898/handbook/pmc/section5/pmc541.htm). The general `AffineGaussianGate` applies a linear map to a point, adds a bias, and adds Gaussian noise. The specialized gates `Displace`, `Scale`, `Mix`, and `Diffuse` fix some of those parameters to cover common choices.\n",
     "\n",
-    "A Gaussian stays Gaussian under this map, so we never have to carry a density around. Carrying the mean and covariance through the circuit and letting each gate update those two moments is enough.\n",
+    "Because a Gaussian remains Gaussian under each of these maps, every gate can update the two moments directly; we do not need to carry the density itself through the circuit.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -953,7 +953,7 @@
    "id": "46fd641a",
    "metadata": {},
    "source": [
-    "Both figures come from that one propagated mean and covariance with no samples underneath, so the marked mean in the joint plot and the two one-dimensional marginals carry no Monte Carlo error to explain away."
+    "Both figures are computed from that one propagated mean and covariance; neither contains sampled points. The marked mean in the joint plot and the two one-dimensional marginals are therefore exact outputs of analytic propagation rather than finite-sample estimates."
    ]
   },
   {
@@ -1057,9 +1057,9 @@
    "source": [
     "## Monte Carlo comparison\n",
     "\n",
-    "The propagated moments are exact, which makes them a clean reference for the sampler.\n",
+    "The propagated moments are exact, so they provide a reference for the sampler.\n",
     "\n",
-    "`HybridPCircuit.sample_multiple` draws full trajectories, and empirical means and covariances approach their analytic values as the sample count grows ([Metropolis and Ulam, 1949](#ref-metropolis-ulam)). The useful question is therefore how closely it agrees at a finite sample count, which is what a tolerance scaled to that count answers.\n",
+    "`HybridPCircuit.sample_multiple` draws full trajectories, and empirical means and covariances approach their analytic values as the sample count grows ([Metropolis and Ulam, 1949](#ref-metropolis-ulam)). At any finite sample count, however, the estimates fluctuate. We therefore compare each discrepancy with a tolerance scaled to the number of samples rather than requiring exact equality.\n",
     "\n",
     "We draw 20,000 samples and check each empirical moment against a six-standard-error tolerance at this seed.\n",
     "\n"
@@ -1406,9 +1406,9 @@
    "source": [
     "## Mixtures: leaving the Gaussian family\n",
     "\n",
-    "Every gate so far has been affine with Gaussian noise, so every distribution so far has been Gaussian. Leaving that family takes a gate whose behavior depends on a discrete choice.\n",
+    "Every gate so far has applied an affine map with Gaussian noise. These maps preserve Gaussian distributions, so producing a non-Gaussian density requires a different operation: a discrete choice among Gaussian components.\n",
     "\n",
-    "`MixtureGaussianGate` is that gate. It uses a **pdit** (a $d$-state discrete site) as a control to select one of `K` Gaussian components, then adds the selected component's mean and Gaussian noise to the current continuous value. Starting from $x=0$, marginalizing the control gives a mixture density:\n",
+    "`MixtureGaussianGate` supplies that choice. It uses a **pdit** (a $d$-state discrete site) as a control to select one of `K` Gaussian components, then adds the selected component's mean and Gaussian noise to the current continuous value. Starting from $x=0$, marginalizing the control gives the mixture density\n",
     "\n",
     "$$\n",
     "\\rho(x) = \\sum_{k} \\pi_k\\,\\mathcal{N}(x;\\, \\mu_k,\\, \\sigma_k^2),\n",
@@ -1416,13 +1416,13 @@
     "\n",
     "which is no longer Gaussian.\n",
     "\n",
-    "The control needs a gate of its own. `PditShift` flips the pdit from 0 to 1 with a probability set by its log-odds `theta`, which is how this binary demonstration encodes the component weights.\n",
+    "The control needs a gate of its own. `PditShift` flips the pdit from 0 to 1 with a probability set by its log-odds `theta`; in this binary demonstration, that probability encodes the component weights.\n",
     "\n",
-    "That leaves a clean split of parameters. `MixtureGaussianGate` carries the component `means` and `log_vars`, and the control distribution carries the weights $\\pi_k$. The sampler below draws the pdit control with the declared weights, then lets `MixtureGaussianGate` draw the component-conditioned Gaussian sample.\n",
+    "The parameters are divided accordingly. `MixtureGaussianGate` carries the component `means` and `log_vars`, while the control distribution carries the weights $\\pi_k$. The sampler below first draws the pdit control with the declared weights, then lets `MixtureGaussianGate` draw the component-conditioned Gaussian sample.\n",
     "\n",
-    "The notebook helper `plot_mixture_density`, from `examples/helpers/_plots_fields.py`, draws the figure and evaluates the exact PDF itself, reading the gate's `means` and `log_vars` together with the separate control `weights` over a display grid.\n",
+    "The notebook helper `plot_mixture_density`, from `examples/helpers/_plots_fields.py`, draws the figure and evaluates the exact PDF. It reads the gate's `means` and `log_vars` together with the separate control `weights` over a display grid, allowing the sampled histogram to be compared with the density specified by the same parameters.\n",
     "\n",
-    "This is the non-Gaussian primitive the continuous arc is built on, and the full process is developed in [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb).\n"
+    "This construction provides the non-Gaussian primitive used by the continuous arc. [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb) develops the full regime-switching process.\n"
    ]
   },
   {

--- a/examples/11_gaussian_hierarchical_ssm.ipynb
+++ b/examples/11_gaussian_hierarchical_ssm.ipynb
@@ -23,17 +23,17 @@
    "id": "ea3dd444",
    "metadata": {},
    "source": [
-    "Suppose something is going on that you can't measure. Call it the **drive**: one hidden quantity that rises while an event of interest is under way and falls when it isn't. You never see the drive itself, but you do have six noisy sensors that each respond to it in their own way. The question this tutorial answers is whether you can reconstruct, after the trial is over, the time steps during which the drive was active.\n",
+    "Many systems contain a quantity that matters but cannot be measured directly. Here that quantity is a hidden **drive**: it rises while an event of interest is under way and falls when the event is absent. We observe only six noisy sensors, each responding to the drive in a different way. Can we use those observations to reconstruct, after the trial is over, the time steps during which the drive was active?\n",
     "\n",
-    "We answer it with a [linear-Gaussian state-space model](#ref-kalman-1960) built in Torx. We generate six synthetic Gaussian observation channels directly from a 3-dimensional latent state, condition the model on all of them, and read an **event score** off the result: one number per time step, near 1 where the model believes the drive was active and near 0 where it believes it wasn't. Because we generated the data ourselves we also hold the true latent trajectory, and that's what lets us check the score at the end.\n",
+    "We answer this question with a [linear-Gaussian state-space model](#ref-kalman-1960) built in Torx. We begin with the generative model: a 3-dimensional latent state produces six synthetic Gaussian observation channels. We then translate that model into a time-homogeneous circuit, condition on the complete observation sequence, and reduce the inferred state to an **event score**. This gives one number per time step, near 1 where the model believes the drive was active and near 0 where it believes it was not. Because the data are synthetic, we retain the true latent trajectory and can compare it with the recovered drive at the end.\n",
     "\n",
     "Each latent state and observation is a **pmode**, a continuous Torx site valued in $\\mathbb{R}^N$ and tracked by its mean and covariance.\n",
     "\n",
-    "This example is time-homogeneous, which means the same dynamics and emission parameters apply at every time step. Torx represents that assumption by explicitly unrolling the sequence into per-step gates while reusing the same transition and emission `theta` values.\n",
+    "The example is time-homogeneous: the same dynamics and emission parameters apply at every time step. Torx represents this assumption by explicitly unrolling the sequence into per-step gates while reusing the same transition and emission `theta` values.\n",
     "\n",
-    "The full program is therefore an initial gate, shared-parameter transition gates, and per-step emission gates, all of them `AffineGaussianGate` instances.\n",
+    "The resulting program consists of an initial gate, shared-parameter transition gates, and per-step emission gates, all of them `AffineGaussianGate` instances.\n",
     "\n",
-    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates latent states using the full observation sequence, including observations from later time steps, so it's an offline, acausal calculation. Filtering is the online counterpart: it estimates the state at each step from that step's observation and the earlier ones only, so it can run as data arrives. We smooth here because we're analyzing a finished trial and want the best estimate at every step rather than a causal one.</p></details>\n",
+    "<details class=\"tx-disclosure\"><summary>Term: smoothing</summary><p>Smoothing estimates each latent state from the complete observation sequence, including observations at later time steps. It is therefore an offline, acausal calculation. Filtering is the online counterpart: it estimates the state at each step using only that step's observation and earlier observations, so it can run as data arrives. We use smoothing because the trial is complete and we want the best estimate at every step rather than a causal estimate.</p></details>\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -760,11 +760,11 @@
    "source": [
     "## Exact posterior\n",
     "\n",
-    "We can now ask the model what the latent drive was, given everything we observed. For a linear-Gaussian model that answer involves no approximation: conditioning the joint Gaussian on the full observation sequence gives the same smoothed posterior as the classical two-pass recursion, which runs [Kalman filtering (1960)](#ref-kalman-1960) forward through the data to get a causal estimate at each step, then makes the backward pass of [Rauch, Tung, and Striebel (1965)](#ref-rts-1965) to revise each of those estimates using the observations that arrived after it.\n",
+    "With the joint Gaussian assembled, we can infer the latent drive from the observations. For this linear-Gaussian model, conditioning on the complete observation sequence is exact: it gives the same smoothed posterior as the classical two-pass recursion. [Kalman filtering (1960)](#ref-kalman-1960) first moves forward through the data to compute a causal estimate at each step; [Rauch, Tung, and Striebel smoothing (1965)](#ref-rts-1965) then moves backward to revise those estimates using later observations.\n",
     "\n",
-    "`AffineGaussianSimulator.condition` reaches the same result in one step, conditioning on all 32 observations at once. The result is exact for this model, offline, and acausal because each latent estimate can use later observations.\n",
+    "`AffineGaussianSimulator.condition` obtains the same result by conditioning on all 32 observations at once. Because every latent estimate can use later observations, the result is offline and acausal as well as exact for this model.\n",
     "\n",
-    "So we compile the circuit for `AffineGaussianSimulator`, then condition on the observed pmodes in `observed` and query the latent pmodes in `latent_sites`."
+    "We therefore compile the circuit for `AffineGaussianSimulator`, supply the observed pmodes in `observed`, and query the latent pmodes in `latent_sites`."
    ]
   },
   {
@@ -821,7 +821,7 @@
    "id": "66cc2dbb",
    "metadata": {},
    "source": [
-    "Exact is a strong claim, so we test it against code that shares nothing with the gates. A dense NumPy baseline independently propagates the LGSSM moments from `(A, C, Q, R, m0, P0)` and then applies the Schur-complement conditioning formula, which gives us a separate reference for the prior and for the posterior. Torx must match both the dense prior and dense posterior to within the relative and absolute tolerances asserted below."
+    "The exactness claim needs a reference that does not reuse the gate construction. A dense NumPy baseline independently propagates the LGSSM moments from `(A, C, Q, R, m0, P0)` and applies the Schur-complement conditioning formula. This separates two checks: Torx must reproduce both the dense prior propagation and the dense posterior, within the relative and absolute tolerances asserted below."
    ]
   },
   {
@@ -1002,7 +1002,7 @@
    "id": "bd666dcb",
    "metadata": {},
    "source": [
-    "The posterior links every pair of time steps, but for dynamics this local the link should weaken as the gap grows. To see whether it does, a structural check bins the smoothed covariance into per-timestep blocks and tests two expectations: most of the mass should sit on the diagonal, and among the off-diagonal terms the nearest-neighbor lag should dominate. The printed mean block norms for lags 0 to 4 are the evidence."
+    "Exact agreement establishes the posterior values, but the covariance should also reflect the local dynamics. We divide the smoothed covariance into per-timestep blocks and test two expectations: most of the mass should lie on the diagonal, and the nearest-neighbor lag should be the largest off-diagonal term. The printed mean block norms for lags 0 through 4 make that comparison visible."
    ]
   },
   {
@@ -1114,13 +1114,13 @@
    "source": [
     "## Offline event-score sanity check\n",
     "\n",
-    "One question is left: did the smoother actually recover the hidden drive? To answer it we project `posterior_mean` onto `intent_axis`, which collapses each 3-dimensional smoothed state into the scalar latent drive we care about. Projecting each step's per-site covariance marginal along the same direction gives the variance of that projection, so every point comes with an uncertainty.\n",
+    "Agreement with the dense reference establishes the inference algebra. We now ask a different question: did the smoother recover the hidden drive in this trial? We project `posterior_mean` onto `intent_axis`, reducing each 3-dimensional smoothed state to the scalar drive of interest. Projecting each per-site covariance marginal along the same direction gives the variance of that scalar, so every estimate has an associated uncertainty.\n",
     "\n",
-    "Two facts limit what a good result here would prove. `intent_axis` is fixed in advance and is also the axis that defines the hidden labels, so the score and the labels are read along the very same direction, which is the friendliest arrangement possible, and on top of that we run a single seed. Together those two limits make this a check that the circuit and its conditioning recover a latent signal, rather than a measurement of how a detector would behave on data it had not been handed the answer to.\n",
+    "Two constraints limit the conclusion. First, `intent_axis` is fixed in advance and also defines the hidden labels, so the score and labels are read along the same direction. Second, the experiment uses a single seed. This is therefore a check that the circuit and conditioning recover a latent signal, not an estimate of detector performance on data for which the scoring direction was unknown.\n",
     "\n",
-    "The binary prediction uses the median of the complete smoothed trajectory as its threshold. Both that threshold and the smoothed posterior use future time bins, which makes this a retrospective full-trial analysis rather than anything you could run online.\n",
+    "The binary prediction uses the median of the complete smoothed trajectory as its threshold. Both the threshold and the smoothed posterior use future time bins, so this is a retrospective full-trial analysis rather than an online procedure.\n",
     "\n",
-    "The smoothed latent moments give us the posterior drive `posterior_drive` and its standard deviation `posterior_drive_std`."
+    "We begin by computing the posterior drive `posterior_drive` and its standard deviation `posterior_drive_std` from the smoothed latent moments."
    ]
   },
   {
@@ -1153,7 +1153,7 @@
    "id": "9e0c9cab",
    "metadata": {},
    "source": [
-    "The logistic transform is an uncalibrated display score centered on the full-trial median, so read it as an ordering rather than as a probability, keeping in mind that its 0.5 decision boundary is exactly `posterior_drive > detection_threshold`."
+    "We convert the drive to an uncalibrated display score with a logistic transform centered on the full-trial median. The score preserves the ordering of the drive but is not a probability, and its 0.5 decision boundary is exactly `posterior_drive > detection_threshold`."
    ]
   },
   {
@@ -1356,7 +1356,7 @@
    "id": "6c1a03b5",
    "metadata": {},
    "source": [
-    "Because each channel is a different row of `C`, the same drive appears with a different sign and amplitude in every trace, which is why recovery needs all six of them. The gray bands identify the active event steps used only for evaluation."
+    "Each trace corresponds to a different row of `C`, so the drive appears with different signs and amplitudes across the six channels. No channel is a clean view on its own. The gray bands show the active event steps, which are used only for evaluation."
    ]
   },
   {
@@ -1539,7 +1539,7 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We started with a drive we could not measure and six noisy channels that could, and we finished with one score per time step saying when that drive was active. Getting there took a time-homogeneous linear-Gaussian state-space model built in Torx and an offline score read from its exact smoothed posterior.\n",
+    "We began with a hidden drive observed through six noisy channels. A time-homogeneous linear-Gaussian model specified how that drive generated the observations; an explicitly unrolled Torx circuit represented the model; exact conditioning recovered the smoothed latent trajectory; and the final diagnostics compared that trajectory with the known synthetic truth.\n",
     "\n",
     "- The model is represented as 64 `AffineGaussianGate` instances, one initial gate plus one gate per transition and emission.\n",
     "- Transition and emission gates alias fixed `theta` dictionaries at inference time while the circuit remains explicitly unrolled, which keeps the sharing free to build but explicit to train.\n",

--- a/examples/12_langevin_graph_ising.ipynb
+++ b/examples/12_langevin_graph_ising.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We sample the continuous Boltzmann law of a soft-spin graph Ising energy with a custom <a href=\"#ref-parisi-1981\">overdamped-Langevin</a> <code>LangevinGate</code> driven through <code>HybridPCircuit.sample</code> inside a JAX scan. We validate the <a href=\"#ref-roberts-tweedie-1996\">Metropolis-adjusted (MALA)</a> chain against exact quadrature and compare it with the <a href=\"#ref-roberts-tweedie-1996\">unadjusted (ULA)</a> chain.</p>\n",
+    "<p>We use a custom <a href=\"#ref-parisi-1981\">overdamped-Langevin</a> <code>LangevinGate</code> to sample the continuous Boltzmann law of a soft-spin graph Ising energy. A JAX scan repeatedly calls <code>HybridPCircuit.sample</code>; on a tractable one-dimensional target, exact quadrature lets us validate the <a href=\"#ref-roberts-tweedie-1996\">Metropolis-adjusted (MALA)</a> chain and measure the step-size bias of the <a href=\"#ref-roberts-tweedie-1996\">unadjusted (ULA)</a> chain.</p>\n",
     "</div>"
    ]
   },
@@ -23,15 +23,15 @@
    "id": "ad1c0df6",
    "metadata": {},
    "source": [
-    "Overdamped Langevin dynamics is noisy gradient descent on an energy. Repeating the step $x \\leftarrow x - \\varepsilon\\,\\nabla V(x) + \\sqrt{2T\\varepsilon}\\,\\xi$ with $\\xi\\sim\\mathcal N(0,I)$ drives the state toward the Boltzmann law $\\pi(x)\\propto e^{-V(x)/T}$: samples concentrate where the energy $V$ is low, with spread set by the temperature $T$.\n",
+    "Each node in the graph carries a real-valued soft spin. Neighboring spins favor alignment, while an external field tilts the pattern, giving us a continuous-variable counterpart of an Ising sampler. We want samples from the resulting Boltzmann law, which assigns more probability to low-energy states while retaining temperature-dependent fluctuations.\n",
     "\n",
-    "Each node of a graph carries a real-valued soft spin. Neighboring nodes nudge each other toward alignment while an external field tilts the pattern, so this is a continuous-variable cousin of an Ising sampler.\n",
+    "Overdamped Langevin dynamics provides such a sampling procedure by combining gradient descent on the energy with Gaussian noise. Repeating the step $x \\leftarrow x - \\varepsilon\\,\\nabla V(x) + \\sqrt{2T\\varepsilon}\\,\\xi$ with $\\xi\\sim\\mathcal N(0,I)$ drives the state toward the Boltzmann law $\\pi(x)\\propto e^{-V(x)/T}$: the drift moves toward lower $V$, and the noise produces a spread controlled by the temperature $T$.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Langevin sampler vocabulary</summary><p>A pmode is a Torx continuous-valued site, and ULA takes every Langevin proposal while MALA applies a Metropolis accept/reject correction. A stationary law is a distribution unchanged by another update, and quadrature here means numerical integration on a grid.</p></details>\n",
     "\n",
-    "In this tutorial, we sample that Boltzmann law with `LangevinGate`. The gate is our own notebook code rather than a Torx API class. It implements Torx's `AbstractContinuousGate` interface, which is all a circuit needs in order to run it, and it lives in the helper module `examples/helpers/_langevin.py`, whose source we show below. Its `sample` method takes one gradient-drift step on the soft-spin energy, and we repeat `HybridPCircuit.sample` with `jax.lax.scan` in two modes, unadjusted (ULA) and Metropolis-adjusted (MALA), a difference the gate section below spells out in full.\n",
+    "We implement the update with `LangevinGate`, notebook code that satisfies Torx's `AbstractContinuousGate` interface and lives in `examples/helpers/_langevin.py`. Its `sample` method advances the soft-spin state by one gradient-drift step. We then use `jax.lax.scan` to repeat `HybridPCircuit.sample` in either unadjusted (ULA) or Metropolis-adjusted (MALA) mode.\n",
     "\n",
-    "Because the drift $\\nabla V$ is nonlinear, this gate has no closed-form affine-Gaussian channel, so we can't read off exact Gaussian moments the way a linear gate allows. Instead we validate the sampler where the target is tractable, a one-dimensional instance of the same energy whose Boltzmann density we obtain by fine-grid quadrature, and then deploy that same gate on the full graph.\n",
+    "The nonlinear drift $\\nabla V$ rules out the closed-form affine-Gaussian channel available for a linear gate, so exact Gaussian moments are not available as a reference. Instead, we first apply the same sampler to a one-dimensional instance of the energy, compute its Boltzmann density by fine-grid quadrature, and only then deploy the gate on the full graph.\n",
     "\n",
     "The main steps are:\n",
     "\n",
@@ -221,7 +221,7 @@
    "source": [
     "## The Langevin gate\n",
     "\n",
-    "Here's the gate itself. Because `LangevinGate` ships with the notebooks rather than with the Torx API, satisfying the `AbstractContinuousGate` interface is the only contract it has to meet: at run time the circuit passes each gate's `theta` to `sample` as `params`, and everything that happens inside `sample` is ours to write. The following is excerpted from `examples/helpers/_langevin.py`:\n",
+    "We begin with the transition implemented by `LangevinGate`. The class is supplied with these notebooks rather than by the Torx API; to participate in a circuit, it only needs to satisfy the `AbstractContinuousGate` interface. At run time, the circuit passes the gate's `theta` to `sample` as `params`, leaving the proposal and any correction step under the gate's control. The following excerpt comes from `examples/helpers/_langevin.py`:\n",
     "\n",
     "```python\n",
     "class LangevinGate(AbstractContinuousGate[dict[str, Array], tuple[int, ...]]):\n",
@@ -280,16 +280,16 @@
     "            output = jnp.where(accepted, proposal, x)\n",
     "```\n",
     "\n",
-    "`sample` takes one overdamped-Langevin step on the soft-spin energy above:\n",
+    "The proposal is one overdamped-Langevin step on the soft-spin energy:\n",
     "\n",
     "$$x' = x \\underbrace{-\\,\\varepsilon\\,\\nabla V(x)}_{\\vphantom{\\big|}\\text{gradient drift}} + \\underbrace{\\sqrt{2T\\varepsilon}\\,\\xi}_{\\vphantom{\\big|}\\text{Gaussian noise}},\\qquad \\xi\\sim\\mathcal N(0, I).$$\n",
     "\n",
-    "The gradient $\\nabla V$ is `jax.grad` applied to the gate's own `energy` method, so the gate descends the same energy it defines. Repeating the step drives the chain toward $\\pi(x)\\propto e^{-V(x)/T}$. The structural `metropolis` flag selects between two modes:\n",
+    "Here `jax.grad` differentiates the gate's own `energy` method, so the drift and the target $\\pi(x)\\propto e^{-V(x)/T}$ use the same potential. The static `metropolis` flag determines how the proposal becomes the next state:\n",
     "\n",
-    "- ULA (`metropolis=False`) returns the raw proposal. Discretizing the continuous dynamics leaves an $O(\\varepsilon)$ bias, so ULA samples a slightly wrong distribution.\n",
-    "- MALA (`metropolis=True`) accepts the proposal with the Metropolis-Hastings probability for $\\pi$ and otherwise stays put. The accept/reject step cancels the discretization bias, so MALA is asymptotically exact for $e^{-V/T}$.\n",
+    "- ULA (`metropolis=False`) always returns the proposal. Its discrete-time transition approximates the continuous Langevin dynamics and introduces an $O(\\varepsilon)$ bias in the stationary distribution.\n",
+    "- MALA (`metropolis=True`) evaluates the Metropolis-Hastings probability for $\\pi$ and either accepts the proposal or leaves the state unchanged. This correction removes the discretization bias, making the chain asymptotically exact for $e^{-V/T}$.\n",
     "\n",
-    "The energy coefficients and integrator constants travel in `theta`, exactly as `AffineGaussianGate` carries its $(A, b, \\log\\mathrm{var})$: `adj`, `field`, `beta`, `lam_quartic`, `step` ($\\varepsilon$), and `temperature` ($T$). Below we set the deploy-time constants and pack them into `theta` with the `langevin_theta` helper."
+    "The energy coefficients and integrator constants travel in `theta`, just as `AffineGaussianGate` carries its $(A, b, \\log\\mathrm{var})$. The entries are `adj`, `field`, `beta`, `lam_quartic`, `step` ($\\varepsilon$), and `temperature` ($T$). We next set the deployment values and package them with `langevin_theta`."
    ]
   },
   {
@@ -393,7 +393,7 @@
    "id": "0b2584aa",
    "metadata": {},
    "source": [
-    "The schematic below shows how little the circuit does per step. One step is a single custom gate acting on the whole vector pmode $x\\in\\mathbb{R}^{10}$, so the compact bus stands for all ten coupled coordinates, and the scan executes this one-step Torx circuit `reps` times."
+    "The schematic makes the repeated computation explicit. Each step applies one custom gate to the entire vector pmode $x\\in\\mathbb{R}^{10}$; the compact bus therefore represents all ten coupled coordinates rather than ten independent transitions. The scan repeats this one-step Torx circuit `reps` times."
    ]
   },
   {
@@ -444,11 +444,11 @@
    "source": [
     "## Validating against an exact reference\n",
     "\n",
-    "Because $\\nabla V$ is nonlinear, the gate has no affine-Gaussian channel and no closed-form Gaussian moments to check against. We validate the sampler where the target is tractable instead: a single soft spin in the same quartic double-well with a field bias (the couplings switched off), whose Boltzmann density $\\pi(x)\\propto e^{-V(x)/T}$ we obtain by fine-grid quadrature.\n",
+    "The nonlinear gradient $\\nabla V$ gives the gate neither an affine-Gaussian channel nor closed-form Gaussian moments. We therefore validate it on a tractable restriction of the same model: one soft spin in the quartic double well, with a field bias and the couplings switched off. On this one-dimensional problem, fine-grid quadrature gives the Boltzmann density $\\pi(x)\\propto e^{-V(x)/T}$ directly.\n",
     "\n",
-    "This exercises the same `sample` code path as the graph run below (gradient drift plus, for MALA, the Metropolis accept/reject), and only the energy coefficients differ. Matching the 1-D reference therefore validates the proposal-and-acceptance machinery against an exact target. The deployed 10-D chain has no tractable reference of its own, so we check it separately against a long MALA run further down.\n",
+    "This comparison exercises the same `sample` implementation used for the graph: both modes use the gradient-drift proposal, and MALA adds the same Metropolis accept/reject calculation. Only the energy coefficients change. Agreement with the one-dimensional reference can therefore test the proposal and acceptance machinery against an exact target, but it cannot establish convergence of the deployed 10-D chain. We address that separate question later by comparing its per-site means with a much longer MALA run.\n",
     "\n",
-    "To isolate the step-size bias from mixing, we hold the total simulated time $T_{\\mathrm{sim}} = \\texttt{reps}\\times\\varepsilon$ fixed across the sweep, so every chain integrates the same amount of dynamics and only the discretization changes."
+    "To separate discretization error from the amount of simulated dynamics, we fix $T_{\\mathrm{sim}} = \\texttt{reps}\\times\\varepsilon$ throughout the step-size sweep. Every chain then covers the same simulated time while $\\varepsilon$ controls the discretization."
    ]
   },
   {
@@ -601,7 +601,7 @@
    "id": "3022e939",
    "metadata": {},
    "source": [
-    "The first panel asks the most basic question: does the Metropolis-adjusted chain reach the right target at all? It does. The MALA histogram sits on top of the exact Boltzmann density, which tells us that with the accept/reject step the chain samples $\\pi(x)\\propto e^{-V(x)/T}$ to within Monte Carlo noise."
+    "The first panel compares the adjusted transition with the exact target at $\\varepsilon=\\texttt{EPS_MATCH}$. It overlays the MALA histogram with the quadrature Boltzmann density and reports their KS distance. The close overlap and small KS distance show no visible mismatch at this finite-sample resolution; they do not remove the Monte Carlo uncertainty in the histogram."
    ]
   },
   {
@@ -647,7 +647,7 @@
    "id": "e6c3e19e",
    "metadata": {},
    "source": [
-    "The next panel shows what the accept/reject step buys us. At a coarse step the unadjusted chain (ULA) underweights the main mode and overfills the trough relative to the exact density, while MALA, which runs the identical proposal plus accept/reject, stays on the target. That accept/reject step is what removes the bias."
+    "The coarse-step comparison isolates the effect of the Metropolis correction. ULA and MALA use the same Langevin proposal, but ULA accepts every proposal whereas MALA may reject one. In the panel, ULA underweights the main mode and overfills the trough relative to the exact density; MALA remains aligned with the reference. The difference is the discretization bias removed by the accept/reject step."
    ]
   },
   {
@@ -745,7 +745,7 @@
    "source": [
     "## Sampling the full graph\n",
     "\n",
-    "The 1-D checks validate the sampler's machinery on an exact target. We now deploy that gate on the full 10-node energy: `NUM_SAMPLES` independent chains, each `DEPLOY_REPS` Metropolis-adjusted steps from the zero state, returned in one JIT-compiled pass."
+    "The one-dimensional experiment validates the transition machinery where an exact target is available. We now use the same MALA gate for the full 10-node energy. The computation advances `NUM_SAMPLES` independent chains from the zero state for `DEPLOY_REPS` Metropolis-adjusted steps and returns their terminal states in one JIT-compiled pass."
    ]
   },
   {
@@ -784,7 +784,7 @@
    "id": "6a767600",
    "metadata": {},
    "source": [
-    "Are `DEPLOY_REPS` steps enough? With no tractable reference in ten dimensions, we compare per-site mean soft spins $\\langle\\tanh x_i\\rangle$ against a much longer MALA run. Site-specific Monte Carlo error bars and standardized residuals, meaning each site's difference divided by its own standard error, make this a finite-sample convergence sanity check rather than proof of stationarity."
+    "The ten-dimensional target has no tractable quadrature reference, so `DEPLOY_REPS` cannot be assessed by the same exact-density comparison. Instead, we compare the deployed per-site mean soft spins $\\langle\\tanh x_i\\rangle$ with estimates from a much longer MALA run. Site-specific Monte Carlo error bars account for the uncertainty in each pair of estimates, while the standardized residual at a site is its absolute difference divided by its own standard error. This is a finite-sample convergence sanity check: agreement with the longer run is useful evidence, but it is not a proof of stationarity."
    ]
   },
   {
@@ -880,7 +880,7 @@
    "id": "384c41b1",
    "metadata": {},
    "source": [
-    "The labeled, site-specific error bars show where the deployed and long-run estimates differ, and the printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ names the worst standardized residual, which is the one site to look at if any of them hasn't settled."
+    "The parity plot labels each site and gives both estimates site-specific error bars, allowing the deployed and long-run means to be compared on the scale of their Monte Carlo uncertainty. The printed maximum $|\\Delta_i|/\\mathrm{SE}_i$ identifies the worst standardized residual and therefore the site at which the two runs disagree most strongly."
    ]
   },
   {
@@ -890,9 +890,9 @@
    "source": [
     "## Terminal field and magnetization\n",
     "\n",
-    "With the chain deployed, the question becomes what pattern it settled into, so we summarize the terminal samples two ways: as a soft-spin field on the graph and as a magnetization distribution across paths.\n",
+    "We summarize the deployed terminal samples at two levels. The graph view reports the mean soft spin $\\tanh(x_i)$ at each site, while the magnetization distribution retains the variation across sampled paths.\n",
     "\n",
-    "The graph view shows the mean soft spin $\\tanh(x_i)$ over `NUM_SAMPLES` samples on the graph, drawn with a diverging colormap because magnetization is signed and the sign is what we want to read at a glance. The cell below computes both summaries from the terminal states."
+    "In the graph view, a diverging colormap encodes the sign and magnitude of the mean soft spin over `NUM_SAMPLES` terminal states. This makes the response to the signed external field visible site by site. The next cell computes both the site means and the per-path magnetizations from the same terminal samples."
    ]
   },
   {
@@ -1010,7 +1010,7 @@
    "id": "6028d177",
    "metadata": {},
    "source": [
-    "For these parameters the sampled per-path magnetization is broad, and its empirical mean comes out near zero (-0.001). It would be easy to read that as a symmetry result, but the zero-sum external field doesn't by itself force zero net magnetization, so a near-zero mean here is something we observed rather than something the setup guarantees. The graph colors report the observed site-specific response behind that average."
+    "For these parameters, the sampled per-path magnetization is broad and has an empirical mean near zero (-0.001). This value should not be interpreted as a symmetry requirement: a zero-sum external field does not by itself force the net magnetization to vanish. The histogram and graph colors report an empirical finite-sample outcome, with the graph exposing the site-specific responses hidden by the aggregate mean."
    ]
   },
   {
@@ -1020,9 +1020,9 @@
    "source": [
     "## Energy relaxation diagnostic\n",
     "\n",
-    "Every figure so far has looked at where the chains ended up. Here we instead watch one MALA path while it runs, recording its own energy $V(x_t)$ at each step. Starting from $x = 0$ every term except the quartic well vanishes, so we know the starting height exactly: $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. The trace shows relaxation from that initial state, but we don't use 500 steps to claim stationarity.\n",
+    "Terminal-state summaries do not show how a chain approached its endpoint. We therefore record the energy $V(x_t)$ along one MALA path. The path starts at $x = 0$, where every term except the quartic well vanishes, so its initial energy is known exactly: $V(x_0) = \\tfrac{\\lambda_q}{4}\\,n$. A decline from this level demonstrates relaxation from the chosen initial state; a 500-step trace is not sufficient to establish stationarity.\n",
     "\n",
-    "We call the custom `LangevinGate` directly here rather than going through the terminal-state circuit, because only the direct call lets us record every intermediate state. One compiled scan collects $V(x_t)$ and the acceptance rate."
+    "For this diagnostic, we call the custom `LangevinGate` directly rather than using the terminal-state circuit, because the direct call exposes every intermediate state. One compiled scan records $V(x_t)$ together with the acceptance rate."
    ]
   },
   {
@@ -1125,7 +1125,7 @@
    "id": "1122bb83",
    "metadata": {},
    "source": [
-    "The trace drops below its initial energy while continuing to drift late in the run, which is why the dashed line is only the last-100-step mean, a compact relaxation diagnostic rather than an equilibrium estimate."
+    "The trace falls below its initial energy but continues to drift late in the run. Accordingly, the dashed line denotes only the mean over the last 100 steps. It summarizes the late part of this path as a relaxation diagnostic and is not an equilibrium-energy estimate."
    ]
   },
   {
@@ -1216,11 +1216,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We sampled the continuous Boltzmann law of a soft-spin graph Ising energy with a custom `LangevinGate`.\n",
+    "We used a custom `LangevinGate` to sample the continuous Boltzmann law of a soft-spin graph Ising energy. The gate computes the gradient of $V$ with `jax.grad`, advances the state by one Langevin proposal, and optionally applies the Metropolis correction. A JAX scan repeats the Torx `HybridPCircuit.sample` transition, while `jax.vmap` batches independent chains in one JIT-compiled pass.\n",
     "\n",
-    "The gate takes one gradient-drift step on $V$, with the gradient computed by `jax.grad` inside `sample`. A JAX scan repeats that Torx `HybridPCircuit.sample` transition, and `jax.vmap` batches independent chains in one JIT-compiled pass. On a tractable 1-D instance, the Metropolis-adjusted chain matched the exact quadrature density, and the step-size sweep quantified the ULA bias it removes. On the full graph we compared the deployed per-site means against a much longer run with site-specific error bars, and we report the single-path energy trace only as a relaxation diagnostic.\n",
+    "The validation separates questions that require different evidence. On the tractable one-dimensional model, the finite MALA sample was consistent with the exact quadrature density, and the step-size sweep exposed the $O(\\varepsilon)$ bias of ULA. On the full graph, where exact quadrature is unavailable, per-site means from the deployed chains were compared with a much longer run using site-specific Monte Carlo errors. The single-path energy trace established relaxation from the zero state but was not treated as evidence of equilibrium.\n",
     "\n",
-    "Because the drift is nonlinear, the gate forfeits the closed-form affine-Gaussian moment simulator, so the tractable reference and finite-sample diagnostics expose distinct parts of the computation.\n",
+    "Because the nonlinear drift does not admit a closed-form affine-Gaussian moment simulator, these checks cover distinct limitations rather than replacing one another: exact low-dimensional validation tests the transition, and finite-sample deployment diagnostics characterize the observed run.\n",
     "\n",
     "Next, [`13_regime_switching_diffusion.ipynb`](13_regime_switching_diffusion.ipynb) drives a Gaussian process with a discrete control pdit.\n",
     "\n",

--- a/examples/13_regime_switching_diffusion.ipynb
+++ b/examples/13_regime_switching_diffusion.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We let a discrete regime cycle on a pdit, Torx's d-state site, choose which Gaussian law generates the next position increment, which gives a regime-switching diffusion sampler whose only jumps are the latent regime switches. Because every piece of one step has a closed form, we can hold the sampler to analytic references for the regime-conditioned laws, the stationary occupancy, and the terminal mean.</p>\n",
+    "<p>We let a discrete regime cycle on a pdit, Torx's d-state site, and use its state to choose the Gaussian law for the next position increment. This gives a regime-switching diffusion sampler whose only jumps are the latent regime switches; because each part of one step has a closed form, we can compare the regime-conditioned laws, stationary occupancy, and terminal mean with analytic references.</p>\n",
     "</div>"
    ]
   },
@@ -23,21 +23,21 @@
    "id": "d007a3d4",
    "metadata": {},
    "source": [
-    "A **[regime-switching (Markov-modulated) diffusion](#ref-yin-zhu-2010)** is a continuous motion whose behavior changes when a hidden discrete state switches. In this tutorial we build one with Torx: the position $X_t$ drifts and diffuses according to a latent regime $S_t$, and only the regime jumps. Because $X_t$ has no discontinuous jump term of its own, this is a latent-jump controlled diffusion rather than a jump-diffusion in $X$.\n",
+    "A **[regime-switching (Markov-modulated) diffusion](#ref-yin-zhu-2010)** couples continuous motion to a hidden discrete state. In the model we build here, the latent regime $S_t$ selects the drift and diffusion of the position $X_t$, while only $S_t$ jumps. Thus, $X_t$ is a latent-jump controlled diffusion rather than a jump-diffusion with discontinuities in $X$ itself.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Torx sites and time stepping</summary><p>A pdit is a Torx discrete-valued site, while a pmode is a continuous-valued site. A generator gives the infinitesimal rule, and an <a href=\"#ref-kloeden-platen-1992\">Euler step</a> with a <a href=\"#ref-trotter-1959\">Lie-Trotter split</a> approximates it by applying small regime and position updates in sequence.</p></details>\n",
     "\n",
-    "The regime follows a discrete Markov chain, and when it switches the next position increment comes from a different Gaussian law, so the model needs exactly two moving parts: something to advance the regime and something to draw a regime-dependent increment. We assemble those from `PditCycle` and `MixtureGaussianGate`. Torx also ships a binary-firing `torx.psc.JumpDiffusionGate`, but that gate puts jumps in $X$ itself, which is a different model, so we don't use it here.\n",
+    "This description suggests two separate updates: advance the discrete Markov chain, then draw a Gaussian increment whose parameters depend on the resulting regime. We implement them with `PditCycle` and `MixtureGaussianGate`. Torx also provides the binary-firing `torx.psc.JumpDiffusionGate`, but that gate introduces jumps in $X$ itself and therefore represents a different model.\n",
     "\n",
-    "This pattern appears in regime-switching finance, neural spike trains, and other systems where a continuous signal changes its noise level because an unobserved state has changed. Conditioned on the current regime a Gaussian gate gives a Gaussian step, while marginalizing the regime generally gives a non-Gaussian mixture.\n",
+    "The same pattern appears in regime-switching finance, neural spike trains, and other systems where an unobserved state changes the local drift or noise level of a continuous signal. Once we condition on the regime, the Gaussian gate produces a Gaussian step; after we marginalize the regime, the transition law is generally a non-Gaussian mixture.\n",
     "\n",
-    "The main steps are:\n",
+    "We will construct and check the sampler in three stages:\n",
     "\n",
-    "1. advance a 3-state regime with `PditCycle`, then add a regime-conditioned Gaussian step with `MixtureGaussianGate`,\n",
-    "2. compose the two gates into one Euler step with `HybridPCircuit`, then scan it into joint discrete and continuous sample paths, and\n",
-    "3. check the one-step mixture law and occupancy, then compare the terminal mean with an exact reference for the discretized Torx chain.\n",
+    "1. advance a 3-state regime with `PditCycle`, then apply a regime-conditioned Gaussian increment with `MixtureGaussianGate`,\n",
+    "2. compose the gates into one Euler step with `HybridPCircuit` and scan that step into joint discrete and continuous sample paths, and\n",
+    "3. compare the one-step mixture law and occupancy with their references, then compare the terminal mean with an exact reference for the discretized Torx chain.\n",
     "\n",
-    "The same `MixtureGaussianGate` primitive appears in [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb), and [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb) builds a custom nonlinear Langevin gate on the same continuous `pmode` site."
+    "The continuous update uses the same `MixtureGaussianGate` primitive as [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb). For comparison, [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb) constructs a custom nonlinear Langevin gate on the same continuous `pmode` site."
    ]
   },
   {
@@ -189,41 +189,37 @@
    "source": [
     "## The process and its gates\n",
     "\n",
-    "We start from the process we want to sample, because both Torx gates can be read straight off it.\n",
-    "\n",
-    "The target is a regime-switching stochastic differential equation (SDE): a position $X_t$ whose drift and volatility are both set by a latent regime $S_t$, which is itself a continuous-time Markov chain.\n",
+    "We begin with the process we want to sample, since its two terms determine the Torx gates directly. The position $X_t$ follows a regime-switching stochastic differential equation (SDE): both its drift and volatility are selected by a latent regime $S_t$, which evolves as a continuous-time Markov chain.\n",
     "\n",
     "$$\n",
     "dX_t = \\underbrace{\\mu_{S_t}\\,dt}_{\\vphantom{\\big|}\\text{drift}} + \\underbrace{\\sigma_{S_t}\\,dW_t}_{\\vphantom{\\big|}\\text{diffusion}}.\n",
     "$$\n",
     "\n",
-    "Here $W_t$ is a standard Wiener (Brownian) process, and the current regime selects $(\\mu, \\sigma)$ for the continuous increment.\n",
+    "Here $W_t$ is a standard Wiener (Brownian) process. Conditioning on $S_t$ selects one pair $(\\mu, \\sigma)$ and therefore one local Gaussian law for the continuous increment.\n",
     "\n",
-    "To simulate this on a grid of step $\\Delta t$ we need a discrete stand-in for that regime chain, and `PditCycle` is exactly its $O(\\Delta t)$ [Euler discretization](#ref-kloeden-platen-1992), with switch probabilities linear in $\\Delta t$.\n",
+    "To simulate the process on a grid with step $\\Delta t$, we first need a discrete approximation to the regime chain. `PditCycle` supplies its $O(\\Delta t)$ [Euler discretization](#ref-kloeden-platen-1992), with switching probabilities that are linear in $\\Delta t$.\n",
     "\n",
-    "Letting a discrete state pick the increment changes the transition kernel: the increment is Gaussian once we condition on a regime, but marginalizing over an unobserved regime turns it into a mixture of Gaussians.\n",
+    "The discrete state changes the continuous transition kernel. Conditioned on a regime, the increment is Gaussian; if the regime is unobserved and marginalized out, the same increment follows a mixture of Gaussians.\n",
     "\n",
-    "That leaves the question of how to interleave the two updates. The generator, the operator describing how the distribution changes over an instant, splits into a regime part and a position part, $A = A_S + A_X$, and the two pieces don't commute, so the order of the approximation matters.\n",
-    "\n",
-    "One Trotter step applies them in sequence: switch the regime first, then take the position step under the new regime. This is the [Lie-Trotter split](#ref-trotter-1959), whose local one-step error is $O(\\Delta t^2)$, giving first-order $O(\\Delta t)$ global error over the full interval.\n",
+    "We must also choose how to interleave the discrete and continuous updates. The infinitesimal generator splits into a regime part and a position part, $A = A_S + A_X$, and these operators do not commute. We therefore approximate their joint evolution by applying the regime update first and the position update second. This [Lie-Trotter split](#ref-trotter-1959) has local one-step error $O(\\Delta t^2)$ and first-order global error $O(\\Delta t)$ over the full interval.\n",
     "\n",
     "$$\n",
     "T_{\\text{Trotter}}(\\Delta t) = \\underbrace{T_{\\text{MoG}}(\\Delta t)}_{\\vphantom{\\big|}\\text{position step}}\\, \\underbrace{T_{\\text{PditCycle}}(\\Delta t)}_{\\vphantom{\\big|}\\text{regime switch}}.\n",
     "$$\n",
     "\n",
-    "Reading that product right to left, `PditCycle` runs first and advances the regime on a cyclic 3-state chain. At each step of size $\\Delta t$ it:\n",
+    "Operator products act from right to left, so `PditCycle` advances the regime before the Gaussian update is applied. For the cyclic 3-state chain, one step of size $\\Delta t$:\n",
     "\n",
     "- moves forward with probability $p_+ = \\lambda_+\\Delta t$,\n",
     "- moves backward with probability $p_- = \\lambda_-\\Delta t$, and\n",
     "- stays put with probability $p_0 = 1 - p_+ - p_-$.\n",
     "\n",
-    "`MixtureGaussianGate` then applies the increment belonging to whichever regime the chain just switched into:\n",
+    "After the chain switches, `MixtureGaussianGate` applies the increment associated with the new regime:\n",
     "\n",
     "$$\n",
     "X' = X + \\mu_k\\,\\Delta t + \\sigma_k\\sqrt{\\Delta t}\\,\\mathcal{N}(0,1)\\quad\\text{when } S = k .\n",
     "$$\n",
     "\n",
-    "Throughout we use $K=3$ regimes with $\\mu = (1.0,\\,0.0,\\,-0.8)$, $\\sigma = (0.3,\\,1.0,\\,0.5)$, and rates $\\lambda_+ = 0.5$ and $\\lambda_- = 0.3$."
+    "We use $K=3$ regimes, with $\\mu = (1.0,\\,0.0,\\,-0.8)$ and $\\sigma = (0.3,\\,1.0,\\,0.5)$. The forward and backward switching rates are $\\lambda_+ = 0.5$ and $\\lambda_- = 0.3$."
    ]
   },
   {
@@ -418,7 +414,7 @@
    "id": "c4220bc0",
    "metadata": {},
    "source": [
-    "The point to take from the drawing is that every switch moves one place around the ring, forward or backward. For $K=3$ both non-self states are nearest neighbors, so one step can reach either of them. On larger rings the same gate would permit only nearest-neighbor moves."
+    "Every displayed transition moves one place around the ring, either forward or backward. When $K=3$, both non-self states are nearest neighbors and either can be reached in one step; on a larger ring, the same gate would still permit only nearest-neighbor moves."
    ]
   },
   {
@@ -641,15 +637,15 @@
    "source": [
     "## The one-step transition density\n",
     "\n",
-    "A 120-step path is only as trustworthy as one step, so we check a single step first, where the answer is known exactly.\n",
+    "Before interpreting a 120-step path, we check one application of the circuit, for which the transition law is known exactly.\n",
     "\n",
-    "One application of `PditCycle` followed by `MixtureGaussianGate` produces a Gaussian mixture. Conditioning on the new regime $k$ gives the Gaussian increment $\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$, while marginalizing over regimes (averaging across all possible regimes) with the stationary weights $\\pi = (1/3, 1/3, 1/3)$ gives $\\Delta x \\sim \\sum_k \\pi_k\\,\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$.\n",
+    "Applying `PditCycle` and then `MixtureGaussianGate` produces a Gaussian mixture. Conditional on the updated regime $k$, the increment is $\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$. Marginalizing over regimes with stationary weights $\\pi = (1/3, 1/3, 1/3)$ gives $\\Delta x \\sim \\sum_k \\pi_k\\,\\mathcal{N}(\\mu_k\\Delta t,\\,\\sigma_k^2\\Delta t)$.\n",
     "\n",
-    "That mixture is the right target only if our sampling scheme really does draw regimes with the stationary weights, and it does. The pooled sample below starts equally often from each regime, and because this `PditCycle` chain is doubly stochastic (rows and columns each sum to 1), a uniform start stays uniform after one step, so pooling per-regime samples reproduces the stationary marginal.\n",
+    "This mixture is the correct pooled target because the sampling scheme preserves those weights. We start equally often from each regime, and the `PditCycle` transition matrix is doubly stochastic: every row and every column sums to 1. A uniform starting distribution therefore remains uniform after one step, so pooling the per-regime samples reproduces the stationary marginal.\n",
     "\n",
-    "The mixture is also where the discrete site earns its place. Compositions of affine Gaussian gates preserve Gaussianity, so it's the act of selecting among unequal Gaussian components with a discrete regime that generally produces a non-Gaussian law.\n",
+    "The discrete selection is also what changes the family of the marginal law. Composing affine Gaussian gates preserves Gaussianity, whereas selecting among unequal Gaussian components with a discrete regime generally produces a non-Gaussian mixture.\n",
     "\n",
-    "As a check, we sample the one-step increments $\\Delta x$ from each starting regime and compare them with the analytic densities."
+    "We now sample one-step increments $\\Delta x$ from each starting regime and compare the samples with these analytic densities."
    ]
   },
   {
@@ -895,7 +891,7 @@
    "id": "bba6f9ab",
    "metadata": {},
    "source": [
-    "Each histogram follows its analytic curve, which is the observation that matters here. Regimes 0 and 2 give narrow conditional Gaussians while regime 1 gives a wide one, and because the stationary marginal blends all three, it's wider than the sharpest conditional."
+    "The conditional histograms follow their analytic Gaussian curves: regimes 0 and 2 are narrow, while regime 1 is wider. The stationary marginal blends all three components and is therefore wider than the sharpest conditional law. These overlays reveal the overall agreement, but they do not by themselves quantify discrepancies in the tails."
    ]
   },
   {
@@ -1262,11 +1258,11 @@
    "source": [
     "## Verification\n",
     "\n",
-    "Two questions are left. Has the regime chain settled, and is the sampled terminal mean correct?\n",
+    "Two properties remain to be checked: whether the regime chain has settled and whether the sampled terminal mean matches the process that the circuit discretizes.\n",
     "\n",
-    "For the first, we read the back half of the occupancy traces, the steps past $T/2$, which should sit near the uniform stationary distribution once the chain has mixed.\n",
+    "For occupancy, we average the back half of the traces, corresponding to times past $T/2$. Once the chain has mixed, these values should be close to the uniform stationary distribution.\n",
     "\n",
-    "For the second, we compare the sampled terminal mean against three references, each answering a different question. A transition matrix we assemble by hand from the same stated one-step probabilities gives the exact answer for the discretized Torx chain we actually run, so it isolates sampling error. A half-timestep propagation and the exact continuous-time Markov-chain mean then show how much of the remaining gap comes from the timestep itself rather than from sampling."
+    "For the terminal mean, we use three references that separate sampling error from timestep error. A transition matrix assembled by hand from the stated one-step probabilities gives the exact mean for the discretized Torx chain and therefore isolates sampling error. Propagating the same construction at half the timestep, and solving the continuous-time Markov chain exactly, show how the discrete reference changes as $\\Delta t$ is refined."
    ]
   },
   {
@@ -1474,13 +1470,13 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We built a regime-switching diffusion where a pdit-controlled Gaussian mixture gate turns affine Gaussian conditional steps into a generally non-Gaussian marginal.\n",
+    "We constructed a regime-switching diffusion by coupling a cyclic pdit chain to a regime-conditioned Gaussian update. Conditioned on the regime, each continuous step is affine Gaussian; after the discrete state is marginalized out, the same transition is generally a non-Gaussian mixture.\n",
     "\n",
-    "`PditCycle` advances the 3-state regime chain with first-order transition probabilities, and `MixtureGaussianGate` draws the regime-conditioned position increment. `HybridPCircuit` composes the gates into one Euler step, and a jit-compiled `scan` and `vmap` around `circuit.sample` run 20,000 paths over 120 steps.\n",
+    "`PditCycle` advances the 3-state chain with first-order transition probabilities, and `MixtureGaussianGate` draws the corresponding position increment. Their order inside `HybridPCircuit` implements a Lie-Trotter Euler step. A jit-compiled `scan` repeats that step 120 times, while `vmap` batches 20,000 independent paths.\n",
     "\n",
-    "Three checks support that construction. The one-step samples match their conditional and stationary-mixture laws, with the largest KS D at 0.0101 against a sampling tolerance of 0.0354. The back-half occupancy comes within 0.0014 of the uniform stationary distribution. The sampled terminal mean of $+1.4295$ reproduces the exact discretized-chain reference of $+1.4052$ to about one standard error of 0.024, while the independent half-step reference at $+1.4441$ and the exact continuous-time value at $+1.4830$ expose rather than hide the timestep error.\n",
+    "The checks distinguish the sampler's law from the error introduced by time discretization. The one-step samples match the conditional and stationary-mixture laws, with the largest KS D at 0.0101 against a sampling tolerance of 0.0354, and the back-half occupancy comes within 0.0014 of the uniform stationary distribution. The sampled terminal mean of $+1.4295$ agrees with the exact discretized-chain reference of $+1.4052$ to about one standard error of 0.024. The independent half-step value $+1.4441$ and exact continuous-time value $+1.4830$ then show the remaining timestep error rather than folding it into the sampling check.\n",
     "\n",
-    "See also:\n",
+    "For related constructions, see:\n",
     "- [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb), affine Gaussian gates and exact moment propagation.\n",
     "- [`12_langevin_graph_ising.ipynb`](12_langevin_graph_ising.ipynb), a custom nonlinear Langevin gate sampling a soft-spin energy.\n",
     "\n",

--- a/examples/14_gaussian_bernoulli_clustering.ipynb
+++ b/examples/14_gaussian_bernoulli_clustering.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We learn to read a Gaussian mixture as a Boltzmann machine: one joint energy over a continuous visible vector and a categorical hidden unit. Fixing the visible vector turns that energy into a softmax over cluster labels, the responsibilities, and fixing the label turns it into a Gaussian, so those two conditionals are the whole model. We use the softmax to recover the clusters, where hard assignments exceed 99%, and then alternate the two conditionals in a Gibbs chain whose occupancy relaxes to the mixture weights.</p>\n",
+    "<p>A Gaussian mixture can be read as one joint energy over a continuous visible vector and a categorical hidden unit. Fixing the visible vector gives a softmax over cluster labels—the responsibilities—while fixing the label gives the corresponding Gaussian. We use these two conditionals to recover clusters with hard assignments above 99%, and then alternate them in a Gibbs chain whose occupancy relaxes to the mixture weights.</p>\n",
     "</div>"
    ]
   },
@@ -23,13 +23,13 @@
    "id": "930b6ce7",
    "metadata": {},
    "source": [
-    "In this tutorial, we write a Gaussian mixture as one energy function and run it as a **Boltzmann machine** [(Ackley et al. 1985)](#ref-ackley-1985). One categorical hidden unit chooses the cluster, and a Gaussian visible vector describes points drawn from that cluster, so the whole model is a single energy with two kinds of variable inside it.\n",
+    "Many clustering problems combine a continuous observation with an unobserved choice of component. How can one model support both assigning an observed point to a cluster and generating a new point from a chosen cluster? In this tutorial, we answer that question by writing a Gaussian mixture as one energy function and reading it as a **Boltzmann machine** [(Ackley et al. 1985)](#ref-ackley-1985).\n",
     "\n",
-    "In Torx, the model uses the [continuous `pmode` and categorical `pdit`](01_introduction_to_parametrised_stochastic_circuits.ipynb) data primitives. The `pmode` carries the visible vector $v$, and the $K$-state `pdit` carries the one-hot hidden state $h$. We derive the joint Boltzmann kernel $p(v,h)\\propto e^{-E(v,h)}$ on paper and then execute it through its two conditionals, which is why the code carries the parameters $(\\mu_k,\\Sigma_k,\\pi_k)$ rather than a single joint Torx energy object.\n",
+    "The model has two variables. A Gaussian visible vector $v$ represents the observation, and a categorical hidden state $h$ selects its component. In Torx, these are carried by the [continuous `pmode` and categorical `pdit`](01_introduction_to_parametrised_stochastic_circuits.ipynb) data primitives. The $K$-state `pdit` makes $h$ one-hot, so exactly one cluster is active at a time.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: pmode and pdit</summary><p>A <code>pmode</code> is continuous-valued, while a <code>pdit</code> stores one of $K$ discrete states. The categorical state $k$ corresponds to the one-hot vector $e_k$ in the derivation.</p></details>\n",
     "\n",
-    "The hidden unit is one-hot by construction, so exactly one cluster is active at a time.\n",
+    "We first derive the joint Boltzmann kernel $p(v,h)\\propto e^{-E(v,h)}$. We then execute the model through its two conditionals, which is why the code carries $(\\mu_k,\\Sigma_k,\\pi_k)$ rather than constructing a single joint Torx energy object.\n",
     "\n",
     "The main steps are:\n",
     "\n",
@@ -145,21 +145,21 @@
    "source": [
     "## One energy for a visible vector and a one-hot hidden\n",
     "\n",
-    "Our aim in this section is to see that a Gaussian mixture is already a Boltzmann machine, because one energy over a continuous visible vector and one categorical hidden state generates both the cluster probabilities and the per-cluster Gaussians we use later. For diagonal component variances, the Gaussian-mixture energy used by the code is\n",
+    "A Gaussian mixture is usually introduced as a weighted sum of component densities. To express the same model as a Boltzmann machine, we introduce a one-hot hidden state $h$ that selects one component. For diagonal component variances, the energy used by the code is\n",
     "\n",
     "$$\n",
     "E(v,h)=\\sum_k h_k\\left[\\frac{1}{2}\\sum_i\\frac{(v_i-\\mu_{ki})^2}{\\sigma_{ki}^2}+\\frac{1}{2}\\sum_i\\log\\sigma_{ki}^2-\\log\\pi_k\\right],\\qquad p(v,h)\\propto e^{-E(v,h)}.\n",
     "$$\n",
     "\n",
-    "The $k$-independent Gaussian normalizer is omitted, since it cancels in every comparison across clusters that follows. The hidden state is one-hot by construction:\n",
+    "The $k$-independent Gaussian normalizer is omitted because it cancels in every comparison across clusters below. The hidden state satisfies\n",
     "\n",
     "$$\n",
     "\\sum_k h_k=1,\\qquad h_k\\in\\{0,1\\},\n",
     "$$\n",
     "\n",
-    "so $h$ is one of the $K$ basis states $e_k$.\n",
+    "so $h$ must be one of the $K$ basis states $e_k$. This single energy therefore contains both the continuous observation and the categorical component choice.\n",
     "\n",
-    "Written that way the energy still looks specific to mixtures, so we rewrite it once to show that it's an ordinary Boltzmann machine with linear couplings between the visible and hidden units. For shared $\\sigma_i$ the same energy is\n",
+    "How does this mixture energy relate to the usual visible-hidden coupling of a Boltzmann machine? When the components share $\\sigma_i$, we can rewrite it as\n",
     "\n",
     "$$\n",
     "E(v,h)=\\sum_i\\frac{(v_i-a_i)^2}{2\\sigma_i^2}-\\sum_k c_k h_k-\\sum_{i,k}\\frac{v_i}{\\sigma_i}W_{ik}h_k+\\text{constant},\n",
@@ -172,13 +172,11 @@
     "c_k=\\log\\pi_k-a^\\top\\operatorname{diag}(\\sigma)^{-1}W_{:k}-\\frac{1}{2}\\lVert W_{:k}\\rVert^2,\n",
     "$$\n",
     "\n",
-    "up to one $k$-independent additive constant. The bias $c_k$ alone isn't the log mixture weight, because completing the square contributes the other two terms. The code never needs $W$, since it works with $(\\mu_k,\\Sigma_k,\\pi_k)$ throughout, but this equivalence is what licenses calling the model a Boltzmann machine at all.\n",
+    "up to one $k$-independent additive constant. Completing the square contributes the last two terms in the expression for $c_k$, so the bias $c_k$ alone is not the log mixture weight. The code does not need $W$ because it works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, but the reparameterization shows that the Gaussian mixture has the standard linear visible-hidden coupling.\n",
     "\n",
-    "There are two ways to hold $h$ to a one-hot state. Structurally, a single $K$-state `pdit` represents the $K$ cluster choices and nothing else. Energetically, a penalty over $K$ binary units makes the one-hot configurations the ground states. This tutorial takes the structural route, and the closing section builds the energetic one so we can compare the exact categorical constraint against a winner-take-all penalty at finite strength.\n",
+    "One modeling choice remains: how should we enforce the one-hot state? A single $K$-state `pdit` imposes the constraint structurally by representing only the $K$ valid choices. Alternatively, a penalty over $K$ binary units can make the one-hot configurations the ground states. We use the structural representation first, then return to the energetic construction at the end to compare an exact categorical constraint with a winner-take-all penalty of finite strength.\n",
     "\n",
-    "Holding $v$ fixed gives a softmax across the one-hot states, and holding $h=e_k$ fixed gives the Gaussian for component $k$. Those two readings are the next two sections.\n",
-    "\n",
-    "We use three well-separated cluster means, shared variance, and unequal mixture weights.\n"
+    "We can now read the energy in two directions. Holding $v$ fixed gives a softmax across the one-hot states, while holding $h=e_k$ fixed gives the Gaussian for component $k$. We begin with three well-separated cluster means, a shared variance, and unequal mixture weights.\n"
    ]
   },
   {
@@ -306,18 +304,18 @@
    "source": [
     "## The softmax emerges\n",
     "\n",
-    "Taking the first reading, holding $v$ fixed leaves one component score per hidden state, which makes the categorical conditional a softmax:\n",
+    "First, fix the visible vector $v$. Because the hidden state can take only one of the basis states $e_k$, the joint energy leaves one score for each component. Normalizing their exponentials gives the categorical conditional\n",
     "\n",
     "$$\n",
     "p(h=e_k\\mid v)=\\operatorname{softmax}_k(\\theta(v)),\\qquad\n",
     "\\theta_k(v)=\\log\\pi_k-\\frac{1}{2}\\sum_i\\frac{(v_i-\\mu_{ki})^2}{\\sigma_{ki}^2}-\\frac{1}{2}\\sum_i\\log\\sigma_{ki}^2.\n",
     "$$\n",
     "\n",
-    "The recovery section further down implements exactly this expression, in a function we'll meet there called `cluster_logits`. With shared covariance and the linear-coupling parameterization above, the same score is $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
+    "These probabilities are the Gaussian-mixture responsibilities. The recovery section implements the same score in `cluster_logits`. With shared covariance and the linear-coupling parameterization above, it can also be written as $\\theta_k(v)=c_k+\\sum_i(v_i/\\sigma_i)W_{ik}$ plus a $k$-independent term, using the corrected $c_k$.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: responsibility</summary><p>A Gaussian-mixture responsibility is the posterior probability $p(h=e_k\\mid v)$ that component $k$ generated a point, as in the mixture-model treatment of <a href=\"#ref-dempster-1977\">Dempster et al. 1977</a>.</p></details>\n",
     "\n",
-    "The shape of the conditional comes from the hidden unit alone: a single bias `pbit` gives a sigmoid, while the one-hot `pdit` used here gives a softmax. The matching continuous conditional is supplied by `MixtureGaussianGate` in the next section.\n"
+    "The form of this conditional follows from the hidden representation: a single bias `pbit` gives a sigmoid, whereas the one-hot `pdit` used here gives a softmax. We next obtain the matching continuous conditional and implement it with `MixtureGaussianGate`.\n"
    ]
   },
   {
@@ -327,17 +325,15 @@
    "source": [
     "## The Gaussian conditional and the gate\n",
     "\n",
-    "The second reading fixes $h=e_k$, which leaves the energy quadratic in $v$ and therefore Gaussian:\n",
+    "Now fix $h=e_k$. Only the quadratic energy for component $k$ remains, so the conditional over the visible vector is Gaussian:\n",
     "\n",
     "$$\n",
     "p(v\\mid h=e_k)=\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k),\\qquad p(v)=\\sum_k \\pi_k\\,\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k).\n",
     "$$\n",
     "\n",
-    "The code works directly with $(\\mu_k,\\Sigma_k,\\pi_k)$, the same parameters used by the energy and `cluster_logits`, so the two conditionals can't drift apart. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects these parameters to the linear-coupling form above.\n",
+    "The implementation uses $(\\mu_k,\\Sigma_k,\\pi_k)$ in both this conditional and `cluster_logits`, keeping the generative and inferential readings tied to the same parameters. For shared covariance, $\\mu_k=a+\\mathrm{diag}(\\sigma)W_{:k}$ connects them to the linear-coupling form above.\n",
     "\n",
-    "This Gaussian conditional is the piece Torx executes: `MixtureGaussianGate` realizes $p(v\\mid h=e_k)$ and nothing else, with a single `pdit` storing the cluster index $k\\in\\{0,1,2\\}$ directly.\n",
-    "\n",
-    "Next, we construct `gate` and wrap it in a `HybridPCircuit` named `gen`. The circuit infers and preserves the gate's discrete control wire, so the seeded cluster label passes through unchanged."
+    "This is the conditional that Torx executes. `MixtureGaussianGate` realizes $p(v\\mid h=e_k)$, while one `pdit` stores the cluster index $k\\in\\{0,1,2\\}$ directly. We construct the gate and wrap it in a `HybridPCircuit` named `gen`; the circuit infers and preserves the discrete control wire, so a seeded cluster label passes through unchanged."
    ]
   },
   {
@@ -367,7 +363,7 @@
    "id": "2e20f1e1",
    "metadata": {},
    "source": [
-    "We draw the circuit to see how little structure this model needs."
+    "We draw the circuit to identify the discrete control and continuous output used by this conditional sampler."
    ]
   },
   {
@@ -620,17 +616,15 @@
    "source": [
     "## Recovering clusters with the softmax\n",
     "\n",
-    "Now we run the energy the other way and ask which cluster each sampled point came from, which is the softmax conditional evaluated at the data:\n",
+    "Generation fixed $h$ and sampled $v$. For recovery, we fix each observed $v$ and evaluate the other conditional:\n",
     "\n",
     "$$\n",
     "p(h=e_k\\mid v)=\\frac{\\exp[-E_k(v)]}{\\sum_{k'}\\exp[-E_{k'}(v)]}=\\operatorname{softmax}_k(\\theta(v)),\\qquad \\theta_k(v)=\\log \\pi_k-\\frac{1}{2}(v-\\mu_k)^\\top\\Sigma_k^{-1}(v-\\mu_k)-\\frac{1}{2}\\log\\det\\Sigma_k.\n",
     "$$\n",
     "\n",
-    "This is the Gaussian-mixture responsibility from the opening energy, because the logits are the negated component energies with shared constants removed, so each row is the one-hot Boltzmann conditional.\n",
+    "The logits are the negated component energies after removing constants shared across $k$. Their softmax is therefore both the one-hot Boltzmann conditional and the usual Gaussian-mixture responsibility.\n",
     "\n",
-    "The log-determinant is required when covariances differ, and with the shared diagonal covariance used here it cancels in the softmax.\n",
-    "\n",
-    "The `cluster_logits` function below builds these logits from the component energies.\n"
+    "The log-determinant is required when component covariances differ. It cancels for the shared diagonal covariance used here, but `cluster_logits` retains it by constructing the logits from the full component energies.\n"
    ]
   },
   {
@@ -776,7 +770,7 @@
    "id": "6efeed89",
    "metadata": {},
    "source": [
-    "The assignment figure overlays the hard $\\arg\\max_k p(k\\mid v)$ labels on the soft responsibility field, whose component colors blend to encode $p(k\\mid v)$. Every point is recovered with a near-certain responsibility, at a printed hard reassignment accuracy of 1.000 and a soft boundary fraction of 0.000, and the field blends between colors only in the empty regions between clusters, where no data live.\n"
+    "In the assignment figure, point color shows the hard label $\\arg\\max_k p(k\\mid v)$, while the background blends component colors according to $p(k\\mid v)$. The printed hard reassignment accuracy is 1.000 and the soft boundary fraction is 0.000, so every sampled point has a near-certain recovered label. The background blends only in the empty regions between clusters; it locates the decision boundary, but there are no data there on which to evaluate recovery.\n"
    ]
   },
   {
@@ -869,17 +863,17 @@
    "source": [
     "## Block Gibbs on the joint Boltzmann machine\n",
     "\n",
-    "With both conditionals in hand we can stop conditioning on fixed data and sample the joint law itself, by alternating them:\n",
+    "So far, we have used the two conditionals separately for recovery and generation. To sample the joint law, we alternate them:\n",
     "\n",
     "$$\n",
     "h\\sim p(h\\mid v)=\\operatorname{softmax}(\\theta(v)),\\qquad v\\sim p(v\\mid h=e_k)=\\mathcal{N}(v\\mid\\mu_k,\\Sigma_k).\n",
     "$$\n",
     "\n",
-    "We implement both updates directly in JAX from these same formulas, so the Gibbs mechanics stay visible line by line, which means Torx's role in this notebook ends with the conditional Gaussian draws above. One sweep redraws each visible point from its current component, then redraws its label from the analytic responsibility vector.\n",
+    "We implement both updates directly in JAX from the same formulas, leaving each step of the Gibbs procedure explicit. Torx's role in this notebook therefore ends with the conditional Gaussian draws above. During one sweep, we redraw every visible point from its current component and then redraw its label from the analytic responsibility vector.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Gibbs sweep</summary><p>A <a href=\"#ref-geman-1984\">block Gibbs sweep (Geman and Geman 1984)</a> redraws each variable block from its conditional distribution while holding the other block fixed.</p></details>\n",
     "\n",
-    "Mixing speed depends on cluster overlap, and the well-separated mixture above would leave chains almost frozen in whichever cluster they started, so this convergence study uses closer means and a larger shared variance. Every chain starts in cluster 0, which is as far off-stationary as the population can be, and the per-sweep population occupancy then relaxes toward $\\pi$. The curves need not sit exactly on the dashed targets, because a finite population of chains carries sampling noise of its own.\n"
+    "The well-separated mixture used for clustering is a poor setting in which to study Gibbs mixing: a chain would tend to remain in its initial cluster. For the convergence study, we therefore use closer means and a larger shared variance, which makes the components overlap. Every chain starts in cluster 0, far from the target occupancy $\\pi$, and we record how the population occupancy changes after each sweep. Because the population is finite, the curves will fluctuate around the dashed target values rather than match them exactly.\n"
    ]
   },
   {
@@ -1123,7 +1117,7 @@
    "id": "3eac0ee6",
    "metadata": {},
    "source": [
-    "The occupancy leaves its seeded $(1, 0, 0)$ start within a few sweeps and then flattens out. Pooling the back half of the sweeps, after that transient, gives $(0.403, 0.350, 0.246)$ against the target weights $\\pi=(0.400, 0.350, 0.250)$, so the handwritten JAX chain reproduces the mixture weights to within 0.004 per component, the size of the finite-population sampling noise here.\n"
+    "The occupancy moves away from the seeded $(1, 0, 0)$ state within a few sweeps and then fluctuates around a stable level. Averaging over the back half, after the transient, gives $(0.403, 0.350, 0.246)$ compared with $\\pi=(0.400, 0.350, 0.250)$. The largest difference is 0.004, consistent with finite-population sampling noise in this experiment.\n"
    ]
   },
   {
@@ -1133,17 +1127,17 @@
    "source": [
     "## The one-hot constraint as a winner-take-all energy\n",
     "\n",
-    "We close by building the energetic alternative named at the start, so the structural choice this notebook made can be compared against it at a definite penalty strength. Recall from the opening energy section that the one-hot constraint can be written as the penalty energy over binary units $z\\in\\{0,1\\}^K$:\n",
+    "The `pdit` used above represents only valid categorical states. What changes if we instead represent the component choice with $K$ binary units? We can favor one-hot configurations $z\\in\\{0,1\\}^K$ with the penalty\n",
     "\n",
     "$$\n",
     "E_{\\mathrm{WTA}}(z) = \\lambda\\Big(\\sum_k z_k - 1\\Big)^2,\n",
     "$$\n",
     "\n",
-    "whose ground states are exactly the one-hot vectors $e_k$. Up to the constant $\\lambda$, the penalty expands into a bias term $-\\lambda\\sum_k z_k$ plus an all-pairs repulsion $2\\lambda\\sum_{k<k'} z_k z_{k'}$, a winner-take-all Potts-type coupling.\n",
+    "whose ground states are exactly the one-hot vectors $e_k$. Up to the constant $\\lambda$, this energy expands into a bias term $-\\lambda\\sum_k z_k$ and an all-pairs repulsion $2\\lambda\\sum_{k<k'} z_k z_{k'}$, giving a winner-take-all Potts-type coupling.\n",
     "\n",
-    "Its Boltzmann distribution $p(z)\\propto e^{-E_{\\mathrm{WTA}}(z)}$ therefore concentrates on those one-hot states, and by symmetry it assigns them equal probability. At finite $\\lambda$ it still leaks mass onto non-one-hot configurations, which the sweep below makes visible, so it equals the structural $K$-state `pdit` only in the $\\lambda\\to\\infty$ limit, or once restricted to the one-hot subset. Increasing $\\lambda$ sharpens the concentration toward that uniform categorical.\n",
+    "The Boltzmann distribution $p(z)\\propto e^{-E_{\\mathrm{WTA}}(z)}$ assigns equal probability to the one-hot states by symmetry. However, at finite $\\lambda$ it also assigns probability to non-one-hot configurations. The energetic construction therefore matches a structural $K$-state `pdit` only as $\\lambda\\to\\infty$, or after restricting the state space to the one-hot subset. Increasing $\\lambda$ concentrates more probability on that subset.\n",
     "\n",
-    "Here we enumerate all $2^K$ binary configurations and compute the exact finite Boltzmann distribution of the energy directly, so no sampling error enters the comparison. On hardware, the same penalty can be realized with pairwise couplings, but the equilibrium object below is the energy distribution itself."
+    "We enumerate all $2^K$ binary configurations and compute their exact finite Boltzmann probabilities. This removes sampling error from the comparison. The same penalty can be realized on hardware with pairwise couplings, but the object evaluated below is the equilibrium energy distribution itself."
    ]
   },
   {
@@ -1293,7 +1287,7 @@
    "id": "7eff7bb8",
    "metadata": {},
    "source": [
-    "At $\\lambda=4$ the three one-hot states share the mass equally at 0.325387 each, for a one-hot total of 0.976161, and the sweep over $\\lambda$ shows that total rising as the penalty grows. The remaining 0.024 sits on configurations that a $K$-state `pdit` can't represent at all, which is the price of the energetic route at finite $\\lambda$."
+    "At $\\lambda=4$, the three one-hot states have equal probability, 0.325387 each, and together carry 0.976161 of the total mass. The sweep shows this total increasing with $\\lambda$. The remaining 0.024 lies on configurations that a $K$-state `pdit` cannot represent, which is the finite-strength difference between the energetic and structural encodings."
    ]
   },
   {
@@ -1303,17 +1297,17 @@
    "source": [
     "## Verification\n",
     "\n",
-    "The figures above are readings, so we finish by asserting the numbers behind them.\n",
+    "We finish by checking the numerical claims used to interpret the figures.\n",
     "\n",
-    "First the generated data against the parameters we asked for. Each cluster's sampled mean matches $\\mu_k$ within 0.06 and its sampled variance matches $\\sigma_k^2$ within 12% relative, and the realized label proportions match $\\pi$ within 0.025, so the NumPy-and-Torx generation path is faithful to the model it claims to sample.\n",
+    "For generation, each cluster's sampled mean matches $\\mu_k$ within 0.06, its sampled variance matches $\\sigma_k^2$ within 12% relative, and the realized label proportions match $\\pi$ within 0.025. These checks cover the NumPy-and-Torx conditional sampling path.\n",
     "\n",
-    "Then the inference path. Every responsibility row sums to one within $10^{-6}$, and the softmax of our Boltzmann logits matches responsibilities assembled independently from per-component Gaussian densities within $10^{-4}$, which is the claim that the energy view and the textbook mixture view are the same computation. Hard reassignment accuracy is asserted above 0.99, confirming that clusters this well separated are recoverable from the responsibilities alone.\n",
+    "For recovery, every responsibility row sums to one within $10^{-6}$. The softmax of the Boltzmann logits also matches responsibilities computed independently from the per-component Gaussian densities within $10^{-4}$, checking that the energy and mixture calculations agree. Hard reassignment accuracy is above 0.99 for these well-separated clusters.\n",
     "\n",
-    "Next, the pooled sample mean and variance of the visible data match the analytic mixture moments within 0.08 and 5% relative, so the full marginal is right as well as the per-cluster blocks checked earlier.\n",
+    "The pooled sample mean and variance of the visible data match the analytic mixture moments within 0.08 and 5% relative, respectively. This checks the full marginal in addition to the individual component blocks.\n",
     "\n",
-    "For the Gibbs chain we assert both ends. The seeded start really is off-stationary, with over 95% of chains in cluster 0, and the back-half occupancy is within 0.04 of $\\pi$ in every component, which together make the trace a relaxation rather than a chain that began at its target.\n",
+    "For the Gibbs chain, the seeded start has more than 95% of chains in cluster 0, and every component of the back-half occupancy lies within 0.04 of $\\pi$. Together, these conditions distinguish relaxation from a chain initialized at its target.\n",
     "\n",
-    "Finally, the winner-take-all distribution puts over 95% of its mass on one-hot states, spreads that mass equally across them to within $10^{-9}$, and increases monotonically in $\\lambda$, matching the three claims made for it above."
+    "Finally, the winner-take-all distribution places more than 95% of its mass on one-hot states, divides that mass equally to within $10^{-9}$, and increases it monotonically with $\\lambda$. These are the three properties used in the structural-versus-energetic comparison."
    ]
   },
   {
@@ -1461,9 +1455,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "This tutorial wrote a Gaussian-categorical mixture as one Boltzmann machine, then ran that single energy from both sides.\n",
+    "We began with one joint energy over a continuous visible vector and a categorical hidden state. Fixing the visible vector produced the softmax responsibilities used for clustering, while fixing the hidden state produced the component Gaussian used for generation. These are complementary conditionals of the same Gaussian-categorical Boltzmann machine.\n",
     "\n",
-    "The analytic joint energy uses the same $(\\mu_k,\\Sigma_k,\\pi_k)$ parameterization as the executed JAX logits, which is what lets the derivation on paper and the running code check each other. Generation split across two libraries: NumPy drew the labels and shuffled the blocks, while Torx `MixtureGaussianGate` drew the conditional Gaussian samples and nothing else. Recovery was pure JAX, computing the responsibilities and the hard assignments taken from them. The closing block Gibbs section then alternated the two conditional formulas in a separate handwritten JAX loop, which kept every step of a sweep on the page.\n",
+    "The analytic energy and the JAX logits share the parameterization $(\\mu_k,\\Sigma_k,\\pi_k)$, allowing the two calculations to be compared directly. NumPy drew labels and shuffled the component blocks, Torx `MixtureGaussianGate` drew the conditional Gaussian samples, and JAX recovered the responsibilities and hard assignments. Alternating the same two conditional formulas in a handwritten JAX Gibbs loop then recovered the mixture weights from an off-stationary population.\n",
+    "\n",
+    "The final comparison separated two ways to encode the categorical state. A `pdit` enforces the $K$ valid choices structurally, whereas a finite winner-take-all energy over $K$ binary units retains some probability on invalid configurations. The latter approaches the former as the penalty strength increases.\n",
     "\n",
     "See also:\n",
     "- [`10_pmode_gaussian_gates.ipynb`](10_pmode_gaussian_gates.ipynb), pure Gaussian gates and closed-form Gaussian conditioning.\n",

--- a/examples/15_intro_to_factors.ipynb
+++ b/examples/15_intro_to_factors.ipynb
@@ -14,7 +14,7 @@
    "metadata": {},
    "source": [
     "<div class=\"note\"><span class=\"note-t\">In brief</span>\n",
-    "<p>We define four tutorial factors, sample each one on its own, then compose them with Torx's factor bases, sampler, directed graph, and composite factors, so a single sampling interface carries from one probabilistic bit up to a whole graph. Because Torx <code>TiledFactor</code> and <code>ChainFactor</code> are meant to be bookkeeping around a factor and nothing more, we rerun them with the same random keys as manual JAX equivalents and require the draws to agree exactly.</p>\n",
+    "<p>We define four tutorial factors on Torx factor base classes, call each one directly, then place the same factors in a directed graph and two composite factors. At every level, sampling uses <code>sample(key, inputs, params)</code>: the object changes from one probabilistic bit to a graph or composite, but the calling convention does not. Because <code>TiledFactor</code> and <code>ChainFactor</code> only organize calls to an underlying factor, we also compare them with manual JAX equivalents under the same random keys and require the draws to agree exactly.</p>\n",
     "</div>\n"
    ]
   },
@@ -23,15 +23,15 @@
    "id": "40ce5e41",
    "metadata": {},
    "source": [
-    "In this tutorial we start from the smallest object Torx can sample, a single **probabilistic bit** (pbit), and build upward from there. We give that pbit a factor of its own, wire two factors into a Torx directed factor graph, and then connect the resulting software hierarchy to the parametrised stochastic circuit (PSC) view used elsewhere in the gallery.\n",
+    "Torx can sample objects at several levels: an individual probabilistic factor, a directed graph of factors, or a circuit-shaped graph. We begin with the smallest of these objects, a single **probabilistic bit** (pbit), and then build upward. The pbit receives a factor of its own, two factors are wired into a Torx directed factor graph, and the resulting hierarchy is related to the parametrised stochastic circuit (PSC) view used elsewhere in the gallery.\n",
     "\n",
-    "A **factor** is one conditional distribution packaged as an object. It reads named inputs, reads parameters that live outside the object and arrive with each call, and returns one stochastic output. Keeping the parameters outside is what makes a factor reusable, because the object itself carries no numbers to get stale. Four factors carry the teaching here: `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor` are defined in this notebook and aren't Torx library primitives, while the base classes, sampler, graph, and composites that combine them all come from Torx.\n",
+    "A **factor** packages one conditional distribution as an object. It reads named inputs and parameters supplied with each call, then returns one stochastic output. The parameters remain outside the object, so the same factor can be reused with different values rather than retaining numbers that may become stale. The four probability laws in this notebook belong to `CoinFactor`, `ConditionalBit`, `TinyCategorical`, and `FlipFactor`; these are tutorial classes, not Torx library primitives. Torx supplies the base classes, graph, and composites that invoke them.\n",
     "\n",
-    "A **directed factor graph** is a set of such factors with the output of one wired into the input of another, arranged without cycles so that every node can be sampled in a single pass from parents to children. Torx gates are factors as well, through their base classes, so the difference between a gate and a bare factor isn't the probability model but how much has already been decided about placement. A PSC fixes their placement into circuit wiring, while a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n",
+    "A **directed factor graph** wires the output of one factor into the input of another. Because the wiring has no cycles, its nodes can be sampled once in parent-to-child order. Torx gates are also factors through their base classes, so a gate and a bare factor differ in how much placement has already been specified, not in whether they define a probability model. A PSC fixes factors into circuit wiring, whereas a concrete `DFG` places factors at named `Site` nodes in an arbitrary DAG.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Torx DFG and conventional factor graph</summary><p>A Torx directed factor graph is a DAG of conditional samplers, while the <a href=\"#ref-kschischang-2001\">conventional factor graph</a> of Kschischang et al. is a bipartite graph of variable and factor nodes. A PSC subclasses Torx <code>AbstractDFG</code> as a circuit-shaped implementation, but it isn't a subclass of the concrete Torx <code>DFG</code> class.</p></details>\n",
     "\n",
-    "This tutorial mirrors [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) from the factor side, so the two are worth reading together for both views of the same idea. It also connects the same composition ideas to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n"
+    "This tutorial develops the factor-side view of the construction introduced from the PSC side in [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb). [Notebook 16](16_gibbs_sampling_factor_graph.ipynb) applies the same composition mechanism to Gibbs sampling on a larger factor graph.\n"
    ]
   },
   {
@@ -181,9 +181,9 @@
    "source": [
     "## A tutorial factor as a sampler\n",
     "\n",
-    "We meet the contract first in its simplest form, on a factor that takes no inputs at all, so nothing about wiring gets in the way. The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor` and declares no input ports at all, which makes it a plain distribution over a single pbit.\n",
+    "We begin with a factor that has no inputs, so its sampling behavior can be examined before any graph wiring is introduced. The notebook-defined `CoinFactor` subclasses Torx `AbstractReferenceFactor` and declares no input ports, making it a distribution over one pbit.\n",
     "\n",
-    "Two details of the contract are visible right away. The parameter dictionary lives outside the object and is passed into each `sample` call, and the custom `sample` method draws 1 with probability $\\sigma(b)$ through Torx `JaxPRNGSampler`.\n"
+    "The call `coin.sample(k, {}, coin_params)` exposes the three parts of the sampling convention. `k` supplies the random key, the empty dictionary records that this factor has no inputs, and `coin_params` supplies the external parameter dictionary. The custom `sample` method calls `jax.random.bernoulli` directly to draw 1 with probability $\\sigma(b)$.\n"
    ]
   },
   {
@@ -255,7 +255,7 @@
    "id": "4fa9de59",
    "metadata": {},
    "source": [
-    "Averaged over 20,000 independent keys, the sampled frequency of 1 comes out at 0.601 against a target $\\sigma(b)$ of 0.599, which confirms that the factor draws the distribution it declares and does so well inside the tolerance of 0.02 we assert at the end."
+    "Across 20,000 independent keys, the sampled frequency of 1 is 0.601, compared with the target $\\sigma(b)=0.599$. Their difference is well within the tolerance of 0.02 asserted at the end of the notebook, so this sample is consistent with the distribution declared by `CoinFactor`."
    ]
   },
   {
@@ -265,13 +265,13 @@
    "source": [
     "## A tutorial factor with inputs\n",
     "\n",
-    "A factor with no inputs can't be wired into anything, so the next step is one that reads a value from elsewhere. The notebook-defined `ConditionalBit` uses the same Torx base contract with one named input port. Its custom formula is\n",
+    "A graph can route information into a factor only if that factor declares an input port. The notebook-defined `ConditionalBit` therefore keeps the same Torx base contract as `CoinFactor` but adds one named input. Its probability law is\n",
     "\n",
     "$$\n",
     "P(\\text{out}=1 \\mid x)=\\sigma(wx+b).\n",
     "$$\n",
     "\n",
-    "To see whether the object really implements that formula, we sweep the drive across 21 values, draw 8,000 samples at each one through Torx `JaxPRNGSampler`, and compare the sampled means with the sigmoid curve. What matters in the figure is agreement across the whole sweep rather than only near the midpoint, since that's what shows the input port feeding the bias with the declared weight.\n"
+    "We evaluate this law at 21 drive values by mapping calls to `ConditionalBit.sample` over independent JAX keys. In the figure, the sampled means are plotted against the corresponding sigmoid curve. Agreement across the full sweep, rather than only near its midpoint, tests whether the `drive` input enters the bias with the declared weight.\n"
    ]
   },
   {
@@ -407,20 +407,20 @@
    "source": [
     "## Wiring tutorial factors into a Torx directed factor graph\n",
     "\n",
-    "Two factors become a graph only once something decides which output feeds which input, and that decision is exactly what a Torx `Site` records. A `Site` places a factor in a graph: it names the parents, routes parent outputs to input ports, and selects a parameter slice with `param_key`. Torx `DFG` then walks these sites in topological order, parents first, then children [(Pearl 1988)](#ref-pearl-1988), which is all the ordering a directed factor graph needs to be sampled in one pass.\n",
+    "A Torx `Site` records how an individual factor participates in a graph. It names the factor's parents, routes parent outputs to input ports, and selects a parameter slice with `param_key`. Torx `DFG` then visits the sites in topological order—parents before children—so the entire directed graph can be sampled in one pass [(Pearl 1988)](#ref-pearl-1988).\n",
     "\n",
-    "Several actors are on stage from here on, so the tables and figures below use these labels:\n",
+    "The tables and figures below distinguish the objects that define probability laws from those that execute, compose, or display them:\n",
     "\n",
     "| Label used below | Owner |\n",
     "|---|---|\n",
-    "| Torx primitive | `AbstractReferenceFactor`, `AbstractMatrixFactor`, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, `ChainFactor` |\n",
+    "| Torx primitive | `AbstractReferenceFactor`, `AbstractMatrixFactor`, `Site`, `DFG`, `TiledFactor`, `ChainFactor` |\n",
     "| Tutorial factor | the four notebook-defined classes and their probability formulas |\n",
     "| Notebook JAX | batching, compilation, estimates, and checks |\n",
     "| Plot helper | presentation only |\n",
     "\n",
-    "Here the concrete Torx graph contains two notebook-defined factors. `coin` draws first, and `out` receives the coin bit through the notebook function `to_drive`, which casts the integer bit into the float that the `drive` port declares. The graph itself keeps the Torx `sample(key, inputs, params)` contract, so we call the two-node graph exactly the way we called the single factor.\n",
+    "The concrete graph contains two notebook-defined factors. `coin` is sampled first. The notebook function `to_drive` then casts its integer output to the floating-point value required by the `drive` port of `out`. The graph retains the `sample(key, inputs, params)` contract, so `graph.sample(key, {}, dfg_params)` has the same calling convention as the single factor.\n",
     "\n",
-    "Tracing one concrete path through the fixed tutorial parameters shows what each actor contributes:\n",
+    "For the fixed tutorial parameters, one path through the graph has these values and owners:\n",
     "\n",
     "| Step | Value | Owner |\n",
     "|---|---:|---|\n",
@@ -429,7 +429,7 @@
     "| `ConditionalBit` score | $2(1)-1=1$ | tutorial formula |\n",
     "| child probability | $P(\\mathrm{out}=1)=\\sigma(1)=0.731$ | tutorial factor called by Torx DFG |\n",
     "\n",
-    "The anatomy below shows the shared factor contract that makes such wiring possible at all: inputs and external parameters enter, and one sample leaves.\n"
+    "The factor-anatomy diagram that follows isolates the common boundary: named inputs and external parameters enter a factor, and one sample leaves. `Site` adds the graph routing around that boundary.\n"
    ]
   },
   {
@@ -580,7 +580,7 @@
    "id": "717fb307",
    "metadata": {},
    "source": [
-    "Across 60,000 graph draws the sampled mean of `out` is 0.549, while marginalizing the hidden coin by hand gives 0.546, so the Torx `DFG` reproduces the distribution that the two tutorial factors define jointly. That's the evidence that its routing and its parents-first ordering are both correct. The schematic below shows the two-node graph we just sampled.\n"
+    "Across 60,000 graph draws, the sampled mean of `out` is 0.549; marginalizing the hidden coin by hand gives 0.546. This agreement is consistent with the joint distribution defined by the two tutorial factors and checks the routing and parent-first execution used in this example. The schematic below encodes that execution path: `coin` is the parent, `to_drive` converts its output for the child's input port, and `out` is sampled second. The schematic shows the dependency structure, while the two means provide the numerical comparison.\n"
    ]
   },
   {
@@ -629,11 +629,11 @@
    "source": [
     "## Exact probabilities as an opt-in capability\n",
     "\n",
-    "Sampling is the one thing every factor must do, but some factors can also report their distribution in closed form, and Torx lets them advertise that instead of demanding it of everyone. The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`, so it carries the common sampling contract alongside the optional `get_log_probability_matrix` capability.\n",
+    "Every factor implements sampling, but only some factors can report their distribution in closed form. Torx represents this as an additional capability rather than a requirement on all factors. The notebook-defined `TinyCategorical` subclasses Torx `AbstractMatrixFactor`, retaining the common sampling interface while adding `get_log_probability_matrix`.\n",
     "\n",
-    "A matrix factor uses rows for input configurations and columns for output configurations, and `input_states` and `output_states` fix that ordering. This factor has no inputs, so its matrix has one row for the empty input configuration and three columns ordered as `x = 0, 1, 2`. Each matrix entry is a normalized log probability, which means exponentiating the row gives probabilities that sum to one.\n",
+    "For a matrix factor, rows enumerate input configurations and columns enumerate output configurations; `input_states` and `output_states` define those orders. `TinyCategorical` has no inputs, so its matrix contains one row for the empty input configuration and three columns ordered as `x = 0, 1, 2`. Each entry is a normalized log probability. Exponentiating the row therefore produces probabilities that sum to one.\n",
     "\n",
-    "One wrinkle when reading the draws: samples return a dictionary keyed by output name, so we read them with `[\"x\"]`.\n"
+    "The call `cat.sample(k, {}, cat_params)` still uses the same three arguments as the earlier factors. Its sample is a dictionary keyed by output name, so the categorical value is read with `[\"x\"]`.\n"
    ]
   },
   {
@@ -767,7 +767,7 @@
    "source": [
     "## Torx composites around a tutorial transition\n",
     "\n",
-    "Two needs come up constantly in practice: running many copies of one factor at once, and running one factor repeatedly on its own output. Torx covers both with composites, and we build them around a transition of our own. The notebook-defined `FlipFactor` supplies the transition formula, Torx `TiledFactor` runs eight weight-tied copies in parallel, and Torx `ChainFactor` repeats five weight-tied steps while feeding each output back to the `state` port. Weight-tied means every copy or step reads one shared parameter slice instead of holding a slice of its own.\n"
+    "We now consider two forms of repeated sampling: applying one factor to several inputs in parallel, and applying it repeatedly while feeding each output into the next step. The notebook-defined `FlipFactor` supplies the transition law for both constructions. Torx `TiledFactor` evaluates eight weight-tied copies in parallel, whereas Torx `ChainFactor` evaluates five weight-tied steps and feeds each output back through the `state` port. Here, weight tying means that every copy or step receives the same parameter slice rather than a separate one.\n"
    ]
   },
   {
@@ -849,7 +849,9 @@
    "id": "d29c9d57",
    "metadata": {},
    "source": [
-    "Tying the weights is what these two composites are really demonstrating. Both reuse the single `FlipFactor` unchanged and hand it one parameter slice, so the tile's eight parallel draws share that same slice, and the chain threads the state through the same tied transition five times before returning the state after the fifth fed-back step. Neither composite alters the `sample` contract, so we call both of them exactly the way we call the single factor."
+    "Both composites reuse the same `FlipFactor` and the same parameter slice. In `TiledFactor`, that slice is shared across eight parallel draws. In `ChainFactor`, the output state is fed through the same tied transition five times, and the composite returns the state after the fifth step.\n",
+    "\n",
+    "The corresponding calls retain the factor convention. `tiled.sample(key, {\"state\": states}, flip_params)` receives eight states, while `chain.sample(key, {\"state\": state}, flip_params)` receives the initial scalar state. Their input objects reflect different computations, but both calls still supply a random key, named inputs, and external parameters in the same order as `flip.sample`."
    ]
   },
   {
@@ -859,9 +861,9 @@
    "source": [
     "## One sampling interface at every level\n",
     "\n",
-    "Nothing about the calling convention changed as we moved up in scale, and that's the design point worth carrying away. All five objects keep the same basic shape: read inputs and parameters, then return a sample. A Torx `DFG` arranges `Site` factors in a DAG and samples them in topological order, whereas a PSC specializes `AbstractDFG` by fixing factors into circuit wiring instead. Composite factors sit at the same level as a plain factor, because they wrap or repeat another factor without changing its `sample` interface.\n",
+    "Across the examples above, the sampled object and the shape of its inputs change, but every call retains the form `sample(key, inputs, params)`. `CoinFactor`, `ConditionalBit`, and `TinyCategorical` sample individual probability laws. `DFG` adds parent routing and topological execution, while `TiledFactor` and `ChainFactor` add parallel or repeated calls around another factor without changing the boundary.\n",
     "\n",
-    "That shared interface is why the two entry points into Torx look different yet compose alike: [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) uses the PSC side, while [notebook 16](16_gibbs_sampling_factor_graph.ipynb) uses factor composition.\n"
+    "A PSC also specializes `AbstractDFG`, but fixes factors into circuit wiring rather than instantiating the concrete `DFG` class for an arbitrary DAG. [Notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb) develops that PSC implementation, while [notebook 16](16_gibbs_sampling_factor_graph.ipynb) uses factor composition for Gibbs sampling.\n"
    ]
   },
   {
@@ -871,7 +873,9 @@
    "source": [
     "## Verification\n",
     "\n",
-    "Finally, we turn each estimate above into a check that would fail if the composition were wrong. We assert the estimates computed above against their exact values, and we hold the composite factors to a stricter standard, because a composite that only reorganizes calls should not change a single draw. So we add deterministic same-key checks, meaning we feed the composite and a hand-written equivalent the identical random keys and require identical results: `TiledFactor` must equal a manual `vmap` over split keys, and `ChainFactor` must equal a manual loop that feeds each step's output back with the same split keys. We also compare a one-step chain against the bare factor."
+    "We now compare each Monte Carlo estimate with its corresponding exact value. These checks use finite-sample tolerances because independent draws need not match their expectations exactly.\n",
+    "\n",
+    "The composites permit a stricter comparison. Since they reorganize calls to `FlipFactor` without changing its transition law, we supply identical random keys to each composite and to a manual JAX construction. `TiledFactor` must then match a manual `vmap` over the same split keys, and `ChainFactor` must match a manual loop that feeds each output back under the same sequence of split keys. A final check compares a one-step chain with the bare factor."
    ]
   },
   {
@@ -1012,14 +1016,11 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We composed notebook-defined tutorial factors with Torx library primitives, and the division of labour is the thing to carry forward.\n",
+    "We defined four tutorial probability laws and composed them with Torx's graph and factor abstractions. The custom classes contain the probability formulas and call JAX random primitives directly; Torx supplies the factor contracts, `Site`, `DFG`, `TiledFactor`, and `ChainFactor` that compose them.\n",
     "\n",
-    "- The custom classes contain the tutorial probability formulas.\n",
-    "- Torx supplies the factor contracts, `JaxPRNGSampler`, `Site`, `DFG`, `TiledFactor`, and `ChainFactor`.\n",
-    "- A Torx DFG is a directed sampler DAG, distinct from the conventional bipartite definition of a factor graph.\n",
-    "- A PSC subclasses `AbstractDFG` as a circuit-shaped implementation and isn't a subclass of concrete `DFG`.\n",
+    "A single factor, a directed graph, and a composite factor are all invoked through `sample(key, inputs, params)`. `Site` and `DFG` add routing and parent-first execution, while `TiledFactor` and `ChainFactor` apply one factor in parallel or repeatedly with feedback. A Torx DFG is a directed sampler DAG, distinct from a conventional bipartite factor graph. A PSC specializes `AbstractDFG` as a circuit-shaped implementation and is not a subclass of concrete `DFG`.\n",
     "\n",
-    "For the circuit-shaped view, go back to [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb). For the larger Ising model, continue to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n",
+    "For the circuit-shaped construction, return to [notebook 01](01_introduction_to_parametrised_stochastic_circuits.ipynb). For the larger Ising model built through factor composition, continue to [notebook 16](16_gibbs_sampling_factor_graph.ipynb).\n",
     "\n",
     "## References\n",
     "\n",

--- a/examples/16_gibbs_sampling_factor_graph.ipynb
+++ b/examples/16_gibbs_sampling_factor_graph.ipynb
@@ -33,19 +33,19 @@
    "id": "cd10da2f",
    "metadata": {},
    "source": [
-    "A **factor** in Torx is a directed conditional $P(\\text{output} \\mid \\text{inputs})$. A custom factor supplies its input and output specs along with `sample` and `init_params`. The one-spin factor here also implements an exact `log_probability`, which gives us an analytic reference for that one-spin conditional only.\n",
+    "A **factor** in Torx is a directed conditional $P(\\text{output} \\mid \\text{inputs})$. A custom factor specifies its inputs and output and implements `sample` and `init_params`. The one-spin factor below also implements an exact `log_probability`, giving us an analytic reference for its conditional distribution.\n",
     "\n",
-    "A parametrised stochastic circuit (PSC) is an ordered list of stochastic gates applied to an initial state. This tutorial builds nothing of that kind: no PSC, no compiled circuit, and no simulator. Everything below is hand-written factors wired into a graph, which keeps the mechanics visible.\n",
+    "A parametrised stochastic circuit (PSC) is an ordered list of stochastic gates applied to an initial state. We do not construct a PSC, compile a circuit, or use a simulator here. Instead, we wire hand-written factors into a graph so that each part of the sampling update remains visible.\n",
     "\n",
-    "[Gibbs sampling](#ref-geman1984) updates one variable at a time from its conditional, and it isn't the main use case Torx is built for. For a dedicated Gibbs sampling library, use [thrml](https://github.com/extropic-ai/thrml). We use it here anyway because a Gibbs sampler happens to exercise the whole `DFG` workflow in one example: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference to check the result against.\n",
+    "[Gibbs sampling](#ref-geman1984) updates variables from their conditional distributions, but it is not Torx's main use case; [thrml](https://github.com/extropic-ai/thrml) is the dedicated library for Gibbs sampling. Why use Gibbs here, then? One sweep brings together the complete `DFG` workflow: a custom factor with an analytic conditional, weight tying, tiling, deterministic reassembly, and an exact finite-state reference against which we can compare the result.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Term: Gibbs and chromatic Gibbs sampling</summary><p>Gibbs sampling resamples variables from their conditional target distributions. In <a href=\"#ref-gonzalez2011\">chromatic Gibbs sampling</a>, same-color spins have no edges between them, so they are conditionally independent given the other color and can update together before the colors swap.</p></details>\n",
     "\n",
-    "The coloring idea comes from [notebook 06](06_ising_sampling_contrastive_divergence.ipynb), where the lattice is colored so non-adjacent spins update together. Notebook 06 runs that idea on an 8-spin ring with `PNOT` gates, while here we write the same chromatic-Gibbs conditional as hand-built factors on a $4\\times4$ torus. The two notebooks share the conditional update and the coloring strategy but use different graphs and Ising distributions.\n",
+    "The coloring follows [notebook 06](06_ising_sampling_contrastive_divergence.ipynb), where non-adjacent spins update together. That notebook uses `PNOT` gates on an 8-spin ring; here we express the same chromatic-Gibbs conditional with hand-built factors on a $4\\times4$ torus. Thus, the update rule and coloring strategy agree, while the graphs and Ising distributions differ.\n",
     "\n",
-    "One design choice matters for everything that follows: the graph receives the per-site `field` as an input rather than as a baked-in weight. With a zero field the model is the symmetric Ising magnet, and with a finite field on selected sites the very same graph performs field-conditioned pattern completion, with no rewiring in between.\n",
+    "One design choice will let us reuse the graph throughout the notebook: the per-site `field` is an input rather than a baked-in weight. At zero field the graph represents the symmetric Ising magnet. Supplying a finite field at selected sites turns the same graph into a field-conditioned pattern-completion model, without changing its wiring.\n",
     "\n",
-    "The grid is a $4\\times4$ torus, which is small enough that all $2^{16} = 65{,}536$ configurations fit in memory. That's the whole reason we can be strict here: the exact distribution is available by brute force for any fixed field, so every check below compares against it rather than against another sampler.\n",
+    "The $4\\times4$ torus contains $2^{16} = 65{,}536$ configurations, all of which fit in memory. We can therefore compute the exact distribution by brute force for any fixed field and compare each sampling result with that distribution rather than with another approximation.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>What runs where?</summary><ul>\n",
     "<li>Torx runs the stochastic factor, tiling, directed factor graph, and weight-tied chain.</li>\n",
@@ -54,7 +54,7 @@
     "<li><code>examples/helpers/_plots_sampling.py</code>, <code>examples/helpers/_notebook_paths.py</code>, and <code>examples/helpers/_notebook_style.py</code> own batching, statistics, plots, paths, and styling.</li>\n",
     "</ul></details>\n",
     "\n",
-    "The main steps are:\n",
+    "We proceed in seven steps:\n",
     "\n",
     "1. set up the $4\\times4$ Boltzmann machine and draw its `DFG`,\n",
     "2. write the one-spin update as a custom factor and check its draws against the conditional it reports analytically,\n",
@@ -330,13 +330,13 @@
    "source": [
     "## The per-spin update as a factor\n",
     "\n",
-    "The smallest piece of the model is a single spin update: given a spin's four neighbors and its local `drive`, draw its new value. Get that one conditional right and the rest of the notebook is wiring.\n",
+    "We begin with the smallest stochastic part of the model: updating one spin given its four neighbors and local `drive`. Once this conditional is defined, tiling and graph assembly will extend it to the full lattice.\n",
     "\n",
-    "That update is one factor: a directed conditional that implements `sample` and `init_params` alongside its specs.\n",
+    "The update is a directed factor that supplies its input and output specifications and implements `sample` and `init_params`.\n",
     "\n",
-    "The update draws a Bernoulli pbit in $\\{0, 1\\}$ with probability $\\sigma(2\\gamma_i)$, then maps it to the stored spin $s_i = 2\\,\\text{pbit} - 1 \\in \\{-1, +1\\}$. Here $\\sigma$ is the logistic sigmoid and the local field $\\gamma_i$ collects the neighbors and the `drive`.\n",
+    "It first draws a Bernoulli pbit in $\\{0, 1\\}$ with probability $\\sigma(2\\gamma_i)$, where $\\sigma$ is the logistic sigmoid and $\\gamma_i$ is the local field. The pbit is then mapped to the stored spin $s_i = 2\\,\\text{pbit} - 1 \\in \\{-1, +1\\}$.\n",
     "\n",
-    "The draw uses `jax.random.bernoulli`. The `drive` and the coupling parameter the kernel consumes already carry the inverse temperature $\\beta$, because we supply $\\text{drive}_i = \\beta\\,b_i$ and $j = \\beta J$, so $\\gamma_i$ is the $\\beta$-scaled local field. The brute-force `exact_distribution` below instead takes the raw physical field $b_i$ and applies $\\beta$ itself, so the two paths agree on the same physics from different inputs.\n",
+    "The draw uses `jax.random.bernoulli`. Both inputs to the local field already include the inverse temperature: we provide $\\text{drive}_i = \\beta\\,b_i$ and set the factor parameter to $j = \\beta J$. By contrast, the brute-force `exact_distribution` defined later accepts the physical field $b_i$ and applies $\\beta$ itself. These two interfaces compute the same conditional:\n",
     "\n",
     "$$\n",
     "\\gamma_i = \\beta\\,b_i + \\beta J\\,\\sum_{j\\in\\mathcal{N}(i)} s_j,\n",
@@ -431,9 +431,9 @@
    "id": "4bf06659",
    "metadata": {},
    "source": [
-    "Now we probe the factor, because a conditional that is subtly wrong would still produce plausible-looking lattices later. We fix the neighbors and `drive` by hand, compute the resulting local field $\\gamma$, draw the update many times, and check that the fraction of $+1$ spins matches $\\sigma(2\\gamma)$.\n",
+    "Before assembling the lattice, we check the factor in isolation. A small error in the conditional can still produce plausible-looking configurations, so visual inspection is not enough. We fix the neighbors and `drive`, compute the resulting local field $\\gamma$, draw many updates, and compare the observed fraction of $+1$ spins with $\\sigma(2\\gamma)$.\n",
     "\n",
-    "This is the single-spin check: the factor samples its conditional, and it reports that same conditional analytically."
+    "This check establishes that `sample` follows the intended single-spin conditional. We next ask whether `log_probability` reports the same distribution."
    ]
   },
   {
@@ -696,9 +696,9 @@
    "id": "c4f4fb09",
    "metadata": {},
    "source": [
-    "With the pieces in hand, we wire the three `Site` objects into the `DFG` that performs one sweep.\n",
+    "We now assemble one complete Gibbs sweep from three `Site` objects. The first site updates color `A`, the second updates color `B` using the new color-`A` values, and the final deterministic site reassembles both blocks into a state vector.\n",
     "\n",
-    "Each block updates all of its spins in parallel, so a block appears in the graph as one tiled factor rather than as eight separate `Site` objects."
+    "Because the eight conditionally independent spins in a block update in parallel, each color appears as one tiled factor rather than as eight separate `Site` objects."
    ]
   },
   {
@@ -785,11 +785,11 @@
    "source": [
     "## Running the chain\n",
     "\n",
-    "The `DFG` above performs exactly one Gibbs sweep, so sampling the model means repeating it. A weight-tied `ChainFactor` does that: it runs the same sweep for many steps with one shared coupling, which is the Torx idiom for a Markov chain Monte Carlo (MCMC) chain.\n",
+    "The `DFG` above performs one Gibbs sweep. To obtain a Markov chain, we repeat that graph with a weight-tied `ChainFactor`, so every step uses the same sweep and the same coupling parameters.\n",
     "\n",
-    "The `drive` input, which carries the $\\beta$-scaled field, is a non-feedback input, so the chain holds it fixed at every step and threads only the spins from one sweep into the next.\n",
+    "Only the spin state feeds back from one sweep to the next. The `drive`, which contains the $\\beta$-scaled field, is a non-feedback input and therefore remains fixed throughout a chain.\n",
     "\n",
-    "We then run 200 sweeps on each of 4,000 independent chains and keep one final sample from each, which gives 4,000 draws that are independent by construction rather than 4,000 correlated points along a single trajectory."
+    "We run 200 sweeps for each of 4,000 independently initialized chains and retain one final state from each chain. The resulting 4,000 draws come from separate chains rather than from successive, correlated states of one trajectory."
    ]
   },
   {
@@ -887,9 +887,9 @@
    "id": "77e99a27",
    "metadata": {},
    "source": [
-    "Before comparing distributions, we want a rough sense of whether 200 sweeps gives the chains room to settle. So we start many chains from a disordered state and track the **order parameter** at each sweep: the magnitude of the average spin, averaged across chains. It runs from 0 for a lattice with no net direction to 1 for a fully aligned one.\n",
+    "Before comparing final-sample distributions, we examine whether 200 sweeps gives the chains time to settle from a disordered start. At each sweep we compute the **order parameter**, the magnitude of the mean spin for each chain, and then summarize it across chains. The order parameter is 0 for a lattice with no net direction and 1 for a fully aligned lattice.\n",
     "\n",
-    "In the figure, the bold line is that mean and the band is the 16th to 84th percentile range across chains. The dashed line marks sweep 80, a reference we picked by hand so we can see whether the trace has levelled off well before the 200th sweep the chain actually runs."
+    "The bold curve shows the mean order parameter, and the band spans the 16th to 84th percentiles across chains. The dashed line marks sweep 80. This hand-chosen reference lets us compare the apparent leveling of the trace with the full 200-sweep runtime; it is not an estimated mixing time."
    ]
   },
   {
@@ -979,7 +979,7 @@
    "id": "e9446982",
    "metadata": {},
    "source": [
-    "The order parameter climbs off its disordered start and then flattens before the marker. Read that as a settling cue rather than as proof of mixing, because a single order parameter can't tell us whether the chains move between the two mirror-image ordered states. The exact-distribution comparisons below are the real test, and they check the final-sample distribution at this 200-sweep runtime."
+    "The order parameter rises from its disordered initial value and becomes approximately flat before the marker. This is evidence that this observable has settled, but it does not establish that the chains have mixed: the magnitude cannot reveal whether a chain moves between the two mirror-image ordered states. We therefore treat the trace as a diagnostic and use exact-distribution comparisons to evaluate the final samples after 200 sweeps."
    ]
   },
   {
@@ -1172,11 +1172,11 @@
    "source": [
     "## Cooling the model\n",
     "\n",
-    "As the magnet cools, it orders, and the order parameter is how we measure that: 0 when the lattice has no net direction, 1 when it's fully aligned.\n",
+    "Cooling increases magnetic order. We measure that change with the same order parameter: 0 indicates no net direction, while 1 indicates complete alignment.\n",
     "\n",
-    "We sweep six inverse temperatures from 0.10 to 0.60 and compare three curves, each answering a different question. Enumeration gives the exact order parameter for this $4\\times4$ torus, so it's the ground truth. The sampler curve tells us whether the chain recovers that truth across the whole temperature range rather than only at the baseline we used above. The [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory) replaces each spin's neighbors with their expected average, which discards exactly the fluctuations that dominate near a transition, so we expect it to part company with the other two curves in the middle of the range.\n",
+    "We evaluate six inverse temperatures from 0.10 to 0.60 and compare three curves. Exact enumeration gives the order parameter for this $4\\times4$ torus. The sampler curve tests whether the chain follows that reference across the full range, rather than only at the baseline temperature considered above. Finally, the [mean-field approximation](https://www.scholarpedia.org/article/Mean_field_theory) replaces neighboring spins with their expected average. Because this replacement removes the fluctuations that are important near a transition, we expect mean field to differ most in the middle of the range.\n",
     "\n",
-    "Two reference points explain where that disagreement comes from. Mean field predicts zero order below its own critical inverse temperature $\\beta = 1/(4J) = 0.25$, while the infinite square lattice has the [exact critical point](#ref-onsager1944) $\\beta_c J = \\tfrac{1}{2}\\log(1+\\sqrt{2}) \\approx 0.4407$. This $4\\times4$ torus is too small to have a true phase transition at either value. What it has instead is a [finite-size crossover](#ref-fisher1972), the smooth change a finite system shows in place of a singular transition, near that infinite-lattice point.\n",
+    "Two reference points help interpret the comparison. Mean field predicts zero order below its critical inverse temperature $\\beta = 1/(4J) = 0.25$, whereas the infinite square lattice has the [exact critical point](#ref-onsager1944) $\\beta_c J = \\tfrac{1}{2}\\log(1+\\sqrt{2}) \\approx 0.4407$. A $4\\times4$ torus is too small to have a true phase transition at either value. Instead, it exhibits a [finite-size crossover](#ref-fisher1972): a smooth change in order near the infinite-lattice critical point.\n",
     "\n",
     "<details class=\"tx-disclosure\"><summary>Where the sampler curve comes from</summary><p>The sampler curve comes from <code>sweep_temperatures</code> in <code>examples/helpers/_plots_sampling.py</code>, which runs fresh chains at each inverse temperature and reports their order parameter.</p></details>"
    ]
@@ -1327,7 +1327,7 @@
    "source": [
     "## Checking against the exact answer\n",
     "\n",
-    "Matching a magnetization histogram is a coarse test, because many different samplers could produce the same one. For a fixed field the Boltzmann distribution over 16 spins is small enough to enumerate, which is what `exact_distribution` computes, so with that exact reference in hand we can match the sampler spin by spin and connection by connection instead."
+    "The magnetization histogram is a useful aggregate, but it is not sufficient: different joint distributions can have the same total-magnetization distribution. Because all 16-spin states can be enumerated, `exact_distribution` gives us a stronger reference for any fixed field. We can compare the sampler with it separately for each spin and each connection."
    ]
   },
   {
@@ -1335,9 +1335,9 @@
    "id": "4ef9a5ec",
    "metadata": {},
    "source": [
-    "To make this check meaningful, we drive the model with a field that varies from site to site. The spins are no longer all equivalent, so each one has its own exact marginal to be checked against.\n",
+    "For this comparison, we apply a field that varies from site to site. The field breaks the equivalence among spins, giving each site a distinct exact marginal.\n",
     "\n",
-    "The left panel shows the average value of each spin. The right panel shows the average agreement across each connection, sampler against exact."
+    "The left panel compares the sampled and exact mean of every spin. The right panel makes the corresponding comparison for mean agreement across every connection. In both panels, the diagonal represents exact agreement."
    ]
   },
   {
@@ -1498,11 +1498,11 @@
    "source": [
     "## Driving it with a field\n",
     "\n",
-    "Because the `field` is an input, the same graph can perform field-conditioned pattern completion.\n",
+    "Because `field` is an input, we can now use the same graph for field-conditioned pattern completion.\n",
     "\n",
-    "We set a field of magnitude 6 on a few sites, leave the rest at zero, and run the chain. The selected spins remain stochastic, so this finite field biases them strongly toward its sign rather than pinning them, while the zero-field sites fill in around them. That distinction is why the verification below checks the biased-site marginals against the exact field-conditioned distribution rather than checking the sign alone.\n",
+    "We apply a field of magnitude 6 at a small set of sites, leave the remaining sites at zero, and run the chain. The selected spins are still stochastic: the finite field strongly favors its sign but does not pin them. The zero-field sites then sample around those biases. For this reason, we compare the biased-site marginals with the exact field-conditioned distribution instead of checking only whether their signs agree.\n",
     "\n",
-    "This is the field-conditioned Boltzmann machine, $P(\\text{spins} \\mid \\text{field})$. Between this and the plots above, only the `field` input changes."
+    "The result is the field-conditioned Boltzmann machine $P(\\text{spins} \\mid \\text{field})$. Relative to the previous experiments, only the `field` input has changed."
    ]
   },
   {
@@ -1761,17 +1761,17 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "We built a Boltzmann machine from hand-written factors, sampled it with Gibbs, and checked it against an exact brute-force reference.\n",
+    "We constructed a Boltzmann machine from hand-written factors, sampled it with Gibbs updates, and compared its outputs with exact enumeration.\n",
     "\n",
-    "- A single spin update is one factor: a directed conditional that draws a pbit with value $1$ with probability $\\sigma(2\\gamma_i)$ and reports that same one-spin conditional through `log_probability`. The probe confirmed that the sampled fraction and the analytic value both reproduce that sigmoid.\n",
-    "- The two checkerboard colors are two Gibbs blocks, each with the same factor tiled across its eight spins and one shared coupling. The `DeterministicFactor` object reassembles them into one state, giving an explicit three-site `DFG` for one Gibbs sweep.\n",
-    "- The weight-tied `ChainFactor` object repeats the sweep into an MCMC chain. At the chosen 200-sweep runtime, the final-chain samples match the exact distribution within the reported errors, spin by spin and connection by connection.\n",
-    "- Cooling the model raises the order parameter through the finite-size crossover. The mean-field approximation overshoots there, and the sampler tracks the exact curve.\n",
-    "- Because the `field` is an input, we used the same graph for finite-field pattern completion with no change to the wiring, giving the field-conditioned Boltzmann machine $P(\\text{spins} \\mid \\text{field})$.\n",
+    "- A single spin update is one directed factor. It draws a pbit with value $1$ with probability $\\sigma(2\\gamma_i)$ and reports the same one-spin conditional through `log_probability`; the probe showed agreement between the sampled fraction and analytic probability.\n",
+    "- The checkerboard colors form two Gibbs blocks. Each block tiles the same factor over eight spins with one shared coupling, and a `DeterministicFactor` reassembles the blocks. Together, these three sites define the `DFG` for one sweep.\n",
+    "- A weight-tied `ChainFactor` repeats the sweep to form an MCMC chain. After 200 sweeps, final states from independent chains match the exact distribution within the reported per-spin and per-connection errors.\n",
+    "- As the model cools, the order parameter rises through the finite-size crossover. The sampler follows the exact curve, while mean field overestimates the order in the crossover region.\n",
+    "- Since `field` is an input, the same graph also performs finite-field pattern completion without any change to its wiring, representing $P(\\text{spins} \\mid \\text{field})$.\n",
     "\n",
-    "[Notebook 06](06_ising_sampling_contrastive_divergence.ipynb) applies the same chromatic-Gibbs conditional idea with `PNOT` gates on an 8-spin ring. This tutorial writes that conditional as factors on a $4\\times4$ torus, so the two share the update rule and coloring strategy while their graphs and Ising distributions differ.\n",
+    "[Notebook 06](06_ising_sampling_contrastive_divergence.ipynb) applies the same chromatic-Gibbs conditional with `PNOT` gates on an 8-spin ring. Here, the conditional is expressed as factors on a $4\\times4$ torus; the update rule and coloring strategy are shared, while the graph and Ising distribution differ.\n",
     "\n",
-    "What this notebook is really about is the `DFG`: a custom factor with an analytic conditional, tiling, weight tying, and deterministic reassembly, composed into a graph whose output we can verify exactly. Gibbs sampling was the vehicle for that tour rather than the destination. If you want Gibbs sampling as a working tool, reach for [thrml](https://github.com/extropic-ai/thrml), which is built for it."
+    "Gibbs sampling provides a concrete way to exercise the `DFG` workflow: an analytic custom conditional is tiled, weight-tied, and combined with deterministic reassembly, and the resulting graph can be checked exactly. For Gibbs sampling as a working tool rather than as a demonstration of these Torx components, use [thrml](https://github.com/extropic-ai/thrml)."
    ]
   },
   {

--- a/examples/basic_usage.ipynb
+++ b/examples/basic_usage.ipynb
@@ -23,7 +23,7 @@
    "id": "5770cbd2",
    "metadata": {},
    "source": [
-    "In this tutorial, we build a parametrised stochastic circuit and train it end to end, so the whole Torx workflow shows up in a single pass before you reach for the detailed guides. It's the quickstart companion to [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb), the full tour that introduces each gate and data primitive at a slower pace.\n",
+    "In this tutorial, we build a parametrised stochastic circuit and train it end to end, following the Torx workflow from circuit construction through simulation and parameter updates. This compact notebook is the quickstart companion to [`01_introduction_to_parametrised_stochastic_circuits.ipynb`](01_introduction_to_parametrised_stochastic_circuits.ipynb), which introduces each gate and data primitive in more detail.\n",
     "\n",
     "By the end, you'll be able to:\n",
     "\n",
@@ -226,7 +226,7 @@
    "id": "a4ee709d",
    "metadata": {},
    "source": [
-    "The loss rebuilds the compiled circuit from `thetas` inside the function, so gradients flow straight back to the parameters. We push the output distribution toward an even split between |00) and |11) with a squared error, then wrap one Adam update in a jitted step."
+    "Inside the loss, we rebuild the compiled circuit from `thetas`; this keeps the computation differentiable with respect to those parameters. The squared-error objective compares the output distribution with an even split between |00) and |11), and the jitted step applies one Adam update."
    ]
   },
   {
@@ -460,9 +460,9 @@
    "source": [
     "## Sampled vs exact gradients\n",
     "\n",
-    "The `BranchingSimulator` estimates gradients by parameter-shift sampling, while the `StateVectorSimulator` computes them exactly. We train the same circuit from the same starting parameters down both paths and compare the loss curves.\n",
+    "The `BranchingSimulator` estimates gradients by parameter-shift sampling, whereas the `StateVectorSimulator` computes them exactly. To compare the two, we train the same circuit from the same initial parameters with each simulator and compare the loss curves.\n",
     "\n",
-    "We compile each circuit once, outside the jitted step, and optimize the compiled circuit directly, since its parameters are inexact-array leaves. The sampled simulator bakes the structure into arrays during compilation, and that step can't be re-run under `jit`, so it has to happen before the training loop."
+    "For this comparison, we compile each circuit once before entering the jitted step and optimize the compiled circuit directly, since its parameters are inexact-array leaves. The sampled simulator encodes the circuit structure as arrays during compilation. Because that compilation cannot run under `jit`, it must happen before the training loop."
    ]
   },
   {


### PR DESCRIPTION
## What changed

Follow-up prose pass across all 17 example notebooks, using Distill's [Understanding Convolutions on Graphs](https://distill.pub/2021/understanding-gnns/) as the voice reference.

The edits remove lecture-style takeaway narration and replace it with concrete problem, mechanism, evidence, and consequence. Definitions now sit closer to what they change; figure prose says what the plot encodes and supports; limitations are stated directly. Notebook 15 keeps the actual design point—the same `sample(key, inputs, params)` interface across a factor, graph, and composite—without telling the reader what lesson to carry away.

An independent review also caught a false `JaxPRNGSampler` attribution in notebook 15. The factor implementations call JAX random primitives directly; Torx supplies the factor contracts, routing, graph, and composites. All occurrences were corrected and re-reviewed.

## Scope

- 17 notebooks
- 176 revised markdown cells
- prose only
- no code, outputs, execution counts, cell counts, or metadata changed

## Verification

- `nbformat.validate`: all 17 notebooks valid
- structural hashes: code cells, outputs, execution counts, notebook metadata unchanged
- `nbconvert` smoke render: all 17 notebooks rendered, 19,182,632 total HTML bytes
- `pytest -q tests/test_docs_renderer.py`: 5 passed
- `pre-commit run --all-files`: isort, black, flake8, pyright passed
- four independent reviewer passes over every changed markdown cell; one technical attribution finding fixed and re-reviewed

Notebook execution was not repeated because every non-markdown cell is byte-identical. The examples CI remains the execution gate.

## Reviewing this

Start with `examples/15_intro_to_factors.ipynb`, especially the opening, the single-factor sampling sections, the ownership table, and the conclusion. That notebook contains the calling-convention explanation that motivated this pass.
