### PR TITLE
docs: polish public launch details

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ print(f"Final distribution: {density}")
 If you found this library useful in academic research, please cite:
 
 ```bibtex
-@misc{verdon2026stochastic,
-  title  = {A Framework for Stochastic Differentiable Programming},
-  author = {Verdon, Guillaume and Tyrpak, Leo and Lockwood, Owen and Morton, Seth
-            and Neagoe, Alexander and Sugolov, Anton and MacCormack, Ian and Amico, Mirko},
-  year   = {2026},
-  note   = {White paper, Extropic},
-  url    = {https://github.com/extropic-ai/torx},
+@misc{verdon2026frameworkstochasticdifferentiableprogramming,
+  title         = {A Framework for Stochastic Differentiable Programming},
+  author        = {Guillaume Verdon and Leo Tyrpak and Owen Lockwood and Seth Morton and Alexander Neagoe and Anton Sugolov and Ian MacCormack and Mirko Amico},
+  year          = {2026},
+  eprint        = {2608.01612},
+  archivePrefix = {arXiv},
+  primaryClass  = {cs.ET},
+  url           = {https://arxiv.org/abs/2608.01612},
 }
 ```
 

--- a/docs_site/scripts/render/assets.py
+++ b/docs_site/scripts/render/assets.py
@@ -36,3 +36,4 @@ INDEX_SCRIPT = read_site_asset("index.js")
 NAV_TRANSITION = read_site_asset("nav_transition.html")
 # torx mark inlined into the top bar and landing header
 LOGO_SVG = read_site_asset("logo.svg").strip()
+FAVICON_LINK = '<link rel="icon" type="image/svg+xml" href="assets/logo.svg">\n'

--- a/docs_site/scripts/render/chrome.py
+++ b/docs_site/scripts/render/chrome.py
@@ -9,6 +9,7 @@ from pygments.lexers import get_lexer_by_name, PythonLexer
 
 from .assets import (
     COPY_SCRIPT,
+    FAVICON_LINK,
     LOGO_SVG,
     NAV_TRANSITION,
     PAGE_SCRIPT,
@@ -166,7 +167,8 @@ def _inject_after_content_main(html, insertion):
 def inject_chrome(html, site, api_categories, active_stem, title):
     """Add the theme, top bar, sidebar, and social-card metadata to a notebook page."""
     head_extra = (
-        og_meta(f"{title} - Torx", f"{active_stem}.html")
+        FAVICON_LINK
+        + og_meta(f"{title} - Torx", f"{active_stem}.html")
         + PRELUDE_CSS
         + THEME_CSS
         + NAV_TRANSITION

--- a/docs_site/scripts/render/manifest.py
+++ b/docs_site/scripts/render/manifest.py
@@ -44,7 +44,7 @@ ASSET_CDN = "."
 DOCS_ASSETS_DIR = Path(os.environ.get("TORX_DOCS_ASSETS") or (ROOT / "_assets"))
 
 # brand media copied into rendered/assets/ each build; landing and getting-started reference these
-BRAND_MEDIA = ("extropic_wordmark.png", "first_circuit.png")
+BRAND_MEDIA = ("extropic_wordmark.png", "first_circuit.png", "logo.svg")
 
 
 def repository_source_url(path):

--- a/docs_site/scripts/render/pages.py
+++ b/docs_site/scripts/render/pages.py
@@ -6,6 +6,7 @@ import re
 from .assets import (
     COPY_SCRIPT,
     DOC_CSS,
+    FAVICON_LINK,
     INDEX_CSS,
     INDEX_SCRIPT,
     LOGO_SVG,
@@ -60,7 +61,7 @@ FIRST_CIRCUIT = (
 )
 
 COPY_SVG = (
-    '<svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+    '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
     'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
     '<rect x="9" y="9" width="13" height="13" rx="2"/>'
     '<path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>'
@@ -89,6 +90,7 @@ def write_doc_page(
         '<!doctype html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         f"<title>{title} - Torx</title>\n"
+        + FAVICON_LINK
         + og_meta(f"{title} - Torx", f"{slug}.html")
         + PRELUDE_CSS
         + THEME_CSS
@@ -228,7 +230,8 @@ def write_index(site, *, out_dir):
         '<meta charset="utf-8">\n'
         '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
         "<title>Torx - Parametrised Stochastic Circuits</title>\n"
-        '<meta name="description" content="Torx is a JAX framework for parametrised stochastic circuits: programs that transform probability distributions, with docs and runnable example notebooks.">\n'
+        + FAVICON_LINK
+        + '<meta name="description" content="Torx is a JAX framework for parametrised stochastic circuits: programs that transform probability distributions, with docs and runnable example notebooks.">\n'
         + og_meta("Torx - Parametrised Stochastic Circuits", "index.html")
         + PRELUDE_CSS
         + "<style>\n"

--- a/docs_site/scripts/site_assets/index.css
+++ b/docs_site/scripts/site_assets/index.css
@@ -93,6 +93,9 @@
   .tx-codecard .tx-copy.tx-copied { color: var(--tx-gold); }
   .tx-codecard pre { margin: 0; padding: .35rem 1.4rem 1rem; overflow-x: auto; color: var(--tx-body);
     font-family: var(--tx-mono); font-size: 12.5px; line-height: 1.78; }
+  @media (max-width: 40rem) {
+    .tx-codecard pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+  }
   .tx-codecard .tx-code-output { display: flex; gap: .75rem; align-items: baseline; border-top: 1px solid rgba(144,48,1,.45);
     padding: .65rem 1.4rem .85rem; color: var(--tx-landing-muted); font-family: var(--tx-mono); font-size: 12px; }
   .tx-codecard .tx-code-output span { color: #9a7a52; text-transform: uppercase; font-size: 10px; letter-spacing: .01em; }


### PR DESCRIPTION
## Summary

- replace the placeholder citation with the official arXiv BibTeX for `2608.01612`
- publish the canonical orange Torx mark as the favicon on rendered docs and notebooks
- keep the landing-page copy button geometry fixed when it changes to the checkmark
- wrap the landing quickstart code on phones so lines remain visible without horizontal scrolling

## Verification

- `uv run --frozen --extra testing --extra docs pytest -q tests/test_docs_renderer.py` (`5 passed`)
- `uv run --frozen --extra docs python docs_site/scripts/build_site.py` (`16 notebooks + getting-started + 6 API pages + index + llms.txt`)
- `uv run --frozen --extra testing pre-commit run --all-files` (`isort`, `black`, `flake8`, and `pyright` passed)
- `uv run --with build python -m build` produced the `0.0.1` sdist and wheel
- browser checks at 1440px and 390px confirmed the favicon renders, copy-state geometry stays fixed, and the mobile quickstart has no horizontal overflow
- thermonuclear maintainability review passed with no remaining findings
