### PR TITLE
keep the parameter dtype in discrete gate matrices under x64

### DIFF
--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -2,7 +2,9 @@
 
 import unittest
 
+import jax
 import jax.numpy as jnp
+from parameterized import parameterized
 
 from torx.psc import (
     PCNOT,
@@ -10,6 +12,8 @@ from torx.psc import (
     PCSWAP,
     PDEMUX,
     PditCycle,
+    PditShift,
+    PditSWAP,
     PJUMP,
     PMultiCNOT,
     PNOT,
@@ -398,3 +402,34 @@ class TestPditCycle(unittest.TestCase):
         # Backward cycle: 0->2, 1->0, 2->1
         expected = jnp.array([[0, 1, 0], [0, 0, 1], [1, 0, 0]], dtype=jnp.float32)
         self.assertTrue(jnp.allclose(matrix, expected))
+
+
+class TestFp32ThetaUnderX64(unittest.TestCase):
+    """`probs` and `get_matrix` return the dtype of `theta`, not the default.
+
+    Under `jax_enable_x64` an undtyped `jnp.zeros`/`jnp.eye` is fp64, which
+    promoted the result of an fp32 `theta` and left it out of step with the
+    rest of the circuit.
+    """
+
+    @parameterized.expand(
+        [
+            ("PNOT", PNOT(0), 1),
+            ("PCNOT", PCNOT([0, 1]), 1),
+            ("PMultiCNOT", PMultiCNOT([0, 1, 2]), 1),
+            ("PditShift", PditShift(0, dims=3), 1),
+            ("PditSWAP", PditSWAP([0, 1], dims=3), 1),
+            ("PditCycle", PditCycle(0, dims=3), 2),
+        ]
+    )
+    def test_fp32_theta_stays_fp32(self, _name, gate, num_params):
+        # getattr: pyright types jax.config attrs inconsistently across platforms
+        prev = getattr(jax.config, "jax_enable_x64")
+        jax.config.update("jax_enable_x64", True)
+        try:
+            theta = jnp.zeros(num_params, dtype=jnp.float32)
+
+            self.assertEqual(gate.probs(theta).dtype, jnp.float32)
+            self.assertEqual(gate.get_matrix(theta).dtype, jnp.float32)
+        finally:
+            jax.config.update("jax_enable_x64", prev)

--- a/tests/test_simulators.py
+++ b/tests/test_simulators.py
@@ -13,6 +13,7 @@ from torx.psc import (
     CompiledStateVectorPCircuit,
     DiscretePCircuit,
     PCNOT,
+    PditCycle,
     PditShift,
     PditSWAP,
     PMultiCNOT,
@@ -1199,3 +1200,44 @@ class TestPditBranchingSimulator(unittest.TestCase):
         # PNOT: [2, 2] (padded), PditShift: [4, 2] (padded)
         self.assertEqual(compiled.dims[0, 0], 2)
         self.assertEqual(compiled.dims[1, 0], 4)
+
+
+class TestFp32ThetasUnderX64(unittest.TestCase):
+    """A consistent fp32 circuit must stay fp32 under `jax_enable_x64`.
+
+    Array constructors that carry no `dtype` take the default float type, so
+    they used to promote fp32 parameters to fp64 halfway through the discrete
+    path. Mirrors `test_fp32_circuit_samples_under_x64` in `test_hybrid_gates`.
+    """
+
+    def setUp(self):
+        # getattr: pyright types jax.config attrs inconsistently across platforms
+        self._prev_x64 = getattr(jax.config, "jax_enable_x64")
+        jax.config.update("jax_enable_x64", True)
+
+    def tearDown(self):
+        jax.config.update("jax_enable_x64", self._prev_x64)
+
+    def test_statevector_density_stays_fp32(self):
+        # The fp64 matrix of a K>2 gate used to break the reps `fori_loop`:
+        # "carry input and carry output must have equal types".
+        circuit = DiscretePCircuit([PditCycle(0, dims=3)], reps=2)
+        sim = StateVectorSimulator()
+
+        compiled = sim.build_circuit(circuit, [jnp.zeros(2, dtype=jnp.float32)])
+        density = sim.density(compiled, jnp.zeros(3, dtype=jnp.float32).at[0].set(1.0))
+
+        self.assertEqual(density.dtype, jnp.float32)
+        self.assertTrue(jnp.allclose(density, jnp.full(3, 1 / 3), atol=1e-6))
+
+    def test_branching_compile_and_sample_stay_fp32(self):
+        # K=2 is affected too: the padded thetas were built with jnp.full.
+        circuit = DiscretePCircuit([PNOT(0), PditCycle(1, dims=3)])
+        thetas = [jnp.zeros(1, dtype=jnp.float32), jnp.zeros(2, dtype=jnp.float32)]
+        sim = BranchingSimulator(num_samples=16)
+
+        compiled = sim.build_circuit(circuit, thetas)
+        samples = sim.sample(compiled, jnp.array([0, 0]), jax.random.key(0))
+
+        self.assertEqual(compiled.thetas.dtype, jnp.float32)
+        self.assertEqual(samples.shape, (16, 2))

--- a/torx/psc/gates/_base.py
+++ b/torx/psc/gates/_base.py
@@ -319,6 +319,17 @@ class AbstractControlledContinuousGate(AbstractHybridGate[_ThetaType, _DimsType]
         return disc[0]
 
 
+def _pad_branch_logits(theta: Float[Array, "..."]) -> Float[Array, "..."]:
+    """Prepend branch 0's implicit zero logit along the last axis.
+
+    The zero keeps ``theta``'s dtype. A bare `jnp.zeros` would take the default
+    float type instead, so an fp32 ``theta`` under `jax_enable_x64` would come
+    back fp64 and no longer match the rest of the circuit.
+    """
+    zero = jnp.zeros((*theta.shape[:-1], 1), dtype=theta.dtype)
+    return jnp.concatenate([zero, theta], axis=-1)
+
+
 class AbstractKBranchGate(
     AbstractDiscreteGate[
         _DiscreteSiteType, Float[Array, " num_branch_params"], _DimsType
@@ -359,8 +370,7 @@ class AbstractKBranchGate(
             sig = jax.nn.sigmoid(theta[0])
             return jnp.stack([1 - sig, sig])
 
-        padded = jnp.concatenate([jnp.zeros(1), theta])
-        return jax.nn.softmax(padded)
+        return jax.nn.softmax(_pad_branch_logits(theta))
 
     @property
     @abstractmethod

--- a/torx/psc/gates/_binary.py
+++ b/torx/psc/gates/_binary.py
@@ -227,16 +227,17 @@ class PMultiCNOT(AbstractMultiBinaryPGate):
 
     def get_matrix(self, theta: Float[Array, "1"]) -> Float[Array, "d d"]:
         """See [`torx.psc.AbstractDiscreteGate.get_matrix`][] for documentation."""
+        p = self.prob(theta)
         return (
-            jnp.eye(2 ** len(self.sites))
+            jnp.eye(2 ** len(self.sites), dtype=p.dtype)
             .at[-2, -2]
-            .set(1 - self.prob(theta))
+            .set(1 - p)
             .at[-2, -1]
-            .set(self.prob(theta))
+            .set(p)
             .at[-1, -2]
-            .set(self.prob(theta))
+            .set(p)
             .at[-1, -1]
-            .set(1 - self.prob(theta))
+            .set(1 - p)
         )
 
 

--- a/torx/psc/gates/_pdit.py
+++ b/torx/psc/gates/_pdit.py
@@ -41,9 +41,9 @@ class PditShift(AbstractSinglePditGate):
     def get_matrix(self, theta: Float[Array, "1"]) -> Float[Array, "d d"]:
         """See [`torx.psc.AbstractDiscreteGate.get_matrix`][] for documentation."""
         d = self.dims[0]
-        identity = jnp.eye(d)
-        cyclic = jnp.roll(identity, shift=1, axis=0)
         p = self.prob(theta)
+        identity = jnp.eye(d, dtype=p.dtype)
+        cyclic = jnp.roll(identity, shift=1, axis=0)
         return (1 - p) * identity + p * cyclic
 
 
@@ -82,17 +82,17 @@ class PditSWAP(AbstractMultiPditGate):
         """See [`torx.psc.AbstractDiscreteGate.get_matrix`][] for documentation."""
         d = self.dims[0]
         d2 = d * d
+        p = self.prob(theta)
 
         # Build SWAP matrix: |i,j> -> |j,i>
-        swap = jnp.zeros((d2, d2))
+        swap = jnp.zeros((d2, d2), dtype=p.dtype)
         for i in range(d):
             for j in range(d):
                 src = i * d + j
                 dst = j * d + i
                 swap = swap.at[dst, src].set(1.0)
 
-        identity = jnp.eye(d2)
-        p = self.prob(theta)
+        identity = jnp.eye(d2, dtype=p.dtype)
         return (1 - p) * identity + p * swap
 
 
@@ -145,7 +145,7 @@ class PditCycle(AbstractSinglePditGate):
         """See [`torx.psc.AbstractDiscreteGate.get_matrix`][] for documentation."""
         d = self.dims[0]
         p = self.probs(theta)  # [p_identity, p_forward, p_backward]
-        identity = jnp.eye(d)
+        identity = jnp.eye(d, dtype=p.dtype)
         forward = jnp.roll(identity, shift=1, axis=0)
         backward = jnp.roll(identity, shift=-1, axis=0)
         return p[0] * identity + p[1] * forward + p[2] * backward

--- a/torx/psc/simulation/sampled.py
+++ b/torx/psc/simulation/sampled.py
@@ -13,6 +13,7 @@ from typing_extensions import Self
 from .._circuit import DiscretePCircuit
 from .._custom_types import BitString
 from ..gates import AbstractGeneratorGate, AbstractKBranchGate
+from ..gates._base import _pad_branch_logits
 from .base import AbstractCompiledPCircuit, AbstractSimulator
 
 
@@ -159,13 +160,20 @@ class CompiledBranchingPCircuit(AbstractCompiledPCircuit[DiscretePCircuit]):
             ]
         ).astype(dtype)
 
+        # The compiled thetas take the gates' parameter dtype rather than the
+        # default float type, so an fp32 circuit is not promoted to fp64 under
+        # jax_enable_x64. Mixed gate dtypes promote under standard rules, since
+        # the padded rows have to stack into one array either way.
+        with jax.numpy_dtype_promotion("standard"):
+            theta_dtype = jnp.result_type(*(jnp.asarray(t).dtype for t in thetas))
+
         # pad thetas to (num_gates, max_branches - 1) with -inf
         thetas_list = []
         for gate, theta in zip(gates, thetas):
-            theta_vals = jnp.atleast_1d(theta)
+            theta_vals = jnp.atleast_1d(theta).astype(theta_dtype)
             K = gate.num_branches
             # theta has K-1 values, pad to max_branches - 1 with -inf
-            padded_theta = jnp.full(max_branches - 1, -jnp.inf)
+            padded_theta = jnp.full(max_branches - 1, -jnp.inf, dtype=theta_dtype)
             padded_theta = padded_theta.at[: K - 1].set(theta_vals[: K - 1])
             thetas_list.append(padded_theta)
         padded_thetas = jnp.stack(thetas_list)
@@ -565,9 +573,7 @@ def sample_circuit(
             shape=(circuit.reps, num_gates, num_samples),
         ).astype(jnp.int32)
     else:
-        padded_logits = jnp.concatenate(
-            [jnp.zeros((num_gates, 1)), circuit.thetas], axis=1
-        )
+        padded_logits = _pad_branch_logits(circuit.thetas)
         branch_indices = jax.random.categorical(
             key,
             padded_logits[None, :, None, :],
@@ -725,9 +731,8 @@ def sample_expval_all_param_shift_inf_bwd(
         # (num_gates, 2)
         probs = jnp.stack([1 - sig, sig], axis=-1)
     else:
-        padded_logits = jnp.concatenate(
-            [jnp.zeros((num_gates, 1)), circuit.thetas], axis=1
-        )  # (num_gates, max_branches)
+        # (num_gates, max_branches)
+        padded_logits = _pad_branch_logits(circuit.thetas)
         probs = jax.nn.softmax(padded_logits, axis=-1)
 
     # grad_theta[g, j] = sum_k dp_k/dtheta_j * (expval_branch[g,k] @ grad_out)
@@ -942,16 +947,14 @@ def sample_expval_all_param_shift_filter_bwd(
     # (num_samples, num_pbits), (reps, num_gates, num_samples)
     primal, branch_indices = residuals
 
-    num_gates = circuit.thetas.shape[0]
     max_branches = circuit.max_branches
 
     if max_branches == 2:
         sig = jax.nn.sigmoid(circuit.thetas[:, 0])
         probs = jnp.stack([1 - sig, sig], axis=-1)  # (num_gates, 2)
     else:
-        padded_logits = jnp.concatenate(
-            [jnp.zeros((num_gates, 1)), circuit.thetas], axis=1
-        )  # (num_gates, max_branches)
+        # (num_gates, max_branches)
+        padded_logits = _pad_branch_logits(circuit.thetas)
         probs = jax.nn.softmax(padded_logits, axis=-1)
 
     # For each gate g and branch k, compute the count and conditional expectation


### PR DESCRIPTION
With fp32 parameters under `jax_enable_x64`, `get_matrix` returns float64 for `PditShift`, `PditSWAP`, `PditCycle` and `PMultiCNOT`, and all four then crash `StateVectorSimulator.density` with `scan body function carry input and carry output must have equal types`. The gates build `jnp.eye(d)` / `jnp.zeros((d2, d2))` with no dtype, so the array takes the default float type instead of the parameter's. `PNOT` and `PCNOT` survive because they build their matrix from `jnp.array([[tracer, ...]])` and infer from the tracer, not because of the K=2 branch in `probs`. `probs` has its own copy of the same mistake, `jnp.concatenate([jnp.zeros(1), theta])`, which is why `PditCycle` is the one gate that leaks at both layers.

`BranchingSimulator.build_circuit` is hit too, at `sampled.py:164-168`: on fp32 thetas under x64 it raises `TypePromotionError: Input dtypes ('float32', 'float64') have no available implicit dtype promotion path`, because `tests/conftest.py` sets `jax_numpy_dtype_promotion = "strict"`. That path now resolves the parameter dtype the way `_infer_default_dtype` in `simulation/gaussian.py` already does for the continuous side, under the same `jax.numpy_dtype_promotion("standard")` guard. The padding-logit expression appeared four times verbatim, so it moved into one `_pad_branch_logits` helper; `from ..gates._base import _pad_branch_logits` crosses packages the same way `_SampleOutput` crosses from `torx/factor.py` into `psc/gates/_continuous.py` and `_HybridGateType` from `_circuit.py` into `simulation/gaussian.py`.

The `num_gates` local at `sampled.py:947` goes unused once the concatenate is replaced, and `.flake8` has `select = E, F`, so pyflakes F841 fails the hook if it stays. The other binding of that name, in `sample_expval_all_param_shift_inf_bwd`, is still used and untouched.

Behavior change worth stating: an x64 user passing fp32 params now gets fp32 arithmetic in the discrete path where they silently got fp64 before. That is the point of the fix, and nothing moves under the default x32 config; I compared `probs`, `get_matrix`, state-vector `density`/`expval_all`/`grad` and branching `sample`/`expval_all`/`grad` across all three diff methods, bit-identical.

`pytest tests/`: 224 passed, 147 subtests passed, 1 failed. The failure is `test_performance.py::TestPerformance::test_compile_and_execute_time`, a wall-clock budget that fails on f8a46c1 too on this machine. black, isort and flake8 clean; pyright output unchanged from main.
