### PR TITLE
Stabilize the single-shift logit transform

### DIFF
--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -19,6 +19,7 @@ from torx.psc import (
     PSWAP,
     StateVectorSimulator,
 )
+from torx.psc.simulation.sampled import _single_shifted_theta
 
 # (name, class, num_sites)
 ALL_BINARY_GATES = [
@@ -53,6 +54,30 @@ def get_initial_basis(num_sites):
 def make_thetas(*values):
     """Build an external theta list (one ``(1,)`` array per 2-branch gate)."""
     return [jnp.atleast_1d(v) for v in values]
+
+
+def test_single_shifted_theta_is_stable_for_saturated_logits():
+    theta = jnp.array([-100.0, -20.0, 0.0, 20.0, 100.0], dtype=jnp.float32)
+
+    shifted = _single_shifted_theta(theta)
+    expected = theta - jnp.logaddexp(jnp.log(jnp.array(2.0)), -theta)
+
+    assert jnp.all(jnp.isfinite(shifted))
+    assert jnp.allclose(shifted, expected)
+
+
+def test_param_shift_single_gradient_is_finite_for_saturated_logits():
+    circuit = DiscretePCircuit([PNOT(0)])
+    simulator = BranchingSimulator(num_samples=32, diff_method="param_shift_single")
+    initial_basis = jnp.array([0], dtype=jnp.int32)
+
+    def loss(theta):
+        compiled = simulator.build_circuit(circuit, [theta])
+        return simulator.expval_all(compiled, initial_basis, jax.random.key(0)).sum()
+
+    for theta in [-100.0, -20.0, 0.0, 20.0, 100.0]:
+        gradient = jax.grad(loss)(jnp.array([theta], dtype=jnp.float32))
+        assert jnp.all(jnp.isfinite(gradient))
 
 
 class TestGradientUnbiasedness(unittest.TestCase):

--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -57,10 +57,13 @@ def make_thetas(*values):
 
 
 def test_single_shifted_theta_is_stable_for_saturated_logits():
-    theta = jnp.array([-100.0, -20.0, 0.0, 20.0, 100.0], dtype=jnp.float32)
+    theta = jnp.array([-100.0, 0.0, 15.0, 17.0, 20.0, 100.0], dtype=jnp.float32)
 
     shifted = _single_shifted_theta(theta)
-    expected = theta - jnp.logaddexp(jnp.log(jnp.array(2.0)), -theta)
+    expected = jnp.array(
+        [-200.0, -1.0986123, 14.306852, 16.306852, 19.306852, 99.306854],
+        dtype=jnp.float32,
+    )
 
     assert jnp.all(jnp.isfinite(shifted))
     assert jnp.allclose(shifted, expected)

--- a/torx/psc/simulation/sampled.py
+++ b/torx/psc/simulation/sampled.py
@@ -753,6 +753,14 @@ def sample_expval_all_param_shift_inf_bwd(
     return grad_circuit
 
 
+def _single_shifted_theta(
+    theta: Float[Array, " ..."],
+) -> Float[Array, " ..."]:
+    """Return the numerically stable single-shift parameter."""
+    log_two = jnp.log(jnp.asarray(2, dtype=theta.dtype))
+    return theta - jnp.logaddexp(log_two, -theta)
+
+
 @eqx.filter_custom_vjp
 def sample_expval_all_param_shift_single(
     circuit: CompiledBranchingPCircuit,
@@ -838,7 +846,7 @@ def sample_expval_all_param_shift_single_bwd(
 
     # (num_gates, num_gates, 1)
     shifted_thetas = jnp.tile(circuit.thetas[None, :, :], (num_gates, 1, 1))
-    shift_values = -jnp.log((1 + jnp.exp(-theta_flat)) ** 2 - 1)  # (num_gates,)
+    shift_values = _single_shifted_theta(theta_flat)  # (num_gates,)
     shifted_thetas = shifted_thetas.at[
         jnp.arange(num_gates), jnp.arange(num_gates), 0
     ].set(shift_values)


### PR DESCRIPTION
## Summary

- rewrite the single-shift logit transform with a numerically stable, algebraically equivalent expression
- preserve the input dtype when constructing the log(2) constant
- add regression coverage for saturated float32 logits and the end-to-end gradient path

## Why

The previous expression can overflow for large negative logits and suffer cancellation for positive logits, producing infinities at ordinary saturated float32 values. The new implementation uses logaddexp and remains finite across the tested range from -100 to 100.

## Validation

- `pytest tests/test_gradients.py -q -k 'single_shifted_theta or single_gradient_is_finite'`
- existing param_shift_single simulator gradient tests
- isort, Black, Flake8, and Pyright through pre-commit

Closes #16
