### PR TITLE
docs: make the whitepaper reachable, define PSC and DFG in the intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <h1 align='center'>Torx</h1>
 <h2 align='center'>Probabilistic circuits in JAX.</h2>
 
-Torx is a [JAX](https://github.com/google/jax)-based library for building and sampling probabilistic programs, with all the benefits of JAX (native GPU/TPU acceleration, differentiability, vectorization). Its two core objects are the **parametrised stochastic circuit (PSC)**, a circuit of probabilistic gates whose wiring mirrors the sampling hardware it targets, and the **directed factor graph (DFG)**, the layer beneath the circuits: a directed acyclic graph of conditional samplers that is drawn once in parent-to-child order. A PSC is one shape a DFG can take.
+Torx is a [JAX](https://github.com/google/jax)-based library for building and sampling probabilistic programs, with all the benefits of JAX (native GPU/TPU acceleration, differentiability, vectorization). Its two core objects are the parametrised stochastic circuit (PSC), a circuit of probabilistic gates whose wiring mirrors the sampling hardware it targets, and the directed factor graph (DFG), the layer beneath the circuits: a directed acyclic graph of conditional samplers, arranged so that each variable appears after the variables it depends on.
 
-**Whitepaper:** [A Framework for Stochastic Differentiable Programming](https://arxiv.org/abs/2608.01612) (arXiv:2608.01612) introduces the framework, works through examples, and reports experimental results on XTR-0 hardware.
+**Whitepaper:** [A Framework for Stochastic Differentiable Programming](https://arxiv.org/abs/2608.01612) (arXiv:2608.01612) introduces the framework, works through examples, and reports experimental results on Extropic's XTR-0 hardware.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 <h1 align='center'>Torx</h1>
 <h2 align='center'>Probabilistic circuits in JAX.</h2>
 
-Torx is a [JAX](https://github.com/google/jax)-based library for PSCs and DFGs with all the benefits of JAX (native GPU/TPU acceleration, differentiability, vectorization).
+Torx is a [JAX](https://github.com/google/jax)-based library for building and sampling probabilistic programs, with all the benefits of JAX (native GPU/TPU acceleration, differentiability, vectorization). Its two core objects are the **parametrised stochastic circuit (PSC)**, a circuit of probabilistic gates whose wiring mirrors the sampling hardware it targets, and the **directed factor graph (DFG)**, the layer beneath the circuits: a directed acyclic graph of conditional samplers that is drawn once in parent-to-child order. A PSC is one shape a DFG can take.
+
+**Whitepaper:** [A Framework for Stochastic Differentiable Programming](https://arxiv.org/abs/2608.01612) (arXiv:2608.01612) introduces the framework, works through examples, and reports experimental results on XTR-0 hardware.
 
 ## Installation
 

--- a/docs_site/scripts/render/chrome.py
+++ b/docs_site/scripts/render/chrome.py
@@ -16,7 +16,7 @@ from .assets import (
     PRELUDE_CSS,
     THEME_CSS,
 )
-from .manifest import EXTROPIC_URL, og_meta, REPO_URL
+from .manifest import EXTROPIC_URL, og_meta, REPO_URL, WHITEPAPER_URL
 from .text import replace_once
 
 
@@ -37,6 +37,7 @@ def build_topbar():
         "</div>"
         '<nav class="tx-pills">'
         '<a class="tx-pill" href="examples.html">Examples</a>'
+        '<a class="tx-pill" href="' + WHITEPAPER_URL + '">Whitepaper</a>'
         '<a class="tx-pill" href="' + REPO_URL + '">GitHub</a>'
         "</nav></header>"
     )

--- a/docs_site/scripts/render/manifest.py
+++ b/docs_site/scripts/render/manifest.py
@@ -31,6 +31,8 @@ _NOTEBOOK_STEM_RE = re.compile(r"^(?P<number>\d{2})_.+")
 TORX_OWN_EXAMPLE_STEMS = frozenset({"basic_usage"})
 
 REPO_URL = "https://github.com/extropic-ai/torx"
+# The Torx whitepaper; linked prominently from the landing page and every doc page.
+WHITEPAPER_URL = "https://arxiv.org/abs/2608.01612"
 # Torx is an Extropic project; every page carries a visible attribution back to it.
 EXTROPIC_URL = "https://extropic.ai/"
 # `SITE_URL` is the canonical host for absolute doc URLs in llms.txt.

--- a/docs_site/scripts/render/pages.py
+++ b/docs_site/scripts/render/pages.py
@@ -22,6 +22,7 @@ from .manifest import (
     REPO_ROOT,
     REPO_URL,
     SITE_URL,
+    WHITEPAPER_URL,
 )
 
 TORX_INSTALL = "pip install extro-torx"
@@ -246,6 +247,7 @@ def write_index(site, *, out_dir):
       <a class="tx-brand" href="index.html">{LOGO_SVG}<span class="tx-brand-name">TORX</span></a>
       <nav class="tx-pills">
         <a class="tx-pill" href="getting-started.html">Docs</a>
+        <a class="tx-pill" href="{WHITEPAPER_URL}">Whitepaper</a>
         <a class="tx-pill" href="{REPO_URL}">GitHub</a>
       </nav>
     </div>
@@ -259,6 +261,7 @@ def write_index(site, *, out_dir):
       from gates on three primitives, then sample them or propagate their moments exactly.</p>
       <div class="tx-cta">
         <a class="tx-pill tx-pill-solid" href="getting-started.html">Get started &rarr;</a>
+        <a class="tx-pill" href="{WHITEPAPER_URL}">Read the whitepaper</a>
         <a class="tx-pill" href="{REPO_URL}">View on GitHub</a>
       </div>
     </div>
@@ -294,7 +297,7 @@ def write_index(site, *, out_dir):
     </video>
     <div class="tx-foot-inner">
       <span>TORX <a href="https://extropic.ai/">EXTROPIC</a></span>
-      <span><a href="{REPO_URL}">GitHub</a></span>
+      <span><a href="{WHITEPAPER_URL}">Whitepaper</a> <a href="{REPO_URL}">GitHub</a></span>
     </div>
   </footer>
 {COPY_SCRIPT}
@@ -321,6 +324,7 @@ def write_llms_txt(site, api_categories, *, out_dir):
         f"- [Getting started]({SITE_URL}/getting-started.html): install Torx and build and sample a first circuit.",
         f"- [Examples index]({SITE_URL}/examples.html): all runnable notebooks in learning order.",
         f"- [API reference]({SITE_URL}/api-core.html): start with the core factor-graph API, then follow the category links.",
+        f"- [Whitepaper]({WHITEPAPER_URL}): A Framework for Stochastic Differentiable Programming (arXiv:2608.01612).",
         f"- [GitHub repository]({REPO_URL}): package and notebook source.",
         "",
         "## Examples",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "extro-torx"
 version = "0.0.1"
-description = "PSCs and DFGs in JAX."
+description = "Parametrised stochastic circuits and directed factor graphs in JAX."
 readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.11"


### PR DESCRIPTION
Gill's flags: the [whitepaper](https://arxiv.org/abs/2608.01612) is not reachable from docs.torx.ai or the README ('bro there is no link anywhere prominent'), and the README intro uses PSC/DFG without defining them ('those words are made up by us').

## Changes
- **Landing page** (docs.torx.ai): Whitepaper pill in the nav, a 'Read the whitepaper' CTA in the hero next to Get started, and a footer link.
- **Every doc page**: Whitepaper pill in the shared topbar.
- **llms.txt**: whitepaper entry.
- **README**: the intro now defines parametrised stochastic circuit and directed factor graph in one sentence each, and links the whitepaper prominently right below.
- **pyproject**: the PyPI description spells out the acronyms.

## Verification
- `docs_site/scripts/build_site.py` renders clean; arXiv URL appears 3x on index.html (nav, hero, footer), on every doc page topbar, and in llms.txt.
- pre-commit green: isort, black, flake8, pyright.