### PR TITLE
fix: unbiased param_shift_filter via score-function + LOO baseline (#9)

### DIFF
--- a/tests/test_gradients.py
+++ b/tests/test_gradients.py
@@ -539,5 +539,238 @@ class TestGradientVariance(unittest.TestCase):
         )
 
 
+class TestParamShiftFilterZeroCount(unittest.TestCase):
+    """Regression tests for issue #9: param_shift_filter must remain unbiased
+    when a branch receives zero samples.
+
+    The previous estimator substituted 0 for E[O | branch] on zero-count
+    branches, which biased the gradient. The current estimator uses a
+    score-function identity with a leave-one-out baseline, which is unbiased
+    for any fixed cotangent when samples are i.i.d. rollouts.
+    """
+
+    def test_unbiased_at_zero_count(self):
+        """End-to-end unbiasedness at N=1 via forced-branch enumeration.
+
+        PCNOT with control=0 leaves the state unchanged regardless of which
+        branch fires, so the true gradient is exactly 0. We run the full
+        jax.grad path at num_samples=1 for seeds covering both branch
+        outcomes, then assert the p_k-weighted average equals 0.
+
+        Testing at theta=0 alone is insufficient: at theta=0, p_k = 0.5 and
+        the p_k-weighted average coincides with the plain average, which
+        could mask a weighting bug. We also test at theta=0.5.
+        """
+        from torx.psc.simulation.sampled import sample_circuit
+
+        circuit = DiscretePCircuit([PCNOT([0, 1])])
+        initial = jnp.array([0, 1], dtype=jnp.int32)
+
+        for theta_val in (0.0, 0.5):
+            with self.subTest(theta=theta_val):
+                thetas = [jnp.array([theta_val])]
+                p_branch1 = float(jax.nn.sigmoid(theta_val))
+                p_branch0 = 1.0 - p_branch1
+
+                sim = BranchingSimulator(num_samples=1, diff_method="param_shift_filter")
+                compiled = sim.build_circuit(circuit, thetas)
+
+                def loss(thetas_list, key):
+                    c = sim.build_circuit(circuit, thetas_list)
+                    return sim.expval_all(c, initial, key).sum()
+
+                grad_fn = jax.jit(jax.grad(loss))
+
+                # Find one seed per branch outcome, deterministically.
+                grads_by_branch = {}
+                for seed in range(1000):
+                    key = jax.random.key(seed)
+                    _, branch_indices = sample_circuit(compiled, initial, key, 1)
+                    branch = int(branch_indices[0, 0, 0])
+                    if branch not in grads_by_branch:
+                        grads_by_branch[branch] = float(grad_fn(thetas, key)[0][0])
+                    if len(grads_by_branch) == 2:
+                        break
+
+                self.assertEqual(
+                    len(grads_by_branch), 2,
+                    f"Could not find seeds covering both branches at theta={theta_val}"
+                )
+
+                expected = (
+                    p_branch0 * grads_by_branch[0] + p_branch1 * grads_by_branch[1]
+                )
+                self.assertAlmostEqual(
+                    expected, 0.0, places=6,
+                    msg=(
+                        f"theta={theta_val}: p_k-weighted mean gradient "
+                        f"{expected:.6f} != 0; branch grads = {grads_by_branch}"
+                    ),
+                )
+
+    def test_variance_pin_at_1k(self):
+        """Score+LOO gradient SD at N=1000 must be below the analytic bound.
+
+        Circuit: PNOT(0) on a 5-pbit state where pbits 1..4 are pinned at 1
+        by the initial basis; loss = weighted sum over all pbits.
+
+        Bound derivation (theta=0, p=0.5):
+          E[score^2] = p(1-p) = 0.25
+          With random per-pbit weights w_i in [0.5, 2]:
+            Var(O * w) under LOO = Var(O_pbit0) * w_0^2 <= (1/4) * 4 = 1
+          Leading-order estimator SD <= sqrt(E[score^2] * 1 / N)
+                                     = sqrt(0.25 / 1000) = 0.0158
+          With 1.5x slack for baseline cross-terms (the N summands are
+          pairwise-uncorrelated with the score but not mutually independent
+          through the shared baseline):
+            bound = 0.0158 * 1.5 = 0.0237, rounded up to 0.025.
+
+        Discrimination: the raw-score estimator (no baseline) scales with
+        E[O^2], not Var(O). With weights in [0.5, 2] and four pbits pinned
+        at 1, E[O^2] ~= (sum w_i)^2 + O(1) ~= 25+, giving raw-score SD
+        ~= sqrt(0.25 * 25 / 1000) = 0.079 >> 0.025. The bound therefore
+        separates score+LOO from raw score on this circuit.
+        """
+        # Random per-pbit weights ensure the constant offset from pinned
+        # pbits has non-trivial magnitude across coordinates.
+        rng_key = jax.random.key(0)
+        weights = jax.random.uniform(rng_key, (5,), minval=0.5, maxval=2.0)
+
+        thetas = [jnp.array([0.0])]
+        circuit = DiscretePCircuit([PNOT(0)])
+        initial = jnp.array([0, 1, 1, 1, 1], dtype=jnp.int32)
+
+        N = 1000
+        num_runs = 50
+
+        sim = BranchingSimulator(num_samples=N, diff_method="param_shift_filter")
+        compiled = sim.build_circuit(circuit, thetas)
+
+        def weighted_loss(thetas_list, key):
+            c = sim.build_circuit(circuit, thetas_list)
+            return (sim.expval_all(c, initial, key) * weights).sum()
+
+        grad_fn = jax.jit(jax.grad(weighted_loss))
+
+        grads = jnp.stack(
+            [grad_fn(thetas, jax.random.key(i))[0][0] for i in range(num_runs)]
+        )
+        sd = float(jnp.std(grads))
+
+        # Analytic: E[score^2] = 0.25. Var(O * w) under LOO = Var(O_pbit0 * w_0)
+        # = w_0^2 * p(1-p) * 1 <= 4 * 0.25 = 1. Leading-order SD <= sqrt(0.25 * 1 / N)
+        # = sqrt(0.25/1000) = 0.0158. With 1.5x slack: 0.0237.
+        bound = 0.025
+        self.assertLess(
+            sd, bound,
+            f"param_shift_filter SD {sd:.4f} exceeds analytic bound {bound} "
+            f"at N={N}; LOO baseline may be missing or misimplemented",
+        )
+
+    def test_mixed_arity_circuit(self):
+        """K=2 gate + K=4 pdit gate in the same circuit.
+
+        Padded branch slots must contribute exactly zero gradient. Verify by
+        comparing the K=2 gate's gradient to the same circuit without the
+        K=4 gate (the K=4 gate's presence should not change the K=2 gate's
+        gradient up to sampling noise).
+        """
+        # PditShift is a K=d gate on a d-state pdit (here d=4)
+        thetas_iso = make_thetas(0.3)
+        circuit_iso = DiscretePCircuit([PNOT(0)])
+
+        thetas_mixed = [jnp.array([0.3]), jnp.zeros(3)]  # K=4 → 3 logits
+        circuit_mixed = DiscretePCircuit([PNOT(0), PditShift(1, 4)])
+
+        sv_sim = StateVectorSimulator()
+
+        def sv_loss_iso(thetas):
+            c = sv_sim.build_circuit(circuit_iso, thetas)
+            return sv_sim.expval_all(c, jnp.array([1.0, 0.0])).sum()
+
+        analytic_iso = float(jax.grad(sv_loss_iso)(thetas_iso)[0][0])
+
+        # Sampled mixed circuit at high N
+        sim = BranchingSimulator(num_samples=20000, diff_method="param_shift_filter")
+        initial = jnp.array([0, 0], dtype=jnp.int32)
+
+        def sample_loss_mixed(thetas_list, key):
+            c = sim.build_circuit(circuit_mixed, thetas_list)
+            return sim.expval_all(c, initial, key)[0]  # just pbit 0
+
+        sample_grad_mixed = float(
+            jax.grad(sample_loss_mixed)(thetas_mixed, jax.random.key(0))[0][0]
+        )
+
+        # If padded branches leaked, the K=2 gate's gradient would be off.
+        # Compare to the isolated analytic value with generous tolerance.
+        self.assertAlmostEqual(
+            sample_grad_mixed, analytic_iso, delta=0.02,
+            msg=(
+                f"Mixed-arity: K=2 gate grad {sample_grad_mixed:.4f} "
+                f"vs isolated analytic {analytic_iso:.4f}"
+            ),
+        )
+
+    def test_reps_at_one_sample(self):
+        """reps=4 with num_samples=1: estimator must remain unbiased."""
+        circuit = DiscretePCircuit([PReset(0)], reps=4)
+        initial = jnp.array([1], dtype=jnp.int32)
+
+        thetas = make_thetas(0.0)
+        sim = BranchingSimulator(num_samples=1, diff_method="param_shift_filter")
+
+        def loss(thetas_list, key):
+            c = sim.build_circuit(circuit, thetas_list)
+            return sim.expval_all(c, initial, key).sum()
+
+        grad_fn = jax.jit(jax.grad(loss))
+
+        # PReset(0) sets pbit 0 to 0 with probability sigmoid(theta); at
+        # reps=4 and theta=0, the true gradient can be computed by
+        # StateVector. Compare the mean over forced-branch seeds to it.
+        sv_sim = StateVectorSimulator()
+
+        def sv_loss(thetas):
+            c = sv_sim.build_circuit(circuit, thetas)
+            return sv_sim.expval_all(c, jnp.array([0.0, 1.0])).sum()
+
+        true_grad = float(jax.grad(sv_loss)(thetas)[0][0])
+
+        # Average over many seeds at N=1 — should converge to true_grad.
+        num_seeds = 2000
+        grads = jnp.stack(
+            [grad_fn(thetas, jax.random.key(s))[0][0] for s in range(num_seeds)]
+        )
+        mean_grad = float(jnp.mean(grads))
+        # Each seed's grad has magnitude ~O(1); SD of the mean over 2000
+        # seeds is ~O(0.02). Use a 5-sigma tolerance to avoid flakes.
+        self.assertAlmostEqual(
+            mean_grad, true_grad, delta=0.1,
+            msg=f"reps=4 N=1: mean grad {mean_grad:.4f} vs true {true_grad:.4f}",
+        )
+
+    def test_degenerate_identical_observables(self):
+        """When all samples produce identical O, gradient must be 0 (no NaN)."""
+        # PNOT with theta very large => p ~= 1 => all samples take the same
+        # branch, all observables identical.
+        thetas = [jnp.array([20.0])]
+        circuit = DiscretePCircuit([PNOT(0)])
+        initial = jnp.array([0], dtype=jnp.int32)
+
+        sim = BranchingSimulator(num_samples=100, diff_method="param_shift_filter")
+
+        def loss(thetas_list):
+            c = sim.build_circuit(circuit, thetas_list)
+            return sim.expval_all(c, initial, jax.random.key(0)).sum()
+
+        grad = jax.grad(loss)(thetas)[0][0]
+        self.assertTrue(jnp.isfinite(grad), f"non-finite gradient: {grad}")
+        self.assertAlmostEqual(
+            float(grad), 0.0, places=5,
+            msg=f"degenerate-O gradient should be ~0, got {grad}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/torx/psc/simulation/sampled.py
+++ b/torx/psc/simulation/sampled.py
@@ -883,19 +883,41 @@ def sample_expval_all_param_shift_filter(
     Estimate the expectation value of all pbits after circuit execution.
 
     This is a wrapper function for `_expval_all` so that a custom VJP rule can
-    be defined without affecting core functionality. The VJP uses the
-    parameter shift rule with deterministic gates, but with no additional
-    circuit executions. For K-branch gates with softmax probabilities, the
-    gradient with respect to logits is:
+    be defined without affecting core functionality. The VJP uses a
+    score-function (likelihood-ratio) estimator with a leave-one-out baseline.
+
+    For K-branch gates with softmax probabilities $p = \mathrm{softmax}([0, \theta])$,
+    the gradient with respect to logits is:
 
     $$\frac{\partial \mathbb{E}[O]}{\partial \theta_k} =
-        p_k \left( \mathbb{E}[O|k] - \mathbb{E}[O] \right)$$
+        \mathbb{E}\left[ O \cdot \left(\mathbb{1}[\mathrm{branch} = k+1] - p_{k+1}\right) \right]$$
 
-    where $p_k = \text{softmax}([0, \theta])_k$ is the probability of branch $k$.
-    The difference between this VJP rule and `param_shift_inf` above is that,
-    for this rule, the conditional expectations $\mathbb{E}[O|k]$ are estimated
-    directly from the primal execution by filtering samples based on which
-    branch was selected at each gate.
+    estimated as
+
+    $$\hat{g}_k = \frac{1}{N} \sum_{s=1}^{N} (O_s - b_s)
+        \left(\mathbb{1}[j_s = k+1] - p_{k+1}\right)$$
+
+    where $j_s$ is the branch drawn at sample $s$, and $b_s$ is the
+    leave-one-out baseline $b_s = \frac{1}{N-1}\sum_{t \neq s} O_t$.
+
+    **Unbiasedness.** The estimator is unbiased for any fixed cotangent
+    (`grad_out`), provided samples are i.i.d. rollouts — which holds because
+    `sample_circuit` draws all branch indices independently per sample column.
+    Note that for a *nonlinear* loss $f(\mathbb{E}[O])$, the end-to-end
+    gradient is not unbiased because `grad_out` itself depends on the same
+    samples; this is true of all estimators of this family.
+
+    **Variance.** The leave-one-out baseline is an unbiased control variate:
+    $\mathbb{E}[b_s \cdot \mathrm{score}_s] = \mathbb{E}[b_s] \cdot
+    \mathbb{E}[\mathrm{score}_s] = 0$ by independence across samples, but it
+    removes the per-sample constant offset of $O$, substantially reducing
+    variance in the count-rich regime. With `num_samples=1` the baseline is
+    undefined and we fall back to the raw score; expect higher gradient
+    variance in that case.
+
+    **Repeated gates.** For gates with shared parameters across `reps`
+    repetitions, the score is summed across repetitions before averaging
+    across samples, matching the chain rule through the unrolled circuit.
 
     **Arguments:**
 
@@ -924,7 +946,7 @@ def sample_expval_all_param_shift_filter_fwd(
 ]:
     """Perform the forward execution of sample_expval_all_param_shift_filter."""
     samples, branch_indices = sample_circuit(circuit, x, key, num_samples)
-    val = jnp.mean(samples.astype(jnp.float32), axis=0)
+    val = jnp.mean(samples.astype(circuit.thetas.dtype), axis=0)
     return val, (samples, branch_indices)
 
 
@@ -950,58 +972,49 @@ def sample_expval_all_param_shift_filter_bwd(
         probs = jnp.stack([1 - sig, sig], axis=-1)  # (num_gates, 2)
     else:
         padded_logits = jnp.concatenate(
-            [jnp.zeros((num_gates, 1)), circuit.thetas], axis=1
+            [
+                jnp.zeros((num_gates, 1), dtype=circuit.thetas.dtype),
+                circuit.thetas,
+            ],
+            axis=1,
         )  # (num_gates, max_branches)
         probs = jax.nn.softmax(padded_logits, axis=-1)
 
-    # For each gate g and branch k, compute the count and conditional expectation
-    # branch_indices: (reps, num_gates, num_samples)
-    # primal: (num_samples, num_pbits)
+    # Score-function estimator:
+    #   d E[O] / d theta_k = E[O * (1[branch = k+1] - p[k+1])]
+    # See the wrapper's docstring for the derivation and unbiasedness conditions.
 
-    # Create one-hot encoding of branch indices
+    # One-hot encoding of which branch was drawn
     # (reps, num_gates, num_samples, max_branches)
-    branch_one_hot = jax.nn.one_hot(branch_indices, max_branches)
+    branch_one_hot = jax.nn.one_hot(branch_indices, max_branches).astype(probs.dtype)
 
-    # Count samples per branch: (reps, num_gates, max_branches)
-    branch_counts = jnp.sum(branch_one_hot, axis=2)
+    # Per-sample score: one_hot - p for branches 1..K-1
+    # (reps, num_gates, num_samples, max_branches-1)
+    score = branch_one_hot[..., 1:] - probs[None, :, None, 1:]
 
-    # Compute conditional expectation E[O | branch=k] for each branch
-    # We need to sum primal values weighted by indicator that branch k was selected
+    # Shared gate parameters accumulate score across repetitions
+    # (num_gates, num_samples, max_branches-1)
+    score_reps_summed = jnp.sum(score, axis=0)
 
-    # For each rep r, gate g, branch k:
-    # E[O | branch=k] = sum_s (primal[s] * I[branch_indices[r,g,s] == k]) / count[r,g,k]
+    # Per-sample observable weighted by the cotangent
+    # (num_samples,)
+    obs = jnp.einsum("sp,p->s", primal.astype(probs.dtype), grad_out)
 
-    # (reps, num_gates, max_branches, num_pbits)
-    # Sum primal values where branch k was selected
-    weighted_sum = jnp.einsum(
-        "sp,rgsk->rgkp", primal.astype(branch_one_hot.dtype), branch_one_hot
-    )
+    # Leave-one-out baseline: b_s = (sum_{t != s} obs_t) / (N - 1).
+    # Unbiased control variate: E[b_s * score_s] = E[b_s] * E[score_s] = 0
+    # because samples are i.i.d. rollouts (all branch draws are made
+    # independently per sample column in sample_circuit).
+    # At num_samples == 1 the baseline is undefined and we fall back to the
+    # raw score.
+    if num_samples > 1:
+        baseline = (jnp.sum(obs) - obs) / (num_samples - 1)
+        centered = obs - baseline
+    else:
+        centered = obs
 
-    safe_counts = jnp.where(branch_counts > 0, branch_counts, 1.0)
-
-    # (reps, num_gates, max_branches, num_pbits)
-    expval_per_branch = weighted_sum / safe_counts[:, :, :, None]
-
-    # Set expval to 0 where count is 0
-    expval_per_branch = jnp.where(
-        branch_counts[:, :, :, None] > 0, expval_per_branch, 0.0
-    )
-
-    # (num_pbits,)
-    expval_overall = jnp.mean(primal.astype(branch_one_hot.dtype), axis=0)
-
-    # Shared gate parameters are reused in every repetition
-    # sum over reps
-    num_reps = branch_indices.shape[0]
-    expval_per_branch_sum = jnp.sum(expval_per_branch, axis=0)
-
-    # diff[g, k] = sum_r (E[O | branch_{r,g}=k] - E[O]) for branches 1..K-1.
-    # (num_gates, max_branches-1, num_pbits)
-    diff = expval_per_branch_sum[:, 1:, :] - num_reps * expval_overall[None, None, :]
-
-    # grad[g, j] = p[g, j+1] * diff[g, j] @ grad_out
+    # Average over samples
     # (num_gates, max_branches-1)
-    grads_in = probs[:, 1:] * jnp.einsum("gjp,p->gj", diff, grad_out)
+    grads_in = jnp.einsum("gsk,s->gk", score_reps_summed, centered) / num_samples
 
     trainable = eqx.filter(circuit, perturbed)
     grad_circuit = jax.tree.unflatten(jax.tree.structure(trainable), (grads_in,))


### PR DESCRIPTION
Closes #9.

## What this is

Replaces the biased conditional-expectation estimator in `param_shift_filter`'s backward pass with a score-function (likelihood-ratio) estimator plus a leave-one-out baseline. The bias mechanism and fix are exactly as described in the issue.

## Reproduced the bug first

Single PCNOT, state [0,1], theta=0, num_samples=1, loss=sum(expval_all). True gradient is exactly 0 (control=0 makes both branches no-ops).

**Before this PR** (main, commit `769d2f9`):
- 200 seeds: unique grads `{-0.5, 0.0}`, mean **-0.2725**
- Matches the issue's table exactly

**After this PR**:
- 200 seeds: unique grads `{-0.5, +0.5}`, mean -0.045 (|mean|/se = 1.3, consistent with 0)
- 1000 seeds: mean -0.004, |mean|/se = 0.25

## Root cause

`torx/psc/simulation/sampled.py:980-988` — the old bwd pass estimated `E[O|k]` by per-branch sample means, substituting 0 when a branch received zero samples. Plugging that fill into the population identity `p_k * (E[O|k] - E[O])` biases the gradient whenever a branch count is zero.

## The fix

Score-function identity, unbiased for any fixed cotangent:

```
∂E[O]/∂θ_k = E[ O · (1[branch = k+1] − p_{k+1}) ]
```

estimated per sample and averaged. Never divides by branch counts, so the zero-count pathology disappears. The leave-one-out baseline `b_s = (Σ_{t≠s} O_t)/(N−1)` is an unbiased control variate (`E[b_s · score_s] = E[b_s]·E[score_s] = 0` by independence across samples) that recovers the low-variance behavior of the old estimator in the count-rich regime.

For gates with shared parameters across `reps` repetitions, the score is summed across repetitions before averaging across samples, matching the chain rule through the unrolled circuit.

## Variance check

On the 5-gate test circuit from `test_multi_gate_circuit_gradient` (PNOT/PNOT/PCNOT/PSWAP/PNOT, N=10000, 50 runs):

| Estimator | Max per-gate SD | Max bias |
|---|---|---|
| old (biased) | 0.0040 | 0.0013 |
| raw score (no baseline) | 0.0070 | 0.0012 |
| **score + LOO (this PR)** | **0.0039** | **0.0012** |

Score+LOO is statistically indistinguishable from the old estimator at n=50 runs — the LOO baseline closes the variance gap that raw score would otherwise introduce.

## Scope

- `param_shift_inf` and `param_shift_single` audited: neither divides by branch counts, both unaffected.
- Padded branch slots verified safe: `from_pcircuit` pads logits with `-inf`, so softmax gives exactly 0 probability for phantom branches and the score at padded slots is identically 0.
- The forward pass's primal mean now uses `circuit.thetas.dtype` instead of hardcoded float32, for dtype consistency under x64 within this function. The other diff methods retain float32 — happy to unify in a follow-up if desired.

## Tests

5 new tests in `TestParamShiftFilterZeroCount`:

- `test_unbiased_at_zero_count` — end-to-end forced-branch enumeration at N=1, p_k-weighted, at θ=0 and θ=0.5 (the θ=0.5 variant catches weighting bugs that θ=0 hides)
- `test_variance_pin_at_1k` — closed-form SD bound with 1.5× slack for baseline cross-terms; discriminates score+LOO from raw-score on a constant-offset circuit
- `test_mixed_arity_circuit` — K=2 pbit + K=4 pdit in the same circuit (padded-branch safety)
- `test_reps_at_one_sample` — reps=4 at N=1
- `test_degenerate_identical_observables` — all-same-branch corner case

Full suite: **222 passed, 149 subtests passed** (baseline: 217/142; +5 tests, +7 subtests).

Happy to rework the approach if you'd prefer a different estimator — this is the score-function direction suggested in the issue, plus the LOO baseline to keep variance in line with the current estimator.