### PR TITLE
docs: add Extropic attribution to doc-page chrome

### DIFF
--- a/docs_site/scripts/render/chrome.py
+++ b/docs_site/scripts/render/chrome.py
@@ -16,7 +16,7 @@ from .assets import (
     PRELUDE_CSS,
     THEME_CSS,
 )
-from .manifest import og_meta, REPO_URL
+from .manifest import EXTROPIC_URL, og_meta, REPO_URL
 from .text import replace_once
 
 
@@ -31,6 +31,9 @@ def build_topbar():
         '<a class="tx-brand" href="index.html">'
         + LOGO_SVG
         + '<span class="tx-title">TORX</span></a>'
+        '<a class="tx-byline" href="' + EXTROPIC_URL + '">'
+        "<span>by</span>"
+        '<img src="assets/extropic_wordmark.png" alt="Extropic"></a>'
         "</div>"
         '<nav class="tx-pills">'
         '<a class="tx-pill" href="examples.html">Examples</a>'

--- a/docs_site/scripts/render/manifest.py
+++ b/docs_site/scripts/render/manifest.py
@@ -31,6 +31,8 @@ _NOTEBOOK_STEM_RE = re.compile(r"^(?P<number>\d{2})_.+")
 TORX_OWN_EXAMPLE_STEMS = frozenset({"basic_usage"})
 
 REPO_URL = "https://github.com/extropic-ai/torx"
+# Torx is an Extropic project; every page carries a visible attribution back to it.
+EXTROPIC_URL = "https://extropic.ai/"
 # `SITE_URL` is the canonical host for absolute doc URLs in llms.txt.
 SITE_URL = "https://docs.torx.ai/en/latest"
 # Licensed fonts/footer video aren't committed (commercial license); the build

--- a/docs_site/scripts/site_assets/theme.css
+++ b/docs_site/scripts/site_assets/theme.css
@@ -231,6 +231,17 @@
   .tx-topbar .tx-brand:hover .tx-logo { animation: tx-shimmer 1.2s ease-in-out infinite; }
   .tx-topbar .tx-title { font-family: var(--tx-wordmark); font-weight: 700; font-size: 17px;
     letter-spacing: 0.12em; color: var(--tx-cream); }
+  /* Attribution back to Extropic; sits beside the TORX wordmark on every doc page.
+     The wordmark carries the brand; the img alt keeps the name in the markup. */
+  .tx-topbar .tx-byline { display: inline-flex; align-items: center; gap: 7px;
+    font-family: var(--tx-mono); font-size: 10.5px; letter-spacing: .02em;
+    text-transform: uppercase; color: var(--tx-muted); text-decoration: none !important;
+    margin-left: 10px; padding-left: 10px; border-left: 1px solid rgba(255,132,0,.28);
+    transition: color .16s ease; }
+  .tx-topbar .tx-byline img { display: block; height: 11px; width: auto; opacity: .78;
+    transition: opacity .16s ease; }
+  .tx-topbar .tx-byline:hover { color: var(--tx-ink); }
+  .tx-topbar .tx-byline:hover img { opacity: 1; }
   .tx-topbar .tx-pills { display: flex; gap: 8px; }
   .tx-topbar .tx-pill { display: inline-flex; align-items: center; font-size: 10.5px; letter-spacing: -0.01em;
     text-transform: uppercase; color: var(--tx-cream); background: transparent; border: 1px solid rgba(255,132,0,.42);
@@ -243,8 +254,10 @@
     .tx-topbar .tx-title { font-size: 14px; letter-spacing: .08em; }
     .tx-topbar .tx-pills { gap: 5px; }
     .tx-topbar .tx-pill { font-size: 9px; padding: 5px 8px; letter-spacing: 0; }
+    .tx-topbar .tx-byline { font-size: 9px; gap: 5px; margin-left: 7px; padding-left: 7px; }
+    .tx-topbar .tx-byline img { height: 9px; }
   }
-  @media (max-width: 380px) { .tx-topbar .tx-title { display: none; } }
+  @media (max-width: 380px) { .tx-topbar .tx-title, .tx-topbar .tx-byline { display: none; } }
   /* Read the Docs injects a version flyout; the site is single-version, so hide it. */
   readthedocs-flyout { display: none; }
 


### PR DESCRIPTION
Andy, while talking to the trademark lawyers: "can we add some Extropic branding to the Torx doc page? it doesn't say Extropic anywhere on there which i think is bad from a marketing perspective but also hurts our TM claims."

## The gap

Confirmed on the live site. The landing page is branded (hero wordmark plus the `TORX EXTROPIC` footer), but it is the only page that is. `examples.html` and every other doc page use a different chrome (`build_topbar`) with no footer and no Extropic mark.

Searching the live `examples.html` for "extropic" returns three hits, none of them visible to a reader:

1. a CSS comment
2. the Read the Docs `readthedocs-project-slug` meta tag
3. the GitHub org URL in the repo link

## The change

A `by <wordmark>` attribution beside the TORX wordmark in the shared topbar, linking to extropic.ai. Reuses the `extropic_wordmark.png` the landing hero already ships, so no new asset. The `alt="Extropic"` keeps the name in the markup for search and trademark purposes.

Now on 24 of 25 pages. The exception is `index.html`, which already carries the wordmark hero and the Extropic footer.

## Verification

Built the site and served `rendered/` locally.

- 24/25 pages contain the byline, wordmark asset copied to `rendered/assets/`
- image loads: natural 2601x231, rendered 124x11, `alt="Extropic"`, href `https://extropic.ai/`
- responsive at 1440 / 768 / 560 / 420 / 375: no pill overlap, no horizontal overflow at any width
- hidden below 380px alongside the TORX wordmark, matching the existing topbar rule
- `pre-commit run --all-files` green (isort, black, flake8, pyright)

## Note

Below 380px both the TORX wordmark and this attribution hide, so the narrowest phones show only the Torx logo mark. That matches the pre-existing rule for the wordmark. If the lawyers want the Extropic mark present at every viewport, say so and I will add a doc-page footer instead, which has room at all widths.
