### PR TITLE
docs + test: enforce compile-once circuit structure latency invariant…

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,15 @@ density = sim.density(compiled, state)
 print(f"Final distribution: {density}")
 ```
 
+### Latency invariant (compile-once)
+
+Circuit **structure** must be compiled once via `sim.build_circuit(circuit, thetas)`.
+Rebuilding the structure on every call forces a full JAX re-trace and can cost
+two to three orders of magnitude more wall time (observed: 2 690 ms → 28 ms).
+
+Only the continuous parameters (`thetas`) should vary after compilation.
+See issue [#24](https://github.com/extropic-ai/torx/issues/24).
+
 ## Citation
 
 If you found this library useful in academic research, please cite:

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -49,3 +49,52 @@ class TestPerformance(unittest.TestCase):
         tol = 0.15
         self.assertLess(compile_time_dev, expected_compile_time * (1 + tol))
         self.assertLess(execute_time_dev, expected_execute_time * (1 + tol))
+
+    def test_compile_once_latency_invariant(self):
+        """Compile-once path must remain substantially faster than rebuild-per-call.
+
+        Rebuilding circuit structure inside the region that JAX traces forces a
+        full re-trace on every invocation and has been measured at ~100-900x
+        higher latency (issue #24). This test keeps the compile-once path the
+        fast path under a relative ordering constraint.
+        """
+        gates = [PCNOT([0, 1])]
+        structure = DiscretePCircuit(gates * 32)
+        sim = BranchingSimulator(num_samples=32)
+        thetas = structure.init_params(jax.random.PRNGKey(0))
+        key = jax.random.key(0)
+        init_state = jnp.zeros(2, dtype=jnp.int32)
+
+        # Correct path: compile structure once, then JIT only the execution.
+        compiled = sim.build_circuit(structure, thetas)
+        expval_jit = eqx.filter_jit(sim.expval_all)
+
+        # Warm-up
+        _ = expval_jit(compiled, init_state, key).block_until_ready()
+
+        start = time.time()
+        for _ in range(20):
+            _ = expval_jit(compiled, init_state, key).block_until_ready()
+        compiled_time = (time.time() - start) / 20
+
+        # Anti-pattern approximation: re-build structure on every call.
+        def rebuild_and_run(_):
+            c = sim.build_circuit(structure, thetas)
+            return sim.expval_all(c, init_state, key)
+
+        # Intentionally *not* JITting the rebuild so the cost of structure
+        # construction + re-trace is visible.
+        start = time.time()
+        for _ in range(5):
+            _ = rebuild_and_run(None).block_until_ready()
+        rebuild_time = (time.time() - start) / 5
+
+        # Structural invariant: compiled path must stay clearly faster.
+        self.assertLess(
+            compiled_time * 3,
+            rebuild_time,
+            msg=(
+                "compile-once path lost its latency advantage "
+                f"(compiled={compiled_time:.4f}s, rebuild={rebuild_time:.4f}s)"
+            ),
+        )


### PR DESCRIPTION
… (#24)

Document the structural latency invariant (rebuild triggers full JAX re-trace) and add a regression that keeps the compile-once path the fast path. No changes to simulators or backends.